### PR TITLE
fix(release): publish notes from the changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload "${GITHUB_REF_NAME}" .release/kranz.rb
 
+      - name: Publish release notes from changelog
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./scripts/extract-release-notes.sh "${GITHUB_REF_NAME#v}" CHANGELOG.md > .release/release-notes.md
+          gh release edit "${GITHUB_REF_NAME}" --notes-file .release/release-notes.md
+
   homebrew:
     name: Update optional Homebrew tap
     needs: release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 All notable changes to Kranz are documented here. The project follows [Semantic Versioning](https://semver.org/), and release notes are generated from conventional commit subjects.
 
-## [Unreleased]
-
 ## [0.4.0] - 2026-08-01
 
 ### Added
@@ -93,7 +91,6 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 - Explicit global-user and project-config save destinations in the live theme picker.
 - Native compatibility for common Process Compose configurations.
 
-[Unreleased]: https://github.com/kranz-org/kranz/compare/v0.4.0...HEAD
 [0.4.0]: https://github.com/kranz-org/kranz/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/kranz-org/kranz/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/kranz-org/kranz/compare/v0.1.1...v0.2.0

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build run install fmt-check test vet verify lint clean snapshot release-check homebrew-formula-check tag
+.PHONY: all build run install fmt-check test vet verify lint clean snapshot release-check homebrew-formula-check release-notes-check tag
 
 APP_NAME := kranz
 BIN_DIR := bin
@@ -34,7 +34,7 @@ test:
 vet:
 	$(GO) vet ./...
 
-verify: fmt-check vet test build homebrew-formula-check
+verify: fmt-check vet test build homebrew-formula-check release-notes-check
 
 lint:
 	$(GOLANGCI_LINT) run ./...
@@ -44,6 +44,9 @@ release-check:
 
 homebrew-formula-check:
 	./scripts/test-generate-homebrew-formula.sh
+
+release-notes-check:
+	./scripts/test-extract-release-notes.sh
 
 snapshot:
 	$(GORELEASER) release --snapshot --clean

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -57,7 +57,9 @@ workflow; no release commit or generated binary is checked into the repository.
 ## Verify the published release
 
 The workflow must publish four Darwin/Linux archives, `checksums.txt`, and
-`kranz.rb`. Verify the release before announcing it:
+`kranz.rb`. It replaces generated commit notes with the matching version section
+from `CHANGELOG.md`, so squash merges cannot produce an empty release body.
+Verify the release before announcing it:
 
 ```bash
 gh release view v0.4.0

--- a/scripts/extract-release-notes.sh
+++ b/scripts/extract-release-notes.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version=${1:?usage: extract-release-notes.sh VERSION [CHANGELOG]}
+changelog=${2:-CHANGELOG.md}
+heading="## [${version}]"
+
+awk -v heading="$heading" '
+  index($0, heading) == 1 {
+    found = 1
+    next
+  }
+  found && /^## \[/ {
+    exit
+  }
+  found {
+    print
+  }
+  END {
+    if (!found) {
+      exit 1
+    }
+  }
+' "$changelog"

--- a/scripts/test-extract-release-notes.sh
+++ b/scripts/test-extract-release-notes.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+extractor="${script_dir}/extract-release-notes.sh"
+repository_root=$(CDPATH= cd -- "${script_dir}/.." && pwd)
+
+notes=$("$extractor" 0.4.0 "${repository_root}/CHANGELOG.md")
+
+grep -Fq '### Added' <<<"$notes"
+grep -Fq 'Full line editing in the regex log search' <<<"$notes"
+
+if grep -Fq '## [0.3.0]' <<<"$notes"; then
+  echo "release notes must stop at the next changelog version" >&2
+  exit 1
+fi
+
+if "$extractor" 9.9.9 "${repository_root}/CHANGELOG.md" >/dev/null 2>&1; then
+  echo "a missing changelog version must fail" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- extract release notes from the matching CHANGELOG section
- replace GoReleaser commit notes after publication
- test the extraction boundary and missing-version failure
- document why squash merges cannot leave release notes empty

## Validation

- `make verify`
- `make lint`