### PR TITLE
docs: require pull requests for every change

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Repository workflow for coding agents
+
+- Start every task from an up-to-date `main` and create a dedicated branch
+  before changing files. This applies to every change, including small fixes,
+  documentation, CI, and release preparation.
+- Never commit or push task work directly to `main`.
+- Push the task branch, open a pull request, wait for required CI, and merge the
+  pull request. Prefer squash merge unless preserving individual commits is
+  important to the change.
+- Do not rewrite published history.
+- Develop a minor release through task-sized branches merged into `main`. Use a
+  `release/vX.Y.Z` branch only for final release preparation and stabilization,
+  not as a long-lived replacement for `main`.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,10 +20,20 @@ For TUI changes, test both light and dark terminal profiles, narrow terminals do
 
 ## Pull requests
 
+- Create a dedicated branch for every change, including small fixes and
+  documentation. Do not commit or push task work directly to `main`.
+- Open a pull request, wait for required CI, and merge through GitHub. Prefer
+  squash merge unless the individual commits are intentionally meaningful.
 - Use a short conventional commit subject such as `feat:`, `fix:`, `docs:`, or `refactor:`.
 - Explain the outcome, compatibility impact, and validation performed.
 - Update `README.md` and `CHANGELOG.md` for user-visible behavior.
 - Never include credentials, private repository URLs, or captured application data.
+
+Minor versions are developed as a sequence of task-sized branches merged into
+`main`; do not keep a long-lived version branch as a second integration branch.
+Create `release/vX.Y.Z` only when the completed scope is ready for final release
+preparation and stabilization. Published history is not rewritten for cosmetic
+cleanup.
 
 ## Releases
 


### PR DESCRIPTION
## Summary

Document the repository's move to branch-per-task development and required pull requests for every change, including small fixes and documentation.

Clarify that minor versions are assembled from task-sized branches merged into `main`, with a release branch reserved for final stabilization. Preserve the existing published history as the project's development record.

## Validation

- [x] `git diff --check`
- [ ] `make verify` (documentation-only change)
- [ ] Manual TUI behavior checked when the change affects rendering or input (not applicable)
- [x] Documentation and changelog updated when required

## Compatibility

No runtime, configuration, platform, or Process Compose compatibility impact.
