### PR TITLE
feat: add actions configuration model

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -868,3 +868,275 @@ func TestValidateRejectsIncompatibleOrInvalidReadyLog(t *testing.T) {
 		}
 	}
 }
+
+func TestLoadNormalizesServiceActionsAndActionGroups(t *testing.T) {
+	directory := t.TempDir()
+	serviceDir := filepath.Join(directory, "service")
+	actionDir := filepath.Join(directory, "action")
+	groupDir := filepath.Join(directory, "infra")
+	for _, path := range []string{serviceDir, actionDir, groupDir} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	files := map[string]string{
+		filepath.Join(serviceDir, "service.env"): "SERVICE_FILE=yes\nSHARED=service-file\n",
+		filepath.Join(actionDir, "action.env"):   "ACTION_FILE=yes\nSHARED=action-file\n",
+		filepath.Join(groupDir, "group.env"):     "GROUP_FILE=yes\nSHARED=group-file\n",
+	}
+	for path, content := range files {
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	configPath := filepath.Join(directory, "kranz.yaml")
+	data := `
+project: Actions
+defaults:
+  shell: /bin/zsh
+  env:
+    GLOBAL: inherited
+services:
+  app:
+    command: run-app
+    dir: ` + serviceDir + `
+    env_files: [service.env]
+    env:
+      SERVICE_ONLY: yes
+    actions:
+      build-launcher:
+        command: npm run build:launcher
+        description: Build launcher
+        timeout: 45s
+        confirm: true
+      migrate:
+        command: npm run migrate
+        dir: ` + actionDir + `
+        env_files: [action.env]
+        env:
+          SHARED: action-explicit
+action_groups:
+  remote-infra:
+    description: Remote stack
+    dir: ` + groupDir + `
+    env_files: [group.env]
+    actions:
+      up:
+        command: ssh host docker-compose up -d
+      console:
+        command: ssh -t host shell
+        interactive: true
+`
+	if err := os.WriteFile(configPath, []byte(data), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	build := cfg.Services["app"].Actions["build-launcher"]
+	if build.Dir != serviceDir || build.Shell != "/bin/zsh" || build.Timeout != 45*time.Second || !build.ConfirmationRequired() {
+		t.Fatalf("normalized service action = %#v", build)
+	}
+	if build.Env["GLOBAL"] != "inherited" || build.Env["SERVICE_FILE"] != "yes" || build.Env["SERVICE_ONLY"] != "yes" {
+		t.Fatalf("inherited service action env = %v", build.Env)
+	}
+	migrate := cfg.Services["app"].Actions["migrate"]
+	if migrate.Env["ACTION_FILE"] != "yes" || migrate.Env["SHARED"] != "action-explicit" {
+		t.Fatalf("action env precedence = %v", migrate.Env)
+	}
+	group := cfg.ActionGroups["remote-infra"]
+	up := group.Actions["up"]
+	if group.Dir != groupDir || up.Dir != groupDir || up.Shell != "/bin/zsh" {
+		t.Fatalf("normalized action group = group %#v action %#v", group, up)
+	}
+	if up.Env["GLOBAL"] != "inherited" || up.Env["GROUP_FILE"] != "yes" || up.Env["SHARED"] != "group-file" {
+		t.Fatalf("inherited action group env = %v", up.Env)
+	}
+	if !group.Actions["console"].InteractiveEnabled() {
+		t.Fatal("interactive flag was not preserved")
+	}
+	for path := range files {
+		if !containsString(cfg.WatchPaths, path) {
+			t.Fatalf("action env file %s missing from watch paths %v", path, cfg.WatchPaths)
+		}
+	}
+}
+
+func TestLoadFilesMergesActionsByOwnerAndName(t *testing.T) {
+	directory := t.TempDir()
+	basePath := filepath.Join(directory, "kranz.yaml")
+	overridePath := filepath.Join(directory, "kranz.local.yaml")
+	base := `
+project: Layered Actions
+services:
+  app:
+    command: run
+    actions:
+      migrate:
+        command: migrate
+        description: Base description
+        timeout: 10s
+        confirm: true
+action_groups:
+  infra:
+    dir: ./infra
+    actions:
+      up:
+        command: up
+`
+	override := `
+project: Layered Actions
+services:
+  app:
+    actions:
+      migrate:
+        description: Local description
+        confirm: false
+      seed:
+        command: seed
+action_groups:
+  infra:
+    shell: /bin/zsh
+    actions:
+      up:
+        timeout: 30s
+      down:
+        command: down
+`
+	for path, content := range map[string]string{basePath: base, overridePath: override} {
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg, err := LoadFiles([]string{basePath, overridePath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	migrate := cfg.Services["app"].Actions["migrate"]
+	if migrate.Command != "migrate" || migrate.Description != "Local description" || migrate.Timeout != 10*time.Second || migrate.ConfirmationRequired() || migrate.Confirm == nil {
+		t.Fatalf("merged service action = %#v", migrate)
+	}
+	if cfg.Services["app"].Actions["seed"].Command != "seed" {
+		t.Fatalf("new service action missing: %#v", cfg.Services["app"].Actions)
+	}
+	group := cfg.ActionGroups["infra"]
+	if group.Dir != "./infra" || group.Shell != "/bin/zsh" || group.Actions["up"].Timeout != 30*time.Second || group.Actions["down"].Command != "down" {
+		t.Fatalf("merged action group = %#v", group)
+	}
+}
+
+func TestValidateActionsAndActionOnlyProjects(t *testing.T) {
+	valid := &Config{
+		Project: "Operations",
+		ActionGroups: map[string]ActionGroup{
+			"database": {Actions: map[string]Action{"migrate": {Command: "migrate"}}},
+		},
+	}
+	if err := Validate(valid); err != nil {
+		t.Fatalf("action-only project was rejected: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		config  *Config
+		wantErr string
+	}{
+		{
+			name:    "empty project",
+			config:  &Config{Project: "Empty"},
+			wantErr: "service or action group",
+		},
+		{
+			name:    "empty group",
+			config:  &Config{Project: "Empty group", ActionGroups: map[string]ActionGroup{"infra": {}}},
+			wantErr: "must contain at least one action",
+		},
+		{
+			name: "missing command",
+			config: &Config{Project: "Missing", Services: map[string]Service{"app": {
+				Command: "run", Actions: map[string]Action{"broken": {}},
+			}}},
+			wantErr: "field 'command' is required",
+		},
+		{
+			name: "negative timeout",
+			config: &Config{Project: "Timeout", ActionGroups: map[string]ActionGroup{"ops": {
+				Actions: map[string]Action{"broken": {Command: "run", Timeout: -time.Second}},
+			}}},
+			wantErr: "timeout cannot be negative",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := Validate(test.config)
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("validation error = %v, want substring %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestNativeConfigRejectsUnknownActionFields(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "kranz.yaml")
+	data := `
+project: Unknown Action Field
+action_groups:
+  ops:
+    actions:
+      deploy:
+        command: deploy
+        title: Deploy
+`
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(path); err == nil || !strings.Contains(err.Error(), "field title not found") {
+		t.Fatalf("unknown action field error = %v", err)
+	}
+}
+
+func TestActionIDsAndResolutionAreDeterministicAndUnambiguous(t *testing.T) {
+	cfg := &Config{
+		Project: "Action IDs",
+		Services: map[string]Service{
+			"web": {Command: "run", Actions: map[string]Action{
+				"test":           {Command: "web-test"},
+				"build:launcher": {Command: "build"},
+			}},
+		},
+		ActionGroups: map[string]ActionGroup{
+			"ops": {Actions: map[string]Action{
+				"test": {Command: "ops-test"},
+			}},
+		},
+	}
+	want := []ActionID{
+		{OwnerKind: ActionOwnerService, Owner: "web", Name: "build:launcher"},
+		{OwnerKind: ActionOwnerService, Owner: "web", Name: "test"},
+		{OwnerKind: ActionOwnerGroup, Owner: "ops", Name: "test"},
+	}
+	got := cfg.ActionIDs()
+	if len(got) != len(want) {
+		t.Fatalf("action ids = %#v", got)
+	}
+	for index := range want {
+		if got[index] != want[index] {
+			t.Fatalf("action id %d = %#v, want %#v", index, got[index], want[index])
+		}
+		action, exists := cfg.ResolveAction(got[index])
+		if !exists || action.Command == "" {
+			t.Fatalf("resolve %#v = %#v, %v", got[index], action, exists)
+		}
+	}
+	serviceTest, _ := cfg.ResolveAction(want[1])
+	groupTest, _ := cfg.ResolveAction(want[2])
+	if serviceTest.Command != "web-test" || groupTest.Command != "ops-test" {
+		t.Fatalf("same-name actions collided: service %#v group %#v", serviceTest, groupTest)
+	}
+	if _, exists := cfg.ResolveAction(ActionID{OwnerKind: "unknown", Owner: "ops", Name: "test"}); exists {
+		t.Fatal("unknown owner kind resolved")
+	}
+}

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -148,6 +148,16 @@ func mergeConfig(base, override *Config) error {
 			base.ServiceOrder = append(base.ServiceOrder, name)
 		}
 	}
+	if base.ActionGroups == nil {
+		base.ActionGroups = make(map[string]ActionGroup)
+	}
+	for name, incoming := range override.ActionGroups {
+		if current, exists := base.ActionGroups[name]; exists {
+			base.ActionGroups[name] = mergeActionGroup(current, incoming)
+		} else {
+			base.ActionGroups[name] = incoming
+		}
+	}
 	if baseSource == SourceKranz || overrideSource == SourceKranz {
 		base.Source = SourceKranz
 	}
@@ -263,6 +273,70 @@ func mergeService(base, override Service, mergeDependencies bool) Service {
 	}
 	if override.DisableDotenv {
 		base.DisableDotenv = true
+	}
+	base.Actions = mergeActions(base.Actions, override.Actions)
+	return base
+}
+
+func mergeActionGroup(base, override ActionGroup) ActionGroup {
+	if override.Description != "" {
+		base.Description = override.Description
+	}
+	if override.Dir != "" {
+		base.Dir = override.Dir
+	}
+	if override.Shell != "" {
+		base.Shell = override.Shell
+	}
+	base.Env = mergeStringMap(base.Env, override.Env)
+	if len(override.EnvFiles) > 0 {
+		base.EnvFiles = append([]string(nil), override.EnvFiles...)
+	}
+	base.Actions = mergeActions(base.Actions, override.Actions)
+	return base
+}
+
+func mergeActions(base, override map[string]Action) map[string]Action {
+	if base == nil && len(override) > 0 {
+		base = make(map[string]Action, len(override))
+	}
+	for name, incoming := range override {
+		if current, exists := base[name]; exists {
+			base[name] = mergeAction(current, incoming)
+		} else {
+			base[name] = incoming
+		}
+	}
+	return base
+}
+
+func mergeAction(base, override Action) Action {
+	if override.Command != "" {
+		base.Command = override.Command
+	}
+	if override.Description != "" {
+		base.Description = override.Description
+	}
+	if override.Dir != "" {
+		base.Dir = override.Dir
+	}
+	if override.Shell != "" {
+		base.Shell = override.Shell
+	}
+	base.Env = mergeStringMap(base.Env, override.Env)
+	if len(override.EnvFiles) > 0 {
+		base.EnvFiles = append([]string(nil), override.EnvFiles...)
+	}
+	if override.Timeout != 0 {
+		base.Timeout = override.Timeout
+	}
+	if override.Confirm != nil {
+		value := *override.Confirm
+		base.Confirm = &value
+	}
+	if override.Interactive != nil {
+		value := *override.Interactive
+		base.Interactive = &value
 	}
 	return base
 }
@@ -426,11 +500,89 @@ func applyDefaults(cfg *Config) error {
 			applyCheckDefaults(svc.HealthCheck.Readiness)
 			applyCheckDefaults(svc.HealthCheck.Liveness)
 		}
+		for actionName, action := range svc.Actions {
+			normalized, err := normalizeAction(cfg, svc.Dir, svc.Shell, svc.Env, action)
+			if err != nil {
+				return fmt.Errorf("service %q action %q env files: %w", name, actionName, err)
+			}
+			svc.Actions[actionName] = normalized
+		}
 
 		// Map iteration returns a copy, so store the normalized service explicitly.
 		cfg.Services[name] = svc
 	}
+	for groupName, group := range cfg.ActionGroups {
+		if group.Dir == "" {
+			group.Dir = defDir
+		}
+		if group.Shell == "" {
+			group.Shell = defShell
+		}
+		groupFiles := append(append([]string(nil), cfg.Defaults.EnvFiles...), group.EnvFiles...)
+		fileEnv, err := loadEnvFiles(group.Dir, groupFiles)
+		if err != nil {
+			return fmt.Errorf("action group %q env files: %w", groupName, err)
+		}
+		group.Env = mergeStringMap(mergeStringMap(cfg.Defaults.Env, fileEnv), group.Env)
+		for _, path := range resolvedEnvFiles(group.Dir, groupFiles) {
+			cfg.WatchPaths = appendUniqueString(cfg.WatchPaths, path)
+		}
+		for key, value := range group.Env {
+			group.Env[key] = os.ExpandEnv(value)
+		}
+		for actionName, action := range group.Actions {
+			normalized, err := normalizeAction(cfg, group.Dir, group.Shell, group.Env, action)
+			if err != nil {
+				return fmt.Errorf("action group %q action %q env files: %w", groupName, actionName, err)
+			}
+			group.Actions[actionName] = normalized
+		}
+		cfg.ActionGroups[groupName] = group
+	}
 	return nil
+}
+
+func normalizeAction(cfg *Config, ownerDir, ownerShell string, ownerEnv map[string]string, action Action) (Action, error) {
+	if action.Dir == "" {
+		action.Dir = ownerDir
+	}
+	if action.Shell == "" {
+		action.Shell = ownerShell
+	}
+	fileEnv, err := loadEnvFiles(action.Dir, action.EnvFiles)
+	if err != nil {
+		return Action{}, err
+	}
+	action.Env = mergeStringMap(mergeStringMap(ownerEnv, fileEnv), action.Env)
+	for _, path := range resolvedEnvFiles(action.Dir, action.EnvFiles) {
+		cfg.WatchPaths = appendUniqueString(cfg.WatchPaths, path)
+	}
+	for key, value := range action.Env {
+		action.Env[key] = os.ExpandEnv(value)
+	}
+	return action, nil
+}
+
+func loadEnvFiles(baseDir string, files []string) (map[string]string, error) {
+	result := make(map[string]string)
+	for _, path := range resolvedEnvFiles(baseDir, files) {
+		values, err := readDotEnv(path)
+		if err != nil {
+			return nil, err
+		}
+		result = mergeStringMap(result, values)
+	}
+	return result, nil
+}
+
+func resolvedEnvFiles(baseDir string, files []string) []string {
+	resolved := append([]string(nil), files...)
+	for index, path := range resolved {
+		if !filepath.IsAbs(path) {
+			resolved[index] = filepath.Clean(filepath.Join(baseDir, path))
+		}
+	}
+	return resolved
 }
 
 func loadServiceEnvFiles(cfg *Config, svc Service) (map[string]string, error) {

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -3,23 +3,25 @@ package config
 
 import (
 	"net/url"
+	"sort"
 	"time"
 )
 
 // Config is the normalized root structure for every supported source format.
 type Config struct {
-	Project      string             `yaml:"project"`
-	Version      string             `yaml:"version,omitempty"`
-	UI           UIConfig           `yaml:"ui,omitempty"`
-	Defaults     Defaults           `yaml:"defaults,omitempty"`
-	Services     map[string]Service `yaml:"services"`
-	ServiceOrder []string           `yaml:"-"`
-	Source       SourceFormat       `yaml:"-"`
-	Diagnostics  []string           `yaml:"-"`
-	Paths        []string           `yaml:"-"`
-	WatchPaths   []string           `yaml:"-"`
-	dotenvEnv    map[string]string  `yaml:"-"`
-	explicitEnv  map[string]string  `yaml:"-"`
+	Project      string                 `yaml:"project"`
+	Version      string                 `yaml:"version,omitempty"`
+	UI           UIConfig               `yaml:"ui,omitempty"`
+	Defaults     Defaults               `yaml:"defaults,omitempty"`
+	Services     map[string]Service     `yaml:"services,omitempty"`
+	ActionGroups map[string]ActionGroup `yaml:"action_groups,omitempty"`
+	ServiceOrder []string               `yaml:"-"`
+	Source       SourceFormat           `yaml:"-"`
+	Diagnostics  []string               `yaml:"-"`
+	Paths        []string               `yaml:"-"`
+	WatchPaths   []string               `yaml:"-"`
+	dotenvEnv    map[string]string      `yaml:"-"`
+	explicitEnv  map[string]string      `yaml:"-"`
 }
 
 // UIConfig defines project-specific presentation defaults.
@@ -76,7 +78,117 @@ type Service struct {
 	SuccessExitCodes     []int                       `yaml:"success_exit_codes,omitempty"`
 	Disabled             bool                        `yaml:"disabled,omitempty"`
 	DisableDotenv        bool                        `yaml:"is_dotenv_disabled,omitempty"`
+	Actions              map[string]Action           `yaml:"actions,omitempty"`
 	disabledSet          bool                        `yaml:"-"`
+}
+
+// Action describes one explicitly configured command that runs to completion.
+// Its owner supplies any omitted execution context.
+type Action struct {
+	Command     string            `yaml:"command"`
+	Description string            `yaml:"description,omitempty"`
+	Dir         string            `yaml:"dir,omitempty"`
+	Shell       string            `yaml:"shell,omitempty"`
+	Env         map[string]string `yaml:"env,omitempty"`
+	EnvFiles    []string          `yaml:"env_files,omitempty"`
+	Timeout     time.Duration     `yaml:"timeout,omitempty"`
+	Confirm     *bool             `yaml:"confirm,omitempty"`
+	Interactive *bool             `yaml:"interactive,omitempty"`
+}
+
+// ConfirmationRequired resolves the optional confirmation flag.
+func (a Action) ConfirmationRequired() bool {
+	return a.Confirm != nil && *a.Confirm
+}
+
+// InteractiveEnabled resolves the optional terminal handoff flag.
+func (a Action) InteractiveEnabled() bool {
+	return a.Interactive != nil && *a.Interactive
+}
+
+// ActionGroup owns project-level actions that do not belong to a managed
+// service, while providing shared execution context for those actions.
+type ActionGroup struct {
+	Description string            `yaml:"description,omitempty"`
+	Dir         string            `yaml:"dir,omitempty"`
+	Shell       string            `yaml:"shell,omitempty"`
+	Env         map[string]string `yaml:"env,omitempty"`
+	EnvFiles    []string          `yaml:"env_files,omitempty"`
+	Actions     map[string]Action `yaml:"actions"`
+}
+
+// ActionOwnerKind distinguishes service-scoped and project-level actions.
+type ActionOwnerKind string
+
+const (
+	ActionOwnerService ActionOwnerKind = "service"
+	ActionOwnerGroup   ActionOwnerKind = "group"
+)
+
+// ActionID is a comparable, unambiguous runtime identity. Names remain opaque,
+// so natural keys such as build:launcher do not require delimiter parsing.
+type ActionID struct {
+	OwnerKind ActionOwnerKind
+	Owner     string
+	Name      string
+}
+
+// ResolveAction returns the normalized action identified by id.
+func (c *Config) ResolveAction(id ActionID) (Action, bool) {
+	if c == nil {
+		return Action{}, false
+	}
+	switch id.OwnerKind {
+	case ActionOwnerService:
+		service, exists := c.Services[id.Owner]
+		if !exists {
+			return Action{}, false
+		}
+		action, exists := service.Actions[id.Name]
+		return action, exists
+	case ActionOwnerGroup:
+		group, exists := c.ActionGroups[id.Owner]
+		if !exists {
+			return Action{}, false
+		}
+		action, exists := group.Actions[id.Name]
+		return action, exists
+	default:
+		return Action{}, false
+	}
+}
+
+// ActionIDs returns every configured action in deterministic owner/name order.
+func (c *Config) ActionIDs() []ActionID {
+	if c == nil {
+		return nil
+	}
+	ids := make([]ActionID, 0)
+	for _, owner := range c.ServiceNames() {
+		for _, name := range sortedActionNames(c.Services[owner].Actions) {
+			ids = append(ids, ActionID{OwnerKind: ActionOwnerService, Owner: owner, Name: name})
+		}
+	}
+	groups := make([]string, 0, len(c.ActionGroups))
+	for owner := range c.ActionGroups {
+		groups = append(groups, owner)
+	}
+	sort.Strings(groups)
+	for _, owner := range groups {
+		for _, name := range sortedActionNames(c.ActionGroups[owner].Actions) {
+			ids = append(ids, ActionID{OwnerKind: ActionOwnerGroup, Owner: owner, Name: name})
+		}
+	}
+	return ids
+}
+
+func sortedActionNames(actions map[string]Action) []string {
+	names := make([]string, 0, len(actions))
+	for name := range actions {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // PortDiscoveryEnabled resolves the service-level tri-state. Services without

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-// Validate checks project metadata, commands, dependencies, ports, and probes.
+// Validate checks project metadata, commands, actions, dependencies, ports, and probes.
 func Validate(cfg *Config) error {
 	if cfg.Project == "" {
 		return fmt.Errorf("field 'project' is required")
@@ -23,8 +23,8 @@ func Validate(cfg *Config) error {
 		return fmt.Errorf("ui.color_mode must be auto, dark, or light, got %q", cfg.UI.ColorMode)
 	}
 
-	if len(cfg.Services) == 0 {
-		return fmt.Errorf("section 'services' must contain at least one service")
+	if len(cfg.Services) == 0 && len(cfg.ActionGroups) == 0 {
+		return fmt.Errorf("configuration must contain at least one service or action group")
 	}
 
 	svcNames := make(map[string]bool)
@@ -35,6 +35,9 @@ func Validate(cfg *Config) error {
 	for name, svc := range cfg.Services {
 		if svc.Command == "" {
 			return fmt.Errorf("service %q: field 'command' is required", name)
+		}
+		if err := validateActions(fmt.Sprintf("service %q", name), svc.Actions); err != nil {
+			return err
 		}
 
 		// Validate references before cycle detection to produce actionable errors.
@@ -97,12 +100,38 @@ func Validate(cfg *Config) error {
 			}
 		}
 	}
+	for name, group := range cfg.ActionGroups {
+		if strings.TrimSpace(name) == "" {
+			return fmt.Errorf("action group name cannot be empty")
+		}
+		if len(group.Actions) == 0 {
+			return fmt.Errorf("action group %q must contain at least one action", name)
+		}
+		if err := validateActions(fmt.Sprintf("action group %q", name), group.Actions); err != nil {
+			return err
+		}
+	}
 
 	// Cycles would make lifecycle ordering impossible.
 	if err := detectCycles(cfg); err != nil {
 		return err
 	}
 
+	return nil
+}
+
+func validateActions(owner string, actions map[string]Action) error {
+	for name, action := range actions {
+		if strings.TrimSpace(name) == "" {
+			return fmt.Errorf("%s: action name cannot be empty", owner)
+		}
+		if strings.TrimSpace(action.Command) == "" {
+			return fmt.Errorf("%s action %q: field 'command' is required", owner, name)
+		}
+		if action.Timeout < 0 {
+			return fmt.Errorf("%s action %q: timeout cannot be negative", owner, name)
+		}
+	}
 	return nil
 }
 

--- a/internal/service/manager.go
+++ b/internal/service/manager.go
@@ -74,7 +74,7 @@ func (m *Manager) ApplyConfig(next *config.Config) (ReloadResult, error) {
 			result.Removed = append(result.Removed, name)
 			continue
 		}
-		if reflect.DeepEqual(svc.Config, incoming) {
+		if sameManagedServiceConfig(svc.Config, incoming) {
 			continue
 		}
 		wasRunning := svc.Status() != config.StatusStopped || svc.DesiredRunning()
@@ -116,6 +116,15 @@ func (m *Manager) ApplyConfig(next *config.Config) (ReloadResult, error) {
 		result.Restarted = append(result.Restarted, runningChanged...)
 	}
 	return result, nil
+}
+
+// sameManagedServiceConfig excludes actions because changing a one-shot command
+// must not restart its long-running owner. The manager-level config is replaced
+// after reconciliation and remains the source of truth for actions.
+func sameManagedServiceConfig(current, incoming config.Service) bool {
+	current.Actions = nil
+	incoming.Actions = nil
+	return reflect.DeepEqual(current, incoming)
 }
 
 // NewManager creates stopped runtime services from configuration.

--- a/internal/service/manager_test.go
+++ b/internal/service/manager_test.go
@@ -315,6 +315,39 @@ func TestApplyConfigPreservesUnchangedProcessesAndReconcilesChanges(t *testing.T
 	}
 }
 
+func TestApplyConfigDoesNotRestartServiceForActionOnlyChanges(t *testing.T) {
+	manager := NewManager(&config.Config{Project: "Test", Services: map[string]config.Service{
+		"api": {Command: "sleep 60", Actions: map[string]config.Action{
+			"migrate": {Command: "migrate-v1"},
+		}},
+	}})
+	defer manager.Shutdown()
+	if err := manager.StartService("api"); err != nil {
+		t.Fatal(err)
+	}
+	before, _ := manager.GetService("api")
+	pid := before.PID()
+
+	result, err := manager.ApplyConfig(&config.Config{Project: "Test", Services: map[string]config.Service{
+		"api": {Command: "sleep 60", Actions: map[string]config.Action{
+			"migrate": {Command: "migrate-v2"},
+		}},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, _ := manager.GetService("api")
+	if after != before || after.PID() != pid {
+		t.Fatalf("action-only reload restarted service: before PID %d after PID %d", pid, after.PID())
+	}
+	if len(result.Updated) != 0 || len(result.Restarted) != 0 {
+		t.Fatalf("action-only reload result = %#v", result)
+	}
+	if got := manager.cfg.Services["api"].Actions["migrate"].Command; got != "migrate-v2" {
+		t.Fatalf("manager action config = %q", got)
+	}
+}
+
 func TestExitOnEndRequestsProjectTerminationAndStopsPeers(t *testing.T) {
 	manager := NewManager(&config.Config{Project: "Test", Services: map[string]config.Service{
 		"peer": {Command: "sleep 60"},


### PR DESCRIPTION
## Summary
- add service-scoped actions and project-level action groups
- normalize inherited execution context, env files, layered overrides, and stable ActionID resolution
- validate action-only projects and avoid restarting services for action-only reloads

## Verification
- make verify
- make lint
- manual launch from artifacts/examples/runtime-ports after make build

## Scope
This PR establishes the configuration contract only. Runtime execution, TUI, prerequisites, and terminal handoff follow in separate task-sized PRs.