### PR TITLE
feat: add actions runtime

### DIFF
--- a/internal/service/action.go
+++ b/internal/service/action.go
@@ -1,0 +1,355 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/kranz-org/kranz/internal/config"
+)
+
+const (
+	defaultActionLogBuffer = 1000
+	actionStopGracePeriod  = time.Second
+)
+
+var (
+	ErrActionNotFound       = errors.New("action not found")
+	ErrActionRunnerStopping = errors.New("action runner is shutting down")
+	ErrInteractiveAction    = errors.New("interactive action requires terminal handoff")
+)
+
+// ActionStatus describes the lifecycle of a finishing command.
+type ActionStatus uint8
+
+const (
+	ActionReady ActionStatus = iota
+	ActionRunning
+	ActionSucceeded
+	ActionFailed
+	ActionTimedOut
+	ActionCancelled
+)
+
+// String returns the stable user-facing action state.
+func (s ActionStatus) String() string {
+	switch s {
+	case ActionReady:
+		return "ready"
+	case ActionRunning:
+		return "running"
+	case ActionSucceeded:
+		return "succeeded"
+	case ActionFailed:
+		return "failed"
+	case ActionTimedOut:
+		return "timed_out"
+	case ActionCancelled:
+		return "cancelled"
+	default:
+		return "unknown"
+	}
+}
+
+// ActionResult is the concurrency-safe snapshot retained for one action.
+type ActionResult struct {
+	ID         config.ActionID
+	Status     ActionStatus
+	PID        int
+	StartedAt  time.Time
+	FinishedAt time.Time
+	Duration   time.Duration
+	ExitCode   int
+	Error      string
+	Stdout     []string
+	Stderr     []string
+}
+
+// ActionBusyError identifies the action currently occupying an owner.
+type ActionBusyError struct {
+	Requested config.ActionID
+	Running   config.ActionID
+}
+
+func (e *ActionBusyError) Error() string {
+	return fmt.Sprintf("action owner is busy running %s/%s", e.Running.Owner, e.Running.Name)
+}
+
+// ActionExitError reports a finishing command's unsuccessful exit code.
+type ActionExitError struct {
+	ID       config.ActionID
+	ExitCode int
+}
+
+func (e *ActionExitError) Error() string {
+	return fmt.Sprintf("action %s/%s exited with code %d", e.ID.Owner, e.ID.Name, e.ExitCode)
+}
+
+type actionOwner struct {
+	kind config.ActionOwnerKind
+	name string
+}
+
+type activeAction struct {
+	id     config.ActionID
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+// ActionRunner executes normalized non-interactive actions and retains their
+// latest bounded result. It serializes actions per owner while allowing
+// independent services and groups to run concurrently.
+type ActionRunner struct {
+	mu           sync.RWMutex
+	cfg          *config.Config
+	states       map[config.ActionID]ActionResult
+	active       map[actionOwner]*activeAction
+	logBufSize   int
+	shuttingDown bool
+}
+
+// NewActionRunner creates an action runner for one loaded project config.
+func NewActionRunner(cfg *config.Config, logBufSize int) *ActionRunner {
+	if logBufSize <= 0 {
+		logBufSize = defaultActionLogBuffer
+	}
+	return &ActionRunner{
+		cfg:        cfg,
+		states:     make(map[config.ActionID]ActionResult),
+		active:     make(map[actionOwner]*activeAction),
+		logBufSize: logBufSize,
+	}
+}
+
+// ApplyConfig swaps the source of truth for future runs. Results survive only
+// while the same action definition remains configured; active runs finish from
+// the immutable definition with which they started.
+func (r *ActionRunner) ApplyConfig(next *config.Config) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for id := range r.states {
+		if r.isActiveLocked(id) {
+			continue
+		}
+		currentAction, currentExists := r.cfg.ResolveAction(id)
+		nextAction, nextExists := next.ResolveAction(id)
+		if !currentExists || !nextExists || !reflect.DeepEqual(currentAction, nextAction) {
+			delete(r.states, id)
+		}
+	}
+	r.cfg = next
+}
+
+// Run executes one non-interactive action and blocks until it finishes.
+func (r *ActionRunner) Run(ctx context.Context, id config.ActionID) (ActionResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	r.mu.Lock()
+	if r.shuttingDown {
+		r.mu.Unlock()
+		return ActionResult{}, ErrActionRunnerStopping
+	}
+	action, exists := r.cfg.ResolveAction(id)
+	if !exists {
+		r.mu.Unlock()
+		return ActionResult{}, fmt.Errorf("%w: %s/%s", ErrActionNotFound, id.Owner, id.Name)
+	}
+	if action.InteractiveEnabled() {
+		r.mu.Unlock()
+		return ActionResult{}, ErrInteractiveAction
+	}
+	owner := actionOwner{kind: id.OwnerKind, name: id.Owner}
+	if running, busy := r.active[owner]; busy {
+		r.mu.Unlock()
+		return ActionResult{}, &ActionBusyError{Requested: id, Running: running.id}
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	active := &activeAction{id: id, cancel: cancel, done: make(chan struct{})}
+	r.active[owner] = active
+	started := time.Now()
+	r.states[id] = ActionResult{ID: id, Status: ActionRunning, ExitCode: -1, StartedAt: started}
+	r.mu.Unlock()
+
+	result, runErr := r.execute(runCtx, id, action, started)
+	cancel()
+	r.mu.Lock()
+	delete(r.active, owner)
+	r.states[id] = cloneActionResult(result)
+	close(active.done)
+	r.mu.Unlock()
+	return result, runErr
+}
+
+func (r *ActionRunner) execute(ctx context.Context, id config.ActionID, action config.Action, started time.Time) (ActionResult, error) {
+	result := ActionResult{ID: id, Status: ActionFailed, ExitCode: -1, StartedAt: started}
+	if err := ctx.Err(); err != nil {
+		return finishActionResult(result, ActionCancelled, nil, err)
+	}
+
+	process := NewProcessManager(r.logBufSize)
+	pid, err := process.Start(context.Background(), action.Command, action.Dir, action.Env, action.Shell)
+	if err != nil {
+		return finishActionResult(result, ActionFailed, process, err)
+	}
+	result.PID = pid
+	r.setActionPID(id, pid)
+
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- process.Wait() }()
+	var timer *time.Timer
+	var timeout <-chan time.Time
+	if action.Timeout > 0 {
+		timer = time.NewTimer(action.Timeout)
+		timeout = timer.C
+		defer timer.Stop()
+	}
+
+	select {
+	case waitErr := <-waitCh:
+		if waitErr == nil && process.ExitCode() == 0 {
+			return finishActionResult(result, ActionSucceeded, process, nil)
+		}
+		exitErr := &ActionExitError{ID: id, ExitCode: process.ExitCode()}
+		return finishActionResult(result, ActionFailed, process, errors.Join(exitErr, waitErr))
+	case <-ctx.Done():
+		stopErr := process.StopWithOptions(StopOptions{Signal: syscall.SIGTERM, Timeout: actionStopGracePeriod})
+		<-waitCh
+		return finishActionResult(result, ActionCancelled, process, errors.Join(ctx.Err(), stopErr))
+	case <-timeout:
+		stopErr := process.StopWithOptions(StopOptions{Signal: syscall.SIGTERM, Timeout: actionStopGracePeriod})
+		<-waitCh
+		timeoutErr := fmt.Errorf("action timed out after %s: %w", action.Timeout, context.DeadlineExceeded)
+		return finishActionResult(result, ActionTimedOut, process, errors.Join(timeoutErr, stopErr))
+	}
+}
+
+func finishActionResult(result ActionResult, status ActionStatus, process *ProcessManager, runErr error) (ActionResult, error) {
+	result.Status = status
+	result.FinishedAt = time.Now()
+	result.Duration = result.FinishedAt.Sub(result.StartedAt)
+	if process != nil {
+		result.ExitCode = process.ExitCode()
+		result.Stdout = append([]string(nil), process.Stdout().Lines()...)
+		result.Stderr = append([]string(nil), process.Stderr().Lines()...)
+	}
+	if runErr != nil {
+		result.Error = runErr.Error()
+	}
+	return result, runErr
+}
+
+func (r *ActionRunner) setActionPID(id config.ActionID, pid int) {
+	r.mu.Lock()
+	state := r.states[id]
+	state.PID = pid
+	r.states[id] = state
+	r.mu.Unlock()
+}
+
+// State returns the current or most recent result of a configured action.
+func (r *ActionRunner) State(id config.ActionID) (ActionResult, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if state, exists := r.states[id]; exists && (r.isActiveLocked(id) || r.actionExistsLocked(id)) {
+		return cloneActionResult(state), true
+	}
+	if r.actionExistsLocked(id) {
+		return ActionResult{ID: id, Status: ActionReady, ExitCode: -1}, true
+	}
+	return ActionResult{}, false
+}
+
+// States returns deterministic snapshots for every currently configured action.
+func (r *ActionRunner) States() []ActionResult {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ids := r.cfg.ActionIDs()
+	states := make([]ActionResult, 0, len(ids))
+	for _, id := range ids {
+		if state, exists := r.states[id]; exists {
+			states = append(states, cloneActionResult(state))
+		} else {
+			states = append(states, ActionResult{ID: id, Status: ActionReady, ExitCode: -1})
+		}
+	}
+	return states
+}
+
+// Cancel requests termination of a running action.
+func (r *ActionRunner) Cancel(id config.ActionID) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, active := range r.active {
+		if active.id == id {
+			active.cancel()
+			return true
+		}
+	}
+	return false
+}
+
+// Shutdown rejects future runs, cancels active actions, and waits for reaping.
+func (r *ActionRunner) Shutdown() {
+	r.mu.Lock()
+	if r.shuttingDown {
+		r.mu.Unlock()
+		return
+	}
+	r.shuttingDown = true
+	active := make([]*activeAction, 0, len(r.active))
+	for _, run := range r.active {
+		active = append(active, run)
+	}
+	r.mu.Unlock()
+	for _, run := range active {
+		run.cancel()
+	}
+	for _, run := range active {
+		<-run.done
+	}
+}
+
+func (r *ActionRunner) isActiveLocked(id config.ActionID) bool {
+	for _, active := range r.active {
+		if active.id == id {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *ActionRunner) actionExistsLocked(id config.ActionID) bool {
+	_, exists := r.cfg.ResolveAction(id)
+	return exists
+}
+
+func cloneActionResult(result ActionResult) ActionResult {
+	result.Stdout = append([]string(nil), result.Stdout...)
+	result.Stderr = append([]string(nil), result.Stderr...)
+	return result
+}
+
+// RunAction executes one configured non-interactive action.
+func (m *Manager) RunAction(ctx context.Context, id config.ActionID) (ActionResult, error) {
+	return m.actions.Run(ctx, id)
+}
+
+// ActionState returns the current or most recent state of an action.
+func (m *Manager) ActionState(id config.ActionID) (ActionResult, bool) {
+	return m.actions.State(id)
+}
+
+// ActionStates returns deterministic snapshots of all configured actions.
+func (m *Manager) ActionStates() []ActionResult {
+	return m.actions.States()
+}
+
+// CancelAction requests termination of a running action.
+func (m *Manager) CancelAction(id config.ActionID) bool {
+	return m.actions.Cancel(id)
+}

--- a/internal/service/action_test.go
+++ b/internal/service/action_test.go
@@ -1,0 +1,258 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kranz-org/kranz/internal/config"
+)
+
+func TestActionRunnerCapturesSuccessfulResultAndEnvironment(t *testing.T) {
+	directory := t.TempDir()
+	id := serviceActionID("app", "inspect")
+	runner := newTestActionRunner(directory, map[string]config.Action{
+		"inspect": {
+			Command: `printf 'value=%s\n' "$ACTION_VALUE"; printf 'problem\n' >&2`,
+			Dir:     directory,
+			Shell:   "/bin/sh",
+			Env:     map[string]string{"ACTION_VALUE": "inherited"},
+		},
+	})
+
+	ready, exists := runner.State(id)
+	if !exists || ready.Status != ActionReady || ready.ExitCode != -1 {
+		t.Fatalf("initial action state = %#v, %v", ready, exists)
+	}
+	result, err := runner.Run(context.Background(), id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != ActionSucceeded || result.ExitCode != 0 || result.PID <= 0 || result.Duration <= 0 {
+		t.Fatalf("successful result = %#v", result)
+	}
+	if strings.TrimSpace(strings.Join(result.Stdout, "\n")) != "value=inherited" || strings.TrimSpace(strings.Join(result.Stderr, "\n")) != "problem" {
+		t.Fatalf("captured output = stdout %q stderr %q", result.Stdout, result.Stderr)
+	}
+	state, exists := runner.State(id)
+	if !exists || state.Status != ActionSucceeded || state.FinishedAt.IsZero() {
+		t.Fatalf("retained action state = %#v, %v", state, exists)
+	}
+	state.Stdout[0] = "mutated"
+	again, _ := runner.State(id)
+	if strings.TrimSpace(again.Stdout[0]) != "value=inherited" {
+		t.Fatalf("state returned aliased output: %v", again.Stdout)
+	}
+}
+
+func TestActionRunnerReportsFailureAndExitCode(t *testing.T) {
+	id := serviceActionID("app", "fail")
+	runner := newTestActionRunner(t.TempDir(), map[string]config.Action{
+		"fail": {Command: "printf 'broken\\n' >&2; exit 7", Shell: "/bin/sh"},
+	})
+	result, err := runner.Run(context.Background(), id)
+	var exitErr *ActionExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode != 7 {
+		t.Fatalf("run error = %v", err)
+	}
+	if result.Status != ActionFailed || result.ExitCode != 7 || strings.TrimSpace(strings.Join(result.Stderr, "\n")) != "broken" || result.Error == "" {
+		t.Fatalf("failed result = %#v", result)
+	}
+}
+
+func TestActionRunnerTimesOutAndCancelsProcessGroup(t *testing.T) {
+	id := serviceActionID("app", "slow")
+	runner := newTestActionRunner(t.TempDir(), map[string]config.Action{
+		"slow": {Command: "sleep 10", Shell: "/bin/sh", Timeout: 50 * time.Millisecond},
+	})
+	started := time.Now()
+	result, err := runner.Run(context.Background(), id)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("timeout error = %v", err)
+	}
+	if result.Status != ActionTimedOut || result.Duration < 40*time.Millisecond || time.Since(started) > 2*time.Second {
+		t.Fatalf("timed-out result = %#v after %s", result, time.Since(started))
+	}
+}
+
+func TestActionRunnerSerializesOwnerAndAllowsIndependentOwners(t *testing.T) {
+	directory := t.TempDir()
+	serviceID := serviceActionID("app", "slow")
+	secondID := serviceActionID("app", "second")
+	groupID := config.ActionID{OwnerKind: config.ActionOwnerGroup, Owner: "tools", Name: "quick"}
+	cfg := &config.Config{
+		Project: "Actions",
+		Services: map[string]config.Service{"app": {Command: "run", Actions: map[string]config.Action{
+			"slow":   {Command: "sleep 10", Dir: directory, Shell: "/bin/sh"},
+			"second": {Command: "exit 0", Dir: directory, Shell: "/bin/sh"},
+		}}},
+		ActionGroups: map[string]config.ActionGroup{"tools": {Actions: map[string]config.Action{
+			"quick": {Command: "printf 'quick\\n'", Dir: directory, Shell: "/bin/sh"},
+		}}},
+	}
+	runner := NewActionRunner(cfg, 20)
+	type runOutcome struct {
+		result ActionResult
+		err    error
+	}
+	slowDone := make(chan runOutcome, 1)
+	go func() {
+		result, err := runner.Run(context.Background(), serviceID)
+		slowDone <- runOutcome{result: result, err: err}
+	}()
+	waitForActionStatus(t, runner, serviceID, ActionRunning)
+
+	_, err := runner.Run(context.Background(), secondID)
+	var busyErr *ActionBusyError
+	if !errors.As(err, &busyErr) || busyErr.Running != serviceID || busyErr.Requested != secondID {
+		t.Fatalf("same-owner run error = %#v", err)
+	}
+	groupResult, err := runner.Run(context.Background(), groupID)
+	if err != nil || groupResult.Status != ActionSucceeded {
+		t.Fatalf("independent group result = %#v, %v", groupResult, err)
+	}
+	if !runner.Cancel(serviceID) {
+		t.Fatal("running action was not cancelled")
+	}
+	slow := <-slowDone
+	if !errors.Is(slow.err, context.Canceled) || slow.result.Status != ActionCancelled {
+		t.Fatalf("cancelled action = %#v, %v", slow.result, slow.err)
+	}
+}
+
+func TestActionRunnerRejectsInteractiveAndUnknownActions(t *testing.T) {
+	interactive := true
+	runner := newTestActionRunner(t.TempDir(), map[string]config.Action{
+		"console": {Command: "sh", Shell: "/bin/sh", Interactive: &interactive},
+	})
+	if _, err := runner.Run(context.Background(), serviceActionID("app", "console")); !errors.Is(err, ErrInteractiveAction) {
+		t.Fatalf("interactive action error = %v", err)
+	}
+	if _, err := runner.Run(context.Background(), serviceActionID("app", "missing")); !errors.Is(err, ErrActionNotFound) {
+		t.Fatalf("missing action error = %v", err)
+	}
+}
+
+func TestActionRunnerApplyConfigPreservesOrResetsResults(t *testing.T) {
+	directory := t.TempDir()
+	id := serviceActionID("app", "version")
+	action := config.Action{Command: "printf 'v1\\n'", Dir: directory, Shell: "/bin/sh"}
+	runner := newTestActionRunner(directory, map[string]config.Action{"version": action})
+	if _, err := runner.Run(context.Background(), id); err != nil {
+		t.Fatal(err)
+	}
+	same := newActionConfig(map[string]config.Action{"version": action})
+	runner.ApplyConfig(same)
+	state, _ := runner.State(id)
+	if state.Status != ActionSucceeded {
+		t.Fatalf("unchanged action state = %#v", state)
+	}
+	changed := action
+	changed.Command = "printf 'v2\\n'"
+	runner.ApplyConfig(newActionConfig(map[string]config.Action{"version": changed}))
+	state, _ = runner.State(id)
+	if state.Status != ActionReady {
+		t.Fatalf("changed action state = %#v", state)
+	}
+}
+
+func TestActionRunnerShutdownCancelsRunsAndRejectsNewOnes(t *testing.T) {
+	id := serviceActionID("app", "slow")
+	runner := newTestActionRunner(t.TempDir(), map[string]config.Action{
+		"slow": {Command: "sleep 10", Shell: "/bin/sh"},
+	})
+	done := make(chan error, 1)
+	go func() {
+		_, err := runner.Run(context.Background(), id)
+		done <- err
+	}()
+	waitForActionStatus(t, runner, id, ActionRunning)
+	runner.Shutdown()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("shutdown run error = %v", err)
+	}
+	if _, err := runner.Run(context.Background(), id); !errors.Is(err, ErrActionRunnerStopping) {
+		t.Fatalf("post-shutdown run error = %v", err)
+	}
+}
+
+func TestManagerReloadUpdatesActionRunnerWithoutRestartingService(t *testing.T) {
+	directory := t.TempDir()
+	id := serviceActionID("app", "version")
+	manager := NewManager(&config.Config{Project: "Actions", Services: map[string]config.Service{
+		"app": {Command: "sleep 10", Actions: map[string]config.Action{
+			"version": {Command: "printf 'v1\\n'", Dir: directory, Shell: "/bin/sh"},
+		}},
+	}})
+	defer manager.Shutdown()
+	if err := manager.StartService("app"); err != nil {
+		t.Fatal(err)
+	}
+	serviceBefore, _ := manager.GetService("app")
+	pidBefore := serviceBefore.PID()
+	if pidBefore <= 0 {
+		t.Fatalf("started service PID = %d", pidBefore)
+	}
+	result, err := manager.RunAction(context.Background(), id)
+	if err != nil || strings.TrimSpace(strings.Join(result.Stdout, "\n")) != "v1" {
+		t.Fatalf("first action = %#v, %v", result, err)
+	}
+	if _, err := manager.ApplyConfig(&config.Config{Project: "Actions", Services: map[string]config.Service{
+		"app": {Command: "sleep 10", Actions: map[string]config.Action{
+			"version": {Command: "printf 'v2\\n'", Dir: directory, Shell: "/bin/sh"},
+		}},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	state, _ := manager.ActionState(id)
+	if state.Status != ActionReady {
+		t.Fatalf("reloaded action state = %#v", state)
+	}
+	serviceAfter, _ := manager.GetService("app")
+	if serviceAfter != serviceBefore || serviceAfter.PID() != pidBefore {
+		t.Fatalf("action-only reload replaced service: before PID %d, after PID %d", pidBefore, serviceAfter.PID())
+	}
+	result, err = manager.RunAction(context.Background(), id)
+	if err != nil || strings.TrimSpace(strings.Join(result.Stdout, "\n")) != "v2" {
+		t.Fatalf("reloaded action = %#v, %v", result, err)
+	}
+}
+
+func newTestActionRunner(directory string, actions map[string]config.Action) *ActionRunner {
+	for name, action := range actions {
+		if action.Dir == "" {
+			action.Dir = directory
+		}
+		if action.Shell == "" {
+			action.Shell = "/bin/sh"
+		}
+		actions[name] = action
+	}
+	return NewActionRunner(newActionConfig(actions), 20)
+}
+
+func newActionConfig(actions map[string]config.Action) *config.Config {
+	return &config.Config{Project: "Actions", Services: map[string]config.Service{
+		"app": {Command: "run", Actions: actions},
+	}}
+}
+
+func serviceActionID(owner, name string) config.ActionID {
+	return config.ActionID{OwnerKind: config.ActionOwnerService, Owner: owner, Name: name}
+}
+
+func waitForActionStatus(t *testing.T, runner *ActionRunner, id config.ActionID, status ActionStatus) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		state, exists := runner.State(id)
+		if exists && state.Status == status && (status != ActionRunning || state.PID > 0) {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	state, exists := runner.State(id)
+	t.Fatalf("action state = %#v, %v; want %s", state, exists, status)
+}

--- a/internal/service/manager.go
+++ b/internal/service/manager.go
@@ -22,6 +22,7 @@ import (
 type Manager struct {
 	services             map[string]*Service
 	cfg                  *config.Config
+	actions              *ActionRunner
 	mu                   sync.RWMutex
 	healthChecker        *health.Checker
 	portChecker          port.Checker
@@ -107,6 +108,7 @@ func (m *Manager) ApplyConfig(next *config.Config) (ReloadResult, error) {
 	}
 	m.cfg = next
 	m.mu.Unlock()
+	m.actions.ApplyConfig(next)
 	sort.Strings(result.Added)
 
 	if len(runningChanged) > 0 {
@@ -132,6 +134,7 @@ func NewManager(cfg *config.Config) *Manager {
 	m := &Manager{
 		services:             make(map[string]*Service),
 		cfg:                  cfg,
+		actions:              NewActionRunner(cfg, defaultActionLogBuffer),
 		listenerScanInterval: 2 * time.Second,
 	}
 
@@ -744,6 +747,7 @@ func (m *Manager) expandWithDependencies(names []string) (map[string]bool, error
 func (m *Manager) Shutdown() error {
 	m.shuttingDown.Store(true)
 	m.stopListenerDiscovery()
+	m.actions.Shutdown()
 	return m.StopAll()
 }
 


### PR DESCRIPTION
## Summary

- execute normalized non-interactive service and group actions
- retain bounded output, exit status, timing, and observable lifecycle state
- serialize runs per owner while supporting independent owners concurrently
- cancel and reap action process groups on timeout, request cancellation, and shutdown
- apply action-only config reloads without restarting managed services

## Validation

- make verify
- make lint
- make build
- go test -race ./internal/service