### PR TITLE
fix: confirm running action stops

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -210,12 +210,13 @@ type Model struct {
 	toastMessage  string
 	toastTimer    time.Time
 
-	confirmAction  string
-	confirmTarget  string
-	pendingAction  *config.ActionID
-	themeSaveScope themeSaveScope
-	clearTarget    string
-	clearPinned    bool
+	confirmAction     string
+	confirmTarget     string
+	pendingAction     *config.ActionID
+	pendingActionStop bool
+	themeSaveScope    themeSaveScope
+	clearTarget       string
+	clearPinned       bool
 
 	conflictService  string
 	conflictPorts    map[int]*config.PortInfo

--- a/internal/ui/model_actions.go
+++ b/internal/ui/model_actions.go
@@ -175,20 +175,21 @@ func (m *Model) toggleFocusedAction() (tea.Cmd, bool) {
 		return nil, true
 	}
 	if state, ok := m.manager.ActionState(id); ok && state.Status == service.ActionRunning {
-		if m.manager.CancelAction(id) {
-			m.addNotification("action", "Stopping "+id.Name, config.LogWarn)
-		} else {
-			m.addNotification("action", id.Name+" is no longer running", config.LogWarn)
-		}
+		m.beginActionConfirmation(id, true)
 		return nil, true
 	}
 	if action.ConfirmationRequired() {
-		pending := id
-		m.pendingAction = &pending
-		m.mode = ModeConfirmAction
+		m.beginActionConfirmation(id, false)
 		return nil, true
 	}
 	return m.runAction(id, action), true
+}
+
+func (m *Model) beginActionConfirmation(id config.ActionID, stop bool) {
+	pending := id
+	m.pendingAction = &pending
+	m.pendingActionStop = stop
+	m.mode = ModeConfirmAction
 }
 
 func (m *Model) runAction(id config.ActionID, action config.Action) tea.Cmd {
@@ -205,9 +206,19 @@ func (m *Model) runAction(id config.ActionID, action config.Action) tea.Cmd {
 
 func (m *Model) confirmPendingAction() tea.Cmd {
 	id := m.pendingAction
+	stop := m.pendingActionStop
 	m.pendingAction = nil
+	m.pendingActionStop = false
 	m.mode = ModeNormal
 	if id == nil {
+		return nil
+	}
+	if stop {
+		if m.manager.CancelAction(*id) {
+			m.addNotification("action", "Stopping "+id.Name, config.LogWarn)
+		} else {
+			m.addNotification("action", id.Name+" is no longer running", config.LogWarn)
+		}
 		return nil
 	}
 	action, exists := m.cfg.ResolveAction(*id)
@@ -220,6 +231,7 @@ func (m *Model) confirmPendingAction() tea.Cmd {
 
 func (m *Model) cancelPendingAction() {
 	m.pendingAction = nil
+	m.pendingActionStop = false
 	m.mode = ModeNormal
 }
 

--- a/internal/ui/model_actions_test.go
+++ b/internal/ui/model_actions_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/kranz-org/kranz/internal/service"
 )
 
-func TestSStopsRunningAction(t *testing.T) {
+func TestSConfirmsBeforeStoppingRunningAction(t *testing.T) {
 	model := NewModel(&config.Config{Project: "Stop", Services: map[string]config.Service{
 		"app": {Command: "run", Actions: map[string]config.Action{
 			"slow": {Command: "printf 'started\\n'; sleep 10", Shell: "/bin/sh", Dir: t.TempDir()},
@@ -21,7 +21,7 @@ func TestSStopsRunningAction(t *testing.T) {
 	defer model.Shutdown()
 	model.expandedActionOwner[actionOwnerKey(config.ActionOwnerService, "app")] = true
 	model.focusServiceListRow(1)
-	model.width = 120
+	model.width, model.height, model.ready = 120, 30, true
 
 	_, command := model.handleKeyMsg(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
 	if command == nil {
@@ -49,8 +49,31 @@ func TestSStopsRunningAction(t *testing.T) {
 		t.Fatalf("running action output is not streamed with its command:\n%s", output)
 	}
 	_, stopCommand := model.handleKeyMsg(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
-	if stopCommand != nil {
-		t.Fatalf("stop action unexpectedly scheduled another command: %v", stopCommand)
+	if stopCommand != nil || model.mode != ModeConfirmAction || model.pendingAction == nil || !model.pendingActionStop {
+		t.Fatalf("stop confirmation = command %v, mode %v, action %#v, stop %v", stopCommand, model.mode, model.pendingAction, model.pendingActionStop)
+	}
+	confirmationView := ansi.Strip(model.renderConfirmActionView())
+	for _, expected := range []string{"Stop action \"slow\"?", "will be cancelled", "[Enter/y] Stop", "[Esc/n] Cancel"} {
+		if !strings.Contains(confirmationView, expected) {
+			t.Fatalf("stop confirmation missing %q:\n%s", expected, confirmationView)
+		}
+	}
+	_, stopCommand = model.handleConfirmActionKeys(tea.KeyMsg{Type: tea.KeyEsc})
+	if stopCommand != nil || model.mode != ModeNormal || model.pendingAction != nil || model.pendingActionStop {
+		t.Fatalf("cancel stop = command %v, mode %v, action %#v, stop %v", stopCommand, model.mode, model.pendingAction, model.pendingActionStop)
+	}
+	state, _ = model.manager.ActionState(*model.focusedAction)
+	if state.Status != service.ActionRunning {
+		t.Fatalf("cancelled stop changed action state = %#v", state)
+	}
+
+	_, stopCommand = model.handleKeyMsg(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	if stopCommand != nil || model.mode != ModeConfirmAction {
+		t.Fatalf("second stop confirmation = command %v, mode %v", stopCommand, model.mode)
+	}
+	_, stopCommand = model.handleConfirmActionKeys(tea.KeyMsg{Type: tea.KeyEnter})
+	if stopCommand != nil || model.mode != ModeNormal {
+		t.Fatalf("accepted stop = command %v, mode %v", stopCommand, model.mode)
 	}
 	select {
 	case message := <-done:
@@ -336,7 +359,7 @@ func TestConfiguredActionConfirmationCanCancelOrRun(t *testing.T) {
 	}
 }
 
-func TestStoppingConfirmedRunningActionDoesNotAskAgain(t *testing.T) {
+func TestStartConfirmFlagDoesNotBypassStopConfirmation(t *testing.T) {
 	confirmation := true
 	model := NewModel(&config.Config{Project: "Stop confirmed", Services: map[string]config.Service{
 		"app": {Command: "run", Actions: map[string]config.Action{
@@ -361,8 +384,12 @@ func TestStoppingConfirmedRunningActionDoesNotAskAgain(t *testing.T) {
 	}
 
 	stopCommand, handled := model.toggleFocusedAction()
-	if !handled || stopCommand != nil || model.mode != ModeNormal || model.pendingAction != nil {
-		t.Fatalf("stop confirmed action = handled %v, command %v, mode %v, pending %#v", handled, stopCommand, model.mode, model.pendingAction)
+	if !handled || stopCommand != nil || model.mode != ModeConfirmAction || model.pendingAction == nil || !model.pendingActionStop {
+		t.Fatalf("stop confirmed action = handled %v, command %v, mode %v, pending %#v, stop %v", handled, stopCommand, model.mode, model.pendingAction, model.pendingActionStop)
+	}
+	_, stopCommand = model.handleConfirmActionKeys(tea.KeyMsg{Type: tea.KeyEnter})
+	if stopCommand != nil || model.mode != ModeNormal || model.pendingAction != nil || model.pendingActionStop {
+		t.Fatalf("accepted stop = command %v, mode %v, pending %#v, stop %v", stopCommand, model.mode, model.pendingAction, model.pendingActionStop)
 	}
 	select {
 	case message := <-done:

--- a/internal/ui/mouse.go
+++ b/internal/ui/mouse.go
@@ -304,7 +304,7 @@ func (m *Model) handleOverlayMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 			m.mode = ModeNormal
 		}
 	case ModeConfirmAction:
-		if renderedTextHit(rendered, msg.X, msg.Y, "[Enter/y] Run") {
+		if renderedTextHit(rendered, msg.X, msg.Y, "[Enter/y] Run") || renderedTextHit(rendered, msg.X, msg.Y, "[Enter/y] Stop") {
 			return m, m.confirmPendingAction()
 		}
 		if renderedTextHit(rendered, msg.X, msg.Y, "[Esc/n] Cancel") {

--- a/internal/ui/view_modals.go
+++ b/internal/ui/view_modals.go
@@ -310,6 +310,14 @@ func (m *Model) renderConfirmActionView() string {
 		))
 	}
 	id := *m.pendingAction
+	if m.pendingActionStop {
+		content := renderConfirmationModal(
+			fmt.Sprintf("Stop action %q?", id.Name),
+			[]string{fmt.Sprintf("Owner: %s", id.Owner), "The running action will be cancelled."},
+			"[Enter/y] Stop  [Esc/n] Cancel",
+		)
+		return m.placeOverlay(content)
+	}
 	action, exists := m.cfg.ResolveAction(id)
 	if !exists {
 		return m.placeOverlay(renderConfirmationModal(


### PR DESCRIPTION
## Summary
- always confirm before cancelling a running action
- keep `confirm` scoped to action startup only
- support keyboard and mouse confirmation paths

## Verification
- `make verify`
- `make lint`