### PR TITLE
docs: align interactive and disabled guidance

### DIFF
--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -159,4 +159,5 @@ Two limits follow from what handoff means:
 `confirm` and `interactive` answer different questions. `confirm` is about
 whether the command should run at all — use it for anything destructive.
 `interactive` is about who owns the terminal while it runs. An interactive
-action confirms regardless, so setting both only changes the wording.
+action already forces confirmation with handoff-specific wording, so adding
+`confirm: true` to it has no further effect.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -576,8 +576,8 @@ success_exit_codes: [0, 2]
 
 **Type:** bool · **Default:** `false`
 
-The service stays visible and startable by hand but is excluded from `a`-style
-batch starts.
+The service stays visible and startable by hand. Pressing `a` does not select
+it, and start-all skips it, so it is excluded from `a`-style batch starts.
 
 ```yaml
 disabled: true

--- a/examples/README.md
+++ b/examples/README.md
@@ -62,7 +62,7 @@ disabled on purpose: edit its `preflight` action to `exit 1`, reload with
 
 The same example carries `migrate-interactive`, an action that takes over the
 terminal to ask whether it should apply its migrations. Expand `catalog-api`,
-select it, and press `s`.
+focus `migrate-interactive`, and press `s`.
 
 ## Detached lifecycle playground
 


### PR DESCRIPTION
## Summary

Audit the v0.7.0 documentation against the implemented interactive-action and disabled-service behavior. Correct the example focus target, clarify that interactive actions already force confirmation, and spell out how disabled services interact with select-all and start-all.

## Validation

- [x] `npm run docs:check-links`
- [x] `npm run docs:build`
- [x] `go test ./internal/config ./internal/service ./internal/ui`
- [x] `git diff --check`

## Compatibility

Documentation only; no runtime behavior changes.