### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-08-13
+
 ### Added
 
 - Detached service supervision with optional lifecycle start, stop, status,


### PR DESCRIPTION
## Summary

Promote the complete unreleased changelog into the dated 0.7.0 release section.

## Validation

- [x] `make verify`
- [x] `make lint`
- [x] `make release-check`
- [x] `npm run docs:check-links`
- [x] `npm run docs:build`
- [x] release notes extract successfully for 0.7.0

## Compatibility

Minor release containing detached lifecycle, prerequisites, interactive actions, documentation, and the listed fixes.