### PR TITLE
fix(ui): correct mouse interactions

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -245,6 +245,10 @@ type Model struct {
 	backgroundProbeBusy bool
 	lastBackgroundProbe time.Time
 	lastMouseRefresh    time.Time
+	mousePressSequence  uint64
+	lastListClickOwner  string
+	lastListClickSeq    uint64
+	lastListClickAt     time.Time
 	systemAppearanceSet bool
 	systemDark          bool
 	themeBefore         Theme

--- a/internal/ui/model_actions_test.go
+++ b/internal/ui/model_actions_test.go
@@ -127,6 +127,108 @@ func TestEnterExpandsOwnerAndSRunsFocusedAction(t *testing.T) {
 	}
 }
 
+func TestMouseClickFocusesActionForFooterRun(t *testing.T) {
+	model := NewModel(&config.Config{Project: "Actions", Services: map[string]config.Service{
+		"docs": {Command: "sleep 60"},
+	}, ActionGroups: map[string]config.ActionGroup{
+		"analytics": {Actions: map[string]config.Action{
+			"stats": {Command: "true"},
+		}},
+	}}, "test")
+	defer model.Shutdown()
+	model.width, model.height, model.ready = 100, 30, true
+	model.expandedActionOwner[actionOwnerKey(config.ActionOwnerGroup, "analytics")] = true
+
+	found := false
+	for y, line := range strings.Split(ansi.Strip(model.View()), "\n") {
+		if index := strings.Index(line, "stats"); index >= 0 {
+			x := lipgloss.Width(line[:index])
+			_, _ = model.handleMouseMsg(tea.MouseMsg{
+				X: x, Y: y, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft,
+			})
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("stats action not found:\n%s", ansi.Strip(model.View()))
+	}
+	if model.focusedAction == nil || model.focusedAction.Owner != "analytics" || model.focusedAction.Name != "stats" {
+		t.Fatalf("click focused action %#v", model.focusedAction)
+	}
+	buttons := model.actionButtons()
+	if len(buttons) != 3 || !strings.Contains(ansi.Strip(buttons[0].rendered), "Run action: s") {
+		t.Fatalf("clicked action controls = %#v", buttons)
+	}
+	for _, button := range buttons {
+		if button.action == "force" || button.action == "select" || button.action == "restart" {
+			t.Fatalf("service-only action %q shown for focused action", button.action)
+		}
+	}
+	for _, action := range []string{"force", "select", "restart"} {
+		_, blocked := model.triggerAction(action)
+		if blocked != nil {
+			t.Fatalf("%s scheduled a service command for focused action", action)
+		}
+	}
+	if status := model.FocusedService().Status(); status != config.StatusStopped {
+		t.Fatalf("service changed before action run: %s", status)
+	}
+	_, command := model.triggerAction("toggle")
+	if command == nil {
+		t.Fatal("clicked action footer did not schedule the action")
+	}
+	_, _ = model.Update(command())
+	state, _ := model.manager.ActionState(*model.focusedAction)
+	if state.Status != service.ActionSucceeded {
+		t.Fatalf("clicked action status = %#v", state)
+	}
+	if status := model.FocusedService().Status(); status != config.StatusStopped {
+		t.Fatalf("action footer changed service status to %s", status)
+	}
+}
+
+func TestActionGroupFooterCannotOperatePreviouslyFocusedService(t *testing.T) {
+	model := NewModel(&config.Config{Project: "Actions", Services: map[string]config.Service{
+		"docs": {Command: "sleep 60"},
+	}, ActionGroups: map[string]config.ActionGroup{
+		"analytics": {Actions: map[string]config.Action{"stats": {Command: "true"}}},
+	}}, "test")
+	defer model.Shutdown()
+	model.width, model.height, model.ready = 120, 30, true
+
+	rows := model.serviceListRows()
+	groupIndex := -1
+	for index, row := range rows {
+		if row.Kind == actionRowGroup && row.Group == "analytics" {
+			groupIndex = index
+			break
+		}
+	}
+	if groupIndex < 0 {
+		t.Fatalf("analytics group not found in rows: %#v", rows)
+	}
+	model.focusServiceListRow(groupIndex)
+
+	buttons := model.actionButtons()
+	if len(buttons) != 2 || buttons[0].action != "all" || buttons[1].action != "quit" {
+		t.Fatalf("focused group controls = %#v", buttons)
+	}
+	selectedBefore := len(model.selected)
+	for _, action := range []string{"toggle", "force", "select", "restart"} {
+		_, command := model.triggerAction(action)
+		if command != nil {
+			t.Fatalf("%s scheduled a service command for focused group", action)
+		}
+	}
+	if status := model.FocusedService().Status(); status != config.StatusStopped {
+		t.Fatalf("focused group changed service status to %s", status)
+	}
+	if len(model.selected) != selectedBefore {
+		t.Fatalf("focused group changed service selection: %d -> %d", selectedBefore, len(model.selected))
+	}
+}
+
 func TestServiceActionsExpandNavigateRunAndRenderOutput(t *testing.T) {
 	model := NewModel(&config.Config{Project: "Actions", Services: map[string]config.Service{
 		"app": {Command: "sleep 10", Actions: map[string]config.Action{
@@ -197,6 +299,99 @@ func TestServiceActionsExpandNavigateRunAndRenderOutput(t *testing.T) {
 		if !strings.Contains(output, expected) {
 			t.Fatalf("action output missing %q:\n%s", expected, output)
 		}
+	}
+}
+
+func TestDoubleClickOpensServiceAndGroup(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *config.Config
+		label  string
+		owner  string
+	}{
+		{
+			name: "service",
+			config: &config.Config{Project: "Service actions", Services: map[string]config.Service{
+				"app": {Actions: map[string]config.Action{"inspect": {Command: "true"}}},
+			}},
+			label: "app ▸",
+			owner: actionOwnerKey(config.ActionOwnerService, "app"),
+		},
+		{
+			name: "group",
+			config: &config.Config{Project: "Group actions", ActionGroups: map[string]config.ActionGroup{
+				"tools": {Actions: map[string]config.Action{"inspect": {Command: "true"}}},
+			}},
+			label: "▸  tools",
+			owner: actionOwnerKey(config.ActionOwnerGroup, "tools"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			model := NewModel(test.config, "test")
+			defer model.Shutdown()
+			model.width, model.height, model.ready = 100, 30, true
+
+			clickRenderedText(t, model, test.label)
+			if model.expandedActionOwner[test.owner] {
+				t.Fatal("single click opened the row")
+			}
+			clickRenderedText(t, model, test.label)
+			if !model.expandedActionOwner[test.owner] {
+				t.Fatal("double click did not open the row")
+			}
+		})
+	}
+}
+
+func TestDoubleClickRequiresConsecutiveRowClicks(t *testing.T) {
+	model := NewModel(&config.Config{Project: "Service actions", Services: map[string]config.Service{
+		"app": {Actions: map[string]config.Action{"inspect": {Command: "true"}}},
+	}}, "test")
+	defer model.Shutdown()
+	model.width, model.height, model.ready = 100, 30, true
+	owner := actionOwnerKey(config.ActionOwnerService, "app")
+
+	clickRenderedText(t, model, "app ▸")
+	clickRenderedText(t, model, "[2]")
+	clickRenderedText(t, model, "app ▸")
+	if model.expandedActionOwner[owner] {
+		t.Fatal("row opened despite an intervening mouse press")
+	}
+}
+
+func TestDoubleClickExpiresAndDoesNotOverrideCheckboxClicks(t *testing.T) {
+	model := NewModel(&config.Config{Project: "Service actions", Services: map[string]config.Service{
+		"app": {Actions: map[string]config.Action{"inspect": {Command: "true"}}},
+	}}, "test")
+	defer model.Shutdown()
+	model.width, model.height, model.ready = 100, 30, true
+	owner := actionOwnerKey(config.ActionOwnerService, "app")
+
+	started := time.Now()
+	model.mousePressSequence = 1
+	model.openListOwnerOnDoubleClick(owner, started)
+	model.mousePressSequence = 2
+	model.openListOwnerOnDoubleClick(owner, started.Add(doubleClickInterval+time.Millisecond))
+	if model.expandedActionOwner[owner] {
+		t.Fatal("expired clicks opened the row")
+	}
+
+	rowY := -1
+	for y, line := range strings.Split(ansi.Strip(model.View()), "\n") {
+		if strings.Contains(line, "app ▸") {
+			rowY = y
+			break
+		}
+	}
+	if rowY < 0 {
+		t.Fatalf("service row not found:\n%s", ansi.Strip(model.View()))
+	}
+	checkboxClick := tea.MouseMsg{X: checkboxMinColumn, Y: rowY, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft}
+	_, _ = model.handleMouseMsg(checkboxClick)
+	_, _ = model.handleMouseMsg(checkboxClick)
+	if model.selected["app"] || model.expandedActionOwner[owner] {
+		t.Fatalf("double checkbox click left selected=%v expanded=%v", model.selected["app"], model.expandedActionOwner[owner])
 	}
 }
 

--- a/internal/ui/model_keys.go
+++ b/internal/ui/model_keys.go
@@ -240,15 +240,33 @@ func (m *Model) handleLogKey(msg tea.KeyMsg) bool {
 }
 
 func (m *Model) triggerAction(action string) (tea.Model, tea.Cmd) {
+	actionOwnerFocused := m.listMode == listServices && (m.focusedAction != nil || m.focusedActionGroup != "")
 	switch action {
 	case "toggle":
+		if m.focusedAction != nil {
+			if command, handled := m.toggleFocusedAction(); handled {
+				return m, command
+			}
+		}
+		if actionOwnerFocused {
+			return m, nil
+		}
 		return m.toggleSelectedServices()
 	case "force":
+		if actionOwnerFocused {
+			return m, nil
+		}
 		return m.forceToggleSelectedServices()
 	case "select":
+		if actionOwnerFocused {
+			return m, nil
+		}
 		m.toggleFocusedSelection()
 		return m, nil
 	case "restart":
+		if actionOwnerFocused {
+			return m, nil
+		}
 		return m.restartSelectedService()
 	case "all":
 		m.toggleAllSelection()

--- a/internal/ui/model_lifecycle_test.go
+++ b/internal/ui/model_lifecycle_test.go
@@ -504,6 +504,69 @@ func TestMouseCanForceStartFocusedService(t *testing.T) {
 	}
 }
 
+func TestMouseClickChangesServiceStartedByFooterAction(t *testing.T) {
+	model := NewModel(&config.Config{Project: "Test", Services: map[string]config.Service{
+		"api":    {Command: "sleep 60", Dir: ".", Shell: "sh"},
+		"worker": {Command: "sleep 60", Dir: ".", Shell: "sh"},
+	}}, "test")
+	defer model.Shutdown()
+	model.width, model.height, model.ready = 80, 24, true
+	model.selected["api"] = true
+
+	clickRenderedText(t, model, "worker")
+	command := clickRenderedText(t, model, "Start: s")
+	if command == nil {
+		t.Fatal("start button did not schedule the operation")
+	}
+	_, _ = model.Update(command().(operationResultMsg))
+
+	api, _ := model.manager.GetService("api")
+	worker, _ := model.manager.GetService("worker")
+	if api.Status() != config.StatusStopped || worker.Status() != config.StatusRunning {
+		t.Fatalf("after clicking worker, statuses api=%s worker=%s", api.Status(), worker.Status())
+	}
+}
+
+func TestMouseCheckboxKeepsExplicitMultiSelection(t *testing.T) {
+	model := NewModel(&config.Config{Project: "Test", Services: map[string]config.Service{
+		"api":    {Command: "true"},
+		"worker": {Command: "true"},
+	}}, "test")
+	defer model.Shutdown()
+	model.width, model.height, model.ready = 80, 24, true
+	model.selected["api"] = true
+
+	clickRenderedText(t, model, "[ ]")
+	if !model.selected["api"] || !model.selected["worker"] || len(model.selected) != 2 {
+		t.Fatalf("checkbox selection = %#v, want api and worker", model.selected)
+	}
+}
+
+func TestMouseClickInTagGroupChangesServiceStartedByFooterAction(t *testing.T) {
+	model := NewModel(&config.Config{Project: "Test", Services: map[string]config.Service{
+		"api":    {Command: "sleep 60", Dir: ".", Shell: "sh", Tags: []string{"backend"}},
+		"worker": {Command: "sleep 60", Dir: ".", Shell: "sh", Tags: []string{"backend"}},
+	}}, "test")
+	defer model.Shutdown()
+	model.width, model.height, model.ready = 80, 24, true
+	model.listMode = listTags
+	model.expandedTags["backend"] = true
+	model.selected["api"] = true
+
+	clickRenderedText(t, model, "worker")
+	command := clickRenderedText(t, model, "Start: s")
+	if command == nil {
+		t.Fatal("start button did not schedule the operation")
+	}
+	_, _ = model.Update(command().(operationResultMsg))
+
+	api, _ := model.manager.GetService("api")
+	worker, _ := model.manager.GetService("worker")
+	if api.Status() != config.StatusStopped || worker.Status() != config.StatusRunning {
+		t.Fatalf("after clicking grouped worker, statuses api=%s worker=%s", api.Status(), worker.Status())
+	}
+}
+
 func TestDetailsShowLifecycleConfiguration(t *testing.T) {
 	model := NewModel(&config.Config{Project: "Test", Services: map[string]config.Service{
 		"db": {Command: "sleep 60", ReadyLogLine: "READY"},

--- a/internal/ui/mouse.go
+++ b/internal/ui/mouse.go
@@ -2,10 +2,12 @@ package ui
 
 import (
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/kranz-org/kranz/internal/config"
 )
 
 const (
@@ -14,6 +16,7 @@ const (
 	listFirstItemRow    = 2
 	checkboxMinColumn   = 3
 	checkboxMaxColumn   = 5
+	doubleClickInterval = 500 * time.Millisecond
 )
 
 type mouseKeyBinding struct {
@@ -67,6 +70,9 @@ func renderedTextRegionHit(rendered string, x, y int, label string, leftCells, r
 // keyboard input. Keeping both paths aligned prevents click-only behavior from
 // drifting away from documented shortcuts.
 func (m *Model) handleMouseMsg(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	if msg.Action == tea.MouseActionPress && msg.Button == tea.MouseButtonLeft {
+		m.mousePressSequence++
+	}
 	if m.mode != ModeNormal {
 		return m.handleOverlayMouse(msg)
 	}
@@ -218,10 +224,44 @@ func (m *Model) handleServiceRowClick(row, listHeight, column int) {
 		return
 	}
 	rows := m.serviceListRows()
-	m.focusServiceListRow(index)
-	if index < len(rows) && rows[index].Kind == actionRowService && column >= checkboxMinColumn && column <= checkboxMaxColumn {
-		m.toggleFocusedSelection()
+	if index >= len(rows) {
+		return
 	}
+	m.focusServiceListRow(index)
+	owner := ""
+	switch rows[index].Kind {
+	case actionRowService:
+		if column >= checkboxMinColumn && column <= checkboxMaxColumn {
+			m.toggleFocusedSelection()
+			return
+		}
+		m.selectedTags = nil
+		m.selected = make(map[string]bool)
+		owner = actionOwnerKey(config.ActionOwnerService, rows[index].Service.Name)
+	case actionRowGroup:
+		owner = actionOwnerKey(config.ActionOwnerGroup, rows[index].Group)
+	default:
+		return
+	}
+	m.openListOwnerOnDoubleClick(owner, time.Now())
+}
+
+func (m *Model) openListOwnerOnDoubleClick(owner string, now time.Time) {
+	elapsed := now.Sub(m.lastListClickAt)
+	isDoubleClick := owner == m.lastListClickOwner &&
+		m.lastListClickSeq+1 == m.mousePressSequence &&
+		!m.lastListClickAt.IsZero() &&
+		elapsed >= 0 && elapsed <= doubleClickInterval
+	if isDoubleClick {
+		m.lastListClickOwner = ""
+		m.lastListClickSeq = 0
+		m.lastListClickAt = time.Time{}
+		_, _ = m.openFocusedListItem()
+		return
+	}
+	m.lastListClickOwner = owner
+	m.lastListClickSeq = m.mousePressSequence
+	m.lastListClickAt = now
 }
 
 func (m *Model) handleTagRowClick(row, listHeight, column int) {
@@ -242,7 +282,10 @@ func (m *Model) handleTagRowClick(row, listHeight, column int) {
 	}
 	if column >= checkboxStart && column <= checkboxEnd {
 		m.toggleCurrentSelection()
+		return
 	}
+	m.selectedTags = nil
+	m.selected = make(map[string]bool)
 }
 
 func (m *Model) handleOverlayMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -206,6 +206,7 @@ type actionButton struct {
 
 func (m *Model) actionButtons() []actionButton {
 	actionFocused := m.listMode == listServices && m.focusedAction != nil
+	actionGroupFocused := m.listMode == listServices && m.focusedActionGroup != ""
 	targets := m.selectedTargetNames()
 	allActive := len(targets) > 0
 	allRunning := len(targets) > 0
@@ -259,6 +260,19 @@ func (m *Model) actionButtons() []actionButton {
 		if len(m.allServices) > 0 && len(m.selected) == len(m.allServices) {
 			allLabel = "Clear: a"
 		}
+		if actionFocused {
+			return []actionButton{
+				{action: "toggle", rendered: compact(toggleStyle, compactToggle)},
+				{action: "all", rendered: compact(SecondaryButtonStyle, allLabel)},
+				{action: "quit", rendered: compact(DangerButtonStyle, "Quit: q")},
+			}
+		}
+		if actionGroupFocused {
+			return []actionButton{
+				{action: "all", rendered: compact(SecondaryButtonStyle, allLabel)},
+				{action: "quit", rendered: compact(DangerButtonStyle, "Quit: q")},
+			}
+		}
 		return []actionButton{
 			{action: "toggle", rendered: compact(toggleStyle, compactToggle)},
 			{action: "force", rendered: compact(WarningButtonStyle, "Force: S")},
@@ -271,6 +285,19 @@ func (m *Model) actionButtons() []actionButton {
 	allLabel := "Select all: a"
 	if len(m.allServices) > 0 && len(m.selected) == len(m.allServices) {
 		allLabel = "Clear all: a"
+	}
+	if actionFocused {
+		return []actionButton{
+			{action: "toggle", rendered: toggleStyle.Render(toggleLabel)},
+			{action: "all", rendered: SecondaryButtonStyle.Render(allLabel)},
+			{action: "quit", rendered: DangerButtonStyle.Render("Quit: q")},
+		}
+	}
+	if actionGroupFocused {
+		return []actionButton{
+			{action: "all", rendered: SecondaryButtonStyle.Render(allLabel)},
+			{action: "quit", rendered: DangerButtonStyle.Render("Quit: q")},
+		}
 	}
 	return []actionButton{
 		{action: "toggle", rendered: toggleStyle.Render(toggleLabel)},


### PR DESCRIPTION
## Summary

- open service and action-group rows with a mouse double-click
- make a normal service click the lifecycle target while preserving explicit checkbox multi-selection
- route action footer clicks to the focused action and hide/block service-only controls for actions and action groups

## Validation

- [x] make verify
- [x] make lint
- [x] manual TUI mouse check: group expansion, action focus, footer run, services unchanged

## Compatibility

Patch-only TUI behavior fix for v0.7.1. No configuration or API changes. Documentation recordings are unchanged.