### PR TITLE
fix(config): preserve declaration order of services and actions

### DIFF
--- a/internal/config/appearance.go
+++ b/internal/config/appearance.go
@@ -83,6 +83,9 @@ func yamlMappingRoot(document *yaml.Node) (*yaml.Node, error) {
 }
 
 func mappingValue(mapping *yaml.Node, key string) *yaml.Node {
+	if mapping == nil || mapping.Kind != yaml.MappingNode {
+		return nil
+	}
 	for index := 0; index+1 < len(mapping.Content); index += 2 {
 		if mapping.Content[index].Value == key {
 			return mapping.Content[index+1]

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -154,11 +154,13 @@ func mergeConfig(base, override *Config) error {
 	if base.ActionGroups == nil {
 		base.ActionGroups = make(map[string]ActionGroup)
 	}
-	for name, incoming := range override.ActionGroups {
+	for _, name := range override.ActionGroupNames() {
+		incoming := override.ActionGroups[name]
 		if current, exists := base.ActionGroups[name]; exists {
 			base.ActionGroups[name] = mergeActionGroup(current, incoming)
 		} else {
 			base.ActionGroups[name] = incoming
+			base.ActionGroupOrder = append(base.ActionGroupOrder, name)
 		}
 	}
 	if baseSource == SourceKranz || overrideSource == SourceKranz {
@@ -288,7 +290,7 @@ func mergeService(base, override Service, mergeDependencies bool) Service {
 	if override.DisableDotenv {
 		base.DisableDotenv = true
 	}
-	base.Actions = mergeActions(base.Actions, override.Actions)
+	base.Actions, base.ActionOrder = mergeActions(base.Actions, base.ActionOrder, override.Actions, override.ActionNames())
 	return base
 }
 
@@ -389,22 +391,24 @@ func mergeActionGroup(base, override ActionGroup) ActionGroup {
 	if len(override.EnvFiles) > 0 {
 		base.EnvFiles = append([]string(nil), override.EnvFiles...)
 	}
-	base.Actions = mergeActions(base.Actions, override.Actions)
+	base.Actions, base.ActionOrder = mergeActions(base.Actions, base.ActionOrder, override.Actions, override.ActionNames())
 	return base
 }
 
-func mergeActions(base, override map[string]Action) map[string]Action {
+func mergeActions(base map[string]Action, baseOrder []string, override map[string]Action, overrideOrder []string) (map[string]Action, []string) {
 	if base == nil && len(override) > 0 {
 		base = make(map[string]Action, len(override))
 	}
-	for name, incoming := range override {
+	for _, name := range overrideOrder {
+		incoming := override[name]
 		if current, exists := base[name]; exists {
 			base[name] = mergeAction(current, incoming)
 		} else {
 			base[name] = incoming
+			baseOrder = append(baseOrder, name)
 		}
 	}
-	return base
+	return base, baseOrder
 }
 
 func mergeAction(base, override Action) Action {
@@ -457,7 +461,53 @@ func loadNative(data []byte) (*Config, error) {
 		return nil, fmt.Errorf("parse Kranz YAML: %w", err)
 	}
 	cfg.Source = SourceKranz
+	recordDeclarationOrder(&cfg, data)
 	return &cfg, nil
+}
+
+// recordDeclarationOrder captures the document ordering of services, action
+// groups, and the actions each of them owns.
+func recordDeclarationOrder(cfg *Config, data []byte) {
+	cfg.ServiceOrder = mappingKeyOrder(data, "services")
+	for name, service := range cfg.Services {
+		service.ActionOrder = mappingKeyOrder(data, "services", name, "actions")
+		cfg.Services[name] = service
+	}
+	cfg.ActionGroupOrder = mappingKeyOrder(data, "action_groups")
+	for name, group := range cfg.ActionGroups {
+		group.ActionOrder = mappingKeyOrder(data, "action_groups", name, "actions")
+		cfg.ActionGroups[name] = group
+	}
+}
+
+// mappingKeyOrder returns the keys of the mapping reached by following path
+// from the document root, in declaration order. Every source format decodes
+// services and actions into maps, so the document itself is the only place the
+// author's ordering survives.
+func mappingKeyOrder(data []byte, path ...string) []string {
+	var document yaml.Node
+	if err := yaml.Unmarshal(data, &document); err != nil {
+		return nil
+	}
+	if len(document.Content) == 0 {
+		return nil
+	}
+	node := document.Content[0]
+	for _, section := range path {
+		child := mappingValue(node, section)
+		if child == nil {
+			return nil
+		}
+		node = child
+	}
+	if node.Kind != yaml.MappingNode {
+		return nil
+	}
+	keys := make([]string, 0, len(node.Content)/2)
+	for index := 0; index+1 < len(node.Content); index += 2 {
+		keys = append(keys, node.Content[index].Value)
+	}
+	return keys
 }
 
 func normalizeServiceStartSyntax(cfg *Config) error {
@@ -818,17 +868,37 @@ func applyCheckDefaults(c *CheckConfig) {
 	}
 }
 
-// ServiceNames returns service names in stable configuration order.
+// ServiceNames returns service names in declaration order.
 func (cfg *Config) ServiceNames() []string {
-	if len(cfg.ServiceOrder) == len(cfg.Services) {
-		return append([]string(nil), cfg.ServiceOrder...)
-	}
-	names := make([]string, 0, len(cfg.Services))
-	for name := range cfg.Services {
+	return orderedNames(cfg.ServiceOrder, cfg.Services)
+}
+
+// orderedNames lists the keys of values in declaration order. The order is a
+// hint recorded while parsing, never the source of truth: entries missing from
+// values are skipped, and keys the order does not mention, which happens when a
+// source format cannot express ordering, follow alphabetically so the result
+// stays deterministic either way.
+func orderedNames[V any](order []string, values map[string]V) []string {
+	names := make([]string, 0, len(values))
+	listed := make(map[string]struct{}, len(values))
+	for _, name := range order {
+		if _, exists := values[name]; !exists {
+			continue
+		}
+		if _, duplicate := listed[name]; duplicate {
+			continue
+		}
+		listed[name] = struct{}{}
 		names = append(names, name)
 	}
-	sort.Strings(names)
-	return names
+	remainder := make([]string, 0, len(values)-len(names))
+	for name := range values {
+		if _, ordered := listed[name]; !ordered {
+			remainder = append(remainder, name)
+		}
+	}
+	sort.Strings(remainder)
+	return append(names, remainder...)
 }
 
 // GetAllTags returns every unique service tag.

--- a/internal/config/order_test.go
+++ b/internal/config/order_test.go
@@ -1,0 +1,246 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeConfigFile(t *testing.T, directory, name, contents string) string {
+	t.Helper()
+	path := filepath.Join(directory, name)
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return path
+}
+
+func TestLoadPreservesNativeServiceDeclarationOrder(t *testing.T) {
+	directory := t.TempDir()
+	path := writeConfigFile(t, directory, "kranz.yaml", `project: Ordered
+services:
+  web:
+    command: echo web
+  api:
+    command: echo api
+  cache:
+    command: echo cache
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if names := strings.Join(cfg.ServiceNames(), ","); names != "web,api,cache" {
+		t.Errorf("service order = %s, want web,api,cache", names)
+	}
+}
+
+func TestLoadPreservesProcessComposeDeclarationOrder(t *testing.T) {
+	directory := t.TempDir()
+	path := writeConfigFile(t, directory, "process-compose.yaml", `version: "0.5"
+processes:
+  web:
+    command: echo web
+  api:
+    command: echo api
+  cache:
+    command: echo cache
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if names := strings.Join(cfg.ServiceNames(), ","); names != "web,api,cache" {
+		t.Errorf("service order = %s, want web,api,cache", names)
+	}
+}
+
+func TestLoadFilesKeepsBaseOrderAndAppendsNewServicesInOverrideOrder(t *testing.T) {
+	directory := t.TempDir()
+	basePath := writeConfigFile(t, directory, "kranz.yaml", `project: Ordered
+services:
+  web:
+    command: echo web
+  db:
+    command: echo db
+`)
+	overridePath := writeConfigFile(t, directory, "kranz.local.yaml", `services:
+  cache:
+    command: echo cache
+  db:
+    command: echo db-override
+  worker:
+    command: echo worker
+`)
+
+	cfg, err := LoadFiles([]string{basePath, overridePath})
+	if err != nil {
+		t.Fatalf("LoadFiles failed: %v", err)
+	}
+
+	if names := strings.Join(cfg.ServiceNames(), ","); names != "web,db,cache,worker" {
+		t.Errorf("merged order = %s, want web,db,cache,worker", names)
+	}
+}
+
+func TestServiceNamesReconcilesStaleOrder(t *testing.T) {
+	cfg := &Config{
+		Services: map[string]Service{
+			"web":   {Command: "echo web"},
+			"api":   {Command: "echo api"},
+			"cache": {Command: "echo cache"},
+		},
+		ServiceOrder: []string{"web", "removed", "web", "api"},
+	}
+
+	if names := strings.Join(cfg.ServiceNames(), ","); names != "web,api,cache" {
+		t.Errorf("reconciled order = %s, want web,api,cache", names)
+	}
+}
+
+func actionIDStrings(cfg *Config) []string {
+	ids := cfg.ActionIDs()
+	labels := make([]string, 0, len(ids))
+	for _, id := range ids {
+		labels = append(labels, string(id.OwnerKind)+":"+id.Owner+"/"+id.Name)
+	}
+	return labels
+}
+
+func TestLoadPreservesActionAndActionGroupDeclarationOrder(t *testing.T) {
+	directory := t.TempDir()
+	path := writeConfigFile(t, directory, "kranz.yaml", `project: Ordered
+services:
+  app:
+    command: echo app
+    actions:
+      seed:
+        command: echo seed
+      migrate:
+        command: echo migrate
+action_groups:
+  development:
+    actions:
+      build:
+        command: echo build
+      audit:
+        command: echo audit
+  analytics:
+    actions:
+      stats:
+        command: echo stats
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	want := "service:app/seed,service:app/migrate,group:development/build,group:development/audit,group:analytics/stats"
+	if got := strings.Join(actionIDStrings(cfg), ","); got != want {
+		t.Errorf("action order = %s, want %s", got, want)
+	}
+}
+
+func TestLoadFilesKeepsBaseActionOrderAndAppendsNewOnes(t *testing.T) {
+	directory := t.TempDir()
+	basePath := writeConfigFile(t, directory, "kranz.yaml", `project: Ordered
+services:
+  app:
+    command: echo app
+action_groups:
+  development:
+    actions:
+      build:
+        command: echo build
+      audit:
+        command: echo audit
+`)
+	overridePath := writeConfigFile(t, directory, "kranz.local.yaml", `action_groups:
+  analytics:
+    actions:
+      stats:
+        command: echo stats
+  development:
+    actions:
+      zip:
+        command: echo zip
+      build:
+        command: echo build-override
+`)
+
+	cfg, err := LoadFiles([]string{basePath, overridePath})
+	if err != nil {
+		t.Fatalf("LoadFiles failed: %v", err)
+	}
+
+	want := "group:development/build,group:development/audit,group:development/zip,group:analytics/stats"
+	if got := strings.Join(actionIDStrings(cfg), ","); got != want {
+		t.Errorf("merged action order = %s, want %s", got, want)
+	}
+}
+
+func TestActionGroupNamesReconcilesStaleOrder(t *testing.T) {
+	cfg := &Config{
+		ActionGroups: map[string]ActionGroup{
+			"development": {},
+			"analytics":   {},
+			"release":     {},
+		},
+		ActionGroupOrder: []string{"development", "removed", "development", "analytics"},
+	}
+
+	if names := strings.Join(cfg.ActionGroupNames(), ","); names != "development,analytics,release" {
+		t.Errorf("reconciled group order = %s, want development,analytics,release", names)
+	}
+}
+
+func TestLoadPreservesProcfileDeclarationOrder(t *testing.T) {
+	directory := t.TempDir()
+	path := writeConfigFile(t, directory, "Procfile", "web: echo web\napi: echo api\ncache: echo cache\n")
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if names := strings.Join(cfg.ServiceNames(), ","); names != "web,api,cache" {
+		t.Errorf("service order = %s, want web,api,cache", names)
+	}
+}
+
+func TestLoadFilesKeepsBaseServiceActionOrderAndAppendsNewOnes(t *testing.T) {
+	directory := t.TempDir()
+	basePath := writeConfigFile(t, directory, "kranz.yaml", `project: Ordered
+services:
+  app:
+    command: echo app
+    actions:
+      migrate:
+        command: echo migrate
+      seed:
+        command: echo seed
+`)
+	overridePath := writeConfigFile(t, directory, "kranz.local.yaml", `services:
+  app:
+    actions:
+      reset:
+        command: echo reset
+      migrate:
+        command: echo migrate-override
+`)
+
+	cfg, err := LoadFiles([]string{basePath, overridePath})
+	if err != nil {
+		t.Fatalf("LoadFiles failed: %v", err)
+	}
+
+	if names := strings.Join(cfg.Services["app"].ActionNames(), ","); names != "migrate,seed,reset" {
+		t.Errorf("merged service action order = %s, want migrate,seed,reset", names)
+	}
+}

--- a/internal/config/process_compose.go
+++ b/internal/config/process_compose.go
@@ -175,6 +175,7 @@ func loadProcessCompose(data []byte, path string) (*Config, error) {
 			DisableDotenv: process.IsDotenvDisabled, disabledSet: disabledSet,
 		}
 	}
+	cfg.ServiceOrder = mappingKeyOrder(data, "processes")
 	return cfg, nil
 }
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -4,25 +4,25 @@ package config
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
 // Config is the normalized root structure for every supported source format.
 type Config struct {
-	Project      string                 `yaml:"project"`
-	Version      string                 `yaml:"version,omitempty"`
-	UI           UIConfig               `yaml:"ui,omitempty"`
-	Defaults     Defaults               `yaml:"defaults,omitempty"`
-	Services     map[string]Service     `yaml:"services,omitempty"`
-	ActionGroups map[string]ActionGroup `yaml:"action_groups,omitempty"`
-	ServiceOrder []string               `yaml:"-"`
-	Source       SourceFormat           `yaml:"-"`
-	Diagnostics  []string               `yaml:"-"`
-	Paths        []string               `yaml:"-"`
-	WatchPaths   []string               `yaml:"-"`
-	dotenvEnv    map[string]string      `yaml:"-"`
-	explicitEnv  map[string]string      `yaml:"-"`
+	Project          string                 `yaml:"project"`
+	Version          string                 `yaml:"version,omitempty"`
+	UI               UIConfig               `yaml:"ui,omitempty"`
+	Defaults         Defaults               `yaml:"defaults,omitempty"`
+	Services         map[string]Service     `yaml:"services,omitempty"`
+	ActionGroups     map[string]ActionGroup `yaml:"action_groups,omitempty"`
+	ServiceOrder     []string               `yaml:"-"`
+	ActionGroupOrder []string               `yaml:"-"`
+	Source           SourceFormat           `yaml:"-"`
+	Diagnostics      []string               `yaml:"-"`
+	Paths            []string               `yaml:"-"`
+	WatchPaths       []string               `yaml:"-"`
+	dotenvEnv        map[string]string      `yaml:"-"`
+	explicitEnv      map[string]string      `yaml:"-"`
 }
 
 // UIConfig defines project-specific presentation defaults.
@@ -83,6 +83,7 @@ type Service struct {
 	Disabled             bool                        `yaml:"disabled,omitempty"`
 	DisableDotenv        bool                        `yaml:"is_dotenv_disabled,omitempty"`
 	Actions              map[string]Action           `yaml:"actions,omitempty"`
+	ActionOrder          []string                    `yaml:"-"`
 	BeforeStart          []Prerequisite              `yaml:"before_start,omitempty"`
 	disabledSet          bool                        `yaml:"-"`
 }
@@ -244,6 +245,7 @@ type ActionGroup struct {
 	Env         map[string]string `yaml:"env,omitempty"`
 	EnvFiles    []string          `yaml:"env_files,omitempty"`
 	Actions     map[string]Action `yaml:"actions"`
+	ActionOrder []string          `yaml:"-"`
 }
 
 // ActionOwnerKind distinguishes service-scoped and project-level actions.
@@ -295,30 +297,31 @@ func (c *Config) ActionIDs() []ActionID {
 	}
 	ids := make([]ActionID, 0)
 	for _, owner := range c.ServiceNames() {
-		for _, name := range sortedActionNames(c.Services[owner].Actions) {
+		for _, name := range c.Services[owner].ActionNames() {
 			ids = append(ids, ActionID{OwnerKind: ActionOwnerService, Owner: owner, Name: name})
 		}
 	}
-	groups := make([]string, 0, len(c.ActionGroups))
-	for owner := range c.ActionGroups {
-		groups = append(groups, owner)
-	}
-	sort.Strings(groups)
-	for _, owner := range groups {
-		for _, name := range sortedActionNames(c.ActionGroups[owner].Actions) {
+	for _, owner := range c.ActionGroupNames() {
+		for _, name := range c.ActionGroups[owner].ActionNames() {
 			ids = append(ids, ActionID{OwnerKind: ActionOwnerGroup, Owner: owner, Name: name})
 		}
 	}
 	return ids
 }
 
-func sortedActionNames(actions map[string]Action) []string {
-	names := make([]string, 0, len(actions))
-	for name := range actions {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	return names
+// ActionGroupNames returns action group names in declaration order.
+func (c *Config) ActionGroupNames() []string {
+	return orderedNames(c.ActionGroupOrder, c.ActionGroups)
+}
+
+// ActionNames returns the service action names in declaration order.
+func (s Service) ActionNames() []string {
+	return orderedNames(s.ActionOrder, s.Actions)
+}
+
+// ActionNames returns the group action names in declaration order.
+func (g ActionGroup) ActionNames() []string {
+	return orderedNames(g.ActionOrder, g.Actions)
 }
 
 // PortDiscoveryEnabled resolves the service-level tri-state. Services without

--- a/internal/ui/model_actions.go
+++ b/internal/ui/model_actions.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sort"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -26,12 +25,7 @@ func (m *Model) serviceListRows() []actionListRow {
 			}
 		}
 	}
-	groups := make([]string, 0, len(m.cfg.ActionGroups))
-	for name := range m.cfg.ActionGroups {
-		groups = append(groups, name)
-	}
-	sort.Strings(groups)
-	for _, group := range groups {
+	for _, group := range m.cfg.ActionGroupNames() {
 		rows = append(rows, actionListRow{Kind: actionRowGroup, Group: group})
 		if m.expandedActionOwner[actionOwnerKey(config.ActionOwnerGroup, group)] {
 			for _, id := range m.actionIDsFor(config.ActionOwnerGroup, group) {

--- a/internal/ui/model_actions_test.go
+++ b/internal/ui/model_actions_test.go
@@ -633,3 +633,27 @@ func TestStartConfirmFlagDoesNotBypassStopConfirmation(t *testing.T) {
 		t.Fatalf("stopped confirmed action state = %#v", state)
 	}
 }
+
+func TestServiceListRowsFollowActionGroupDeclarationOrder(t *testing.T) {
+	model := NewModel(&config.Config{
+		Project: "Actions",
+		ActionGroups: map[string]config.ActionGroup{
+			"development": {Actions: map[string]config.Action{"build": {Command: "true"}}},
+			"analytics":   {Actions: map[string]config.Action{"stats": {Command: "true"}}},
+			"release":     {Actions: map[string]config.Action{"tag": {Command: "true"}}},
+		},
+		ActionGroupOrder: []string{"development", "analytics", "release"},
+	}, "test")
+	defer model.Shutdown()
+	model.width, model.height, model.ready = 120, 30, true
+
+	groups := make([]string, 0, 3)
+	for _, row := range model.serviceListRows() {
+		if row.Kind == actionRowGroup {
+			groups = append(groups, row.Group)
+		}
+	}
+	if strings.Join(groups, ",") != "development,analytics,release" {
+		t.Errorf("group row order = %v, want [development analytics release]", groups)
+	}
+}


### PR DESCRIPTION
Services, action groups, and their actions decode into maps, so the document ordering was lost and every listing fell back to an alphabetical sort. The ordering is now recorded while parsing and reconciled against the maps when listing names; entries the order does not mention stay alphabetical so results remain deterministic for formats that cannot express ordering.

Merging keeps the base layer order and appends only what an override introduces, in the order the override declares it.

Covered for native, Process Compose, and Procfile sources, for layered merges, for a stale order reconciled against the maps, and for the action group rows the service list renders.