### PR TITLE
test(service): remove the race in the prerequisite ordering test

### DIFF
--- a/internal/service/prerequisite_test.go
+++ b/internal/service/prerequisite_test.go
@@ -163,10 +163,19 @@ func TestPrerequisiteRunsAfterDependenciesAreReady(t *testing.T) {
 	manager := NewManager(&config.Config{
 		Project: "Prerequisites",
 		Services: map[string]config.Service{
-			"database": {Command: "echo database >> " + order + " && sleep 60", Dir: directory, Shell: "/bin/sh"},
+			// The dependency announces readiness on stdout only after it has
+			// appended to the order file, so "ready" and the recorded side
+			// effect cannot be observed out of order.
+			"database": {
+				Command:      "sleep 0.5 && echo database >> " + order + " && echo ready && sleep 60",
+				Dir:          directory,
+				Shell:        "/bin/sh",
+				ReadyLogLine: "ready",
+			},
 			"api": {
-				Command:   "sleep 60",
-				DependsOn: []string{"database"},
+				Command:              "sleep 60",
+				DependsOn:            []string{"database"},
+				DependencyConditions: map[string]config.DependencyConfig{"database": {Condition: config.DependencyLogReady}},
 				Actions: map[string]config.Action{
 					"migrate": {Command: "echo migrate >> " + order, Dir: directory, Shell: "/bin/sh"},
 				},
@@ -179,7 +188,7 @@ func TestPrerequisiteRunsAfterDependenciesAreReady(t *testing.T) {
 	if err := manager.StartServicesContext(context.Background(), []string{"api"}); err != nil {
 		t.Fatal(err)
 	}
-	deadline := time.Now().Add(2 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
 	var content []byte
 	for time.Now().Before(deadline) {
 		content, _ = os.ReadFile(order)


### PR DESCRIPTION
A service without a health check counts as ready as soon as its process is spawned, so the parent could run the prerequisite before the dependency's shell executed its first command. The test recorded ordering through that side effect, which made it fail intermittently on the macOS runner, including on main and on an unrelated pull request.

The dependency now announces readiness on a log line it prints only after appending to the order file, and the append is delayed, so the assertion observes the guarantee it describes. Verified: 20 consecutive runs pass, and with the dependency gate removed the test fails deterministically rather than intermittently.