### PR TITLE
refactor(runtime): route TUI lifecycle through application API

### DIFF
--- a/cmd/kranz/main.go
+++ b/cmd/kranz/main.go
@@ -13,6 +13,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/kranz-org/kranz/internal/app"
 	"github.com/kranz-org/kranz/internal/config"
 	"github.com/kranz-org/kranz/internal/settings"
 	"github.com/kranz-org/kranz/internal/ui"
@@ -72,9 +73,10 @@ func run() (runErr error) {
 	}
 
 	darkBackground := lipgloss.HasDarkBackground()
+	application := app.NewLocal(cfg, cfgPaths, app.Options{})
 	model := ui.NewModelWithOptions(cfg, version, ui.ModelOptions{
 		Settings: userSettings, SettingsPath: settingsPath, ConfigPaths: cfgPaths,
-		DarkBackground: &darkBackground,
+		DarkBackground: &darkBackground, App: application,
 	})
 	defer func() {
 		runErr = errors.Join(runErr, model.Shutdown())

--- a/internal/app/api.go
+++ b/internal/app/api.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"os/exec"
+	"time"
 
 	"github.com/kranz-org/kranz/internal/config"
 	"github.com/kranz-org/kranz/internal/port"
@@ -23,6 +24,11 @@ type API interface {
 	// changed since the last successful load (or unconditionally, if
 	// force is true), and reconciles it into the running services.
 	Reload(force bool) (ReloadResult, error)
+	// AcknowledgeExternalWrite re-stamps the watched configuration paths
+	// without reloading. Call it right after writing to one of them (for
+	// example, saving a theme to the project file) so the next Reload does
+	// not treat that write as an external change worth reconciling.
+	AcknowledgeExternalWrite()
 
 	// Services returns every configured service in stable declaration
 	// order.
@@ -114,4 +120,15 @@ type API interface {
 	// need a deterministic port checker; production callers should not
 	// need it.
 	SetPortChecker(checker port.Checker)
+
+	// The three methods below exist for tests that need a service in a
+	// specific runtime state, or with specific log content, without
+	// spawning and observing a real process. Production delivery surfaces
+	// should never call them: state changes production code, from a
+	// TUI or a CLI, always earns by going through the lifecycle methods.
+	SetServiceStatusForTest(name string, status config.ServiceStatus)
+	SetServiceStateForTest(name string, state config.ServiceState)
+	SetServiceDesiredRunningForTest(name string, desiredRunning bool)
+	AppendLogForTest(name, line string)
+	AppendLogAtForTest(name string, timestamp time.Time, line string)
 }

--- a/internal/app/api.go
+++ b/internal/app/api.go
@@ -1,0 +1,117 @@
+package app
+
+import (
+	"context"
+	"os/exec"
+
+	"github.com/kranz-org/kranz/internal/config"
+	"github.com/kranz-org/kranz/internal/port"
+)
+
+// API is the shared contract between Kranz's delivery surfaces (today the
+// TUI; a future CLI and MCP adapter reuse it) and the runtime that owns
+// process-supervised services. Local implements it directly over
+// service.Manager; a later stream adds an IPC client implementation with an
+// identical surface.
+type API interface {
+	// Project describes the currently loaded configuration.
+	Project() ProjectSnapshot
+	// Config returns the effective configuration. Callers must treat it as
+	// read-only: it is the same value the runtime is using.
+	Config() *config.Config
+	// Reload re-reads the configuration from disk if any watched path
+	// changed since the last successful load (or unconditionally, if
+	// force is true), and reconciles it into the running services.
+	Reload(force bool) (ReloadResult, error)
+
+	// Services returns every configured service in stable declaration
+	// order.
+	Services() []*ServiceSnapshot
+	// Service returns one service by name.
+	Service(name string) (*ServiceSnapshot, bool)
+	// Tags returns every unique configured service tag.
+	Tags() []string
+	// ManagedServiceForPID returns the Kranz service that owns pid, or ""
+	// if no configured service owns it.
+	ManagedServiceForPID(pid int) string
+
+	// StartConfirmationNames returns, in dependency order, every service
+	// among names (and, if includeDependencies is true, their transitive
+	// dependencies) whose start action requires confirmation.
+	StartConfirmationNames(names []string, includeDependencies bool) []string
+	// RequiresStopConfirmation reports whether stopping every one of names
+	// would stop at least one service capable of being stopped.
+	RequiresStopConfirmation(names []string) bool
+	// AffectedServices returns name followed by its transitive dependents
+	// that are not already stopped, in dependency order.
+	AffectedServices(name string) []string
+	// ShutdownPlan describes what a full shutdown will do right now.
+	ShutdownPlan() ShutdownPlan
+
+	// StartServicesContext starts names and their dependencies, honoring
+	// ctx cancellation while it waits on dependency readiness gates.
+	StartServicesContext(ctx context.Context, names []string) error
+	// StopServices stops names and every transitive dependent.
+	StopServices(names []string) error
+	// ForceStopServices stops exactly names, without expanding dependents.
+	ForceStopServices(names []string) error
+	// ForceStartServices starts exactly names, without expanding or
+	// waiting on dependencies.
+	ForceStartServices(names []string) error
+	// StopAll stops every configured service in reverse dependency order.
+	StopAll() error
+	// RestartAll restarts every service that was active when called.
+	RestartAll() error
+	// RestartService restarts name and its transitive dependents.
+	RestartService(name string) error
+	// HasRunningServices reports whether any service is running, starting,
+	// stopping, or unhealthy.
+	HasRunningServices() bool
+	// ProjectExitRequested reports whether an availability policy has
+	// asked the whole project to exit, and with what code.
+	ProjectExitRequested() (bool, int)
+	// Shutdown stops every service that should stop on exit and releases
+	// the runtime. It is idempotent from the caller's perspective only if
+	// the caller itself guards against calling it twice; Local does not
+	// re-guard an already-shut-down runtime.
+	Shutdown() error
+
+	// RunAction runs a non-interactive action to completion.
+	RunAction(ctx context.Context, id config.ActionID) (ActionResult, error)
+	// ActionState returns the last known result for id, if any action
+	// with that identity has ever run or is configured.
+	ActionState(id config.ActionID) (ActionResult, bool)
+	// CancelAction cancels a running action, reporting whether one was
+	// running to cancel.
+	CancelAction(id config.ActionID) bool
+	// PrepareInteractiveAction reserves an interactive action's execution
+	// slot and returns the command a delivery surface must run with direct
+	// terminal access, plus the finish callback that records its result.
+	PrepareInteractiveAction(id config.ActionID) (*exec.Cmd, func(error) ActionResult, error)
+
+	// Logs returns the current buffered log entries for a service.
+	Logs(name string) []config.LogEntry
+	// ClearLogs discards a service's buffered logs and resets its unread
+	// count.
+	ClearLogs(name string)
+	// MarkLogsRead resets a service's unread log count without discarding
+	// its logs.
+	MarkLogsRead(name string)
+	// HealthHistory returns the recorded readiness/liveness event lines
+	// for a service, oldest first.
+	HealthHistory(name string) []string
+
+	// InspectPorts checks the current owner, if any, of each port.
+	InspectPorts(ports []int) (map[int]*config.PortInfo, error)
+	// ReleaseExternalPort verifies a port is still held by expectedPID and,
+	// if so, terminates that external process. It refuses to act if the
+	// port's owner has changed, including to a Kranz-managed service.
+	// alreadyFree reports the port had no owner at all, which the caller
+	// should treat as success without attributing it to this call.
+	ReleaseExternalPort(portNumber, expectedPID int) (alreadyFree bool, err error)
+
+	// SetPortChecker replaces the port checker. It exists for tests that
+	// need a deterministic port checker; production callers should not
+	// need it.
+	SetPortChecker(checker port.Checker)
+}

--- a/internal/app/boundary_test.go
+++ b/internal/app/boundary_test.go
@@ -1,0 +1,51 @@
+package app
+
+import (
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestUIDoesNotImportRuntimePackages proves the application/runtime boundary
+// the refactor introduces: internal/ui's production code may only reach the
+// runtime through internal/app, never by importing internal/service,
+// internal/health, or internal/port directly. Test files are exempt — a test
+// fake implementing an interface those packages declare does not violate the
+// boundary a real delivery surface must respect.
+func TestUIDoesNotImportRuntimePackages(t *testing.T) {
+	forbidden := []string{
+		"github.com/kranz-org/kranz/internal/service",
+		"github.com/kranz-org/kranz/internal/health",
+		"github.com/kranz-org/kranz/internal/port",
+	}
+
+	uiDir := filepath.Join("..", "ui")
+	files, err := filepath.Glob(filepath.Join(uiDir, "*.go"))
+	if err != nil {
+		t.Fatalf("glob %s: %v", uiDir, err)
+	}
+	if len(files) == 0 {
+		t.Fatalf("no files found in %s", uiDir)
+	}
+
+	fileSet := token.NewFileSet()
+	for _, file := range files {
+		if strings.HasSuffix(file, "_test.go") {
+			continue
+		}
+		parsed, err := parser.ParseFile(fileSet, file, nil, parser.ImportsOnly)
+		if err != nil {
+			t.Fatalf("parse %s: %v", file, err)
+		}
+		for _, imported := range parsed.Imports {
+			path := strings.Trim(imported.Path.Value, `"`)
+			for _, forbiddenPath := range forbidden {
+				if path == forbiddenPath {
+					t.Errorf("%s imports %s directly; it must go through internal/app instead", file, path)
+				}
+			}
+		}
+	}
+}

--- a/internal/app/local.go
+++ b/internal/app/local.go
@@ -353,3 +353,33 @@ func (l *Local) SetPortChecker(checker port.Checker) {
 	l.portMu.Unlock()
 	l.manager.SetPortChecker(checker)
 }
+
+func (l *Local) SetServiceStatusForTest(name string, status config.ServiceStatus) {
+	if svc, ok := l.manager.GetService(name); ok {
+		svc.SetStatus(status)
+	}
+}
+
+func (l *Local) SetServiceStateForTest(name string, state config.ServiceState) {
+	if svc, ok := l.manager.GetService(name); ok {
+		svc.SetState(state)
+	}
+}
+
+func (l *Local) SetServiceDesiredRunningForTest(name string, desiredRunning bool) {
+	if svc, ok := l.manager.GetService(name); ok {
+		svc.SetDesiredRunning(desiredRunning)
+	}
+}
+
+func (l *Local) AppendLogForTest(name, line string) {
+	if svc, ok := l.manager.GetService(name); ok {
+		svc.AppendLog(line)
+	}
+}
+
+func (l *Local) AppendLogAtForTest(name string, timestamp time.Time, line string) {
+	if svc, ok := l.manager.GetService(name); ok {
+		svc.AppendLogAt(timestamp, line)
+	}
+}

--- a/internal/app/local.go
+++ b/internal/app/local.go
@@ -1,0 +1,355 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"sync"
+	"time"
+
+	"github.com/kranz-org/kranz/internal/config"
+	"github.com/kranz-org/kranz/internal/health"
+	"github.com/kranz-org/kranz/internal/port"
+	"github.com/kranz-org/kranz/internal/service"
+)
+
+// Options configures the runtime a Local wires up. A zero value is the
+// production default: real health and port checkers.
+type Options struct {
+	PortChecker     port.Checker
+	HealthChecker   *health.Checker
+	ListenerScanner port.ListenerScanner
+}
+
+// Local implements API directly over a service.Manager living in this
+// process. It is the only place in Kranz that constructs a Manager, a
+// health.Checker, and a port.Checker, and it owns the configuration
+// hot-reload pipeline that used to live in the TUI.
+type Local struct {
+	manager       *service.Manager
+	healthChecker *health.Checker
+
+	portMu      sync.RWMutex
+	portChecker port.Checker
+
+	// cfgMu guards every field a config reload replaces atomically: the
+	// effective configuration, the reload bookkeeping, and the watched-file
+	// stamps used to detect a change cheaply.
+	cfgMu          sync.RWMutex
+	cfg            *config.Config
+	configPaths    []string
+	watchPaths     []string
+	generation     uint64
+	loadedAt       time.Time
+	lastReloadErr  string
+	reloadBusy     bool
+	lastConfigScan time.Time
+	stamps         map[string]configStamp
+}
+
+// NewLocal constructs the runtime for one project and starts it observing
+// health and ports. configPaths is the set of files Reload re-reads; it
+// defaults to cfg.Paths when empty, matching how Kranz discovered the
+// configuration in the first place.
+func NewLocal(cfg *config.Config, configPaths []string, opts Options) *Local {
+	manager := service.NewManager(cfg)
+
+	healthChecker := opts.HealthChecker
+	if healthChecker == nil {
+		healthChecker = health.NewChecker()
+	}
+	portChecker := opts.PortChecker
+	if portChecker == nil {
+		portChecker = port.NewChecker()
+	}
+	listenerScanner := opts.ListenerScanner
+	if listenerScanner == nil {
+		listenerScanner = port.NewListenerScanner()
+	}
+	manager.SetHealthChecker(healthChecker)
+	manager.SetPortChecker(portChecker)
+	manager.SetListenerScanner(listenerScanner)
+
+	paths := append([]string(nil), configPaths...)
+	if len(paths) == 0 {
+		paths = append([]string(nil), cfg.Paths...)
+	}
+	watchPaths := watchedConfigPaths(paths, cfg.WatchPaths)
+	stamps, _ := readConfigStamps(watchPaths)
+
+	return &Local{
+		manager:       manager,
+		healthChecker: healthChecker,
+		portChecker:   portChecker,
+		cfg:           cfg,
+		configPaths:   paths,
+		watchPaths:    watchPaths,
+		generation:    1,
+		loadedAt:      time.Now(),
+		stamps:        stamps,
+	}
+}
+
+var _ API = (*Local)(nil)
+
+func (l *Local) Config() *config.Config {
+	l.cfgMu.RLock()
+	defer l.cfgMu.RUnlock()
+	return l.cfg
+}
+
+func (l *Local) Project() ProjectSnapshot {
+	l.cfgMu.RLock()
+	defer l.cfgMu.RUnlock()
+	return ProjectSnapshot{
+		Name:            l.cfg.Project,
+		Source:          l.cfg.Source,
+		ConfigPaths:     append([]string(nil), l.configPaths...),
+		WatchPaths:      append([]string(nil), l.watchPaths...),
+		Generation:      l.generation,
+		LoadedAt:        l.loadedAt,
+		LastReloadError: l.lastReloadErr,
+	}
+}
+
+func (l *Local) snapshotOf(svc *service.Service) *ServiceSnapshot {
+	snapshot := &ServiceSnapshot{
+		Name:           svc.Name,
+		Config:         svc.Config,
+		State:          svc.GetState(),
+		DetectedPorts:  svc.DetectedPorts(),
+		DesiredRunning: svc.DesiredRunning(),
+		StatusObserved: svc.LifecycleStatusObserved(),
+		CanStart:       svc.CanStart(),
+		CanStop:        svc.CanStop(),
+	}
+	if l.healthChecker != nil {
+		if h := l.healthChecker.GetHealth(svc.Name); h != nil {
+			snapshot.Health = HealthSnapshot{
+				Observed:   true,
+				Ready:      h.IsReady(),
+				Alive:      h.IsAlive(),
+				ReadySince: h.GetReadySince(),
+				LastCheck:  h.GetLastCheck(),
+			}
+		}
+	}
+	return snapshot
+}
+
+func (l *Local) Services() []*ServiceSnapshot {
+	services := l.manager.Services()
+	snapshots := make([]*ServiceSnapshot, len(services))
+	for i, svc := range services {
+		snapshots[i] = l.snapshotOf(svc)
+	}
+	return snapshots
+}
+
+func (l *Local) Service(name string) (*ServiceSnapshot, bool) {
+	svc, ok := l.manager.GetService(name)
+	if !ok {
+		return nil, false
+	}
+	return l.snapshotOf(svc), true
+}
+
+func (l *Local) Tags() []string {
+	return l.Config().GetAllTags()
+}
+
+func (l *Local) ManagedServiceForPID(pid int) string {
+	return l.manager.ManagedServiceForPID(pid)
+}
+
+// StartConfirmationNames mirrors the dependency walk the dashboard used to
+// perform itself: it visits names (and, when includeDependencies is true,
+// their transitive config.Service.DependsOn) depth-first, collecting every
+// startable service whose start action requires confirmation in the order
+// its dependencies are visited before it.
+func (l *Local) StartConfirmationNames(names []string, includeDependencies bool) []string {
+	cfg := l.Config()
+	selected := make(map[string]bool)
+	confirmed := make([]string, 0, len(names))
+	var visit func(string)
+	visit = func(name string) {
+		if selected[name] {
+			return
+		}
+		selected[name] = true
+		if includeDependencies {
+			for _, dependency := range cfg.Services[name].DependsOn {
+				visit(dependency)
+			}
+		}
+		snapshot, ok := l.Service(name)
+		if !ok || !snapshot.CanStart {
+			return
+		}
+		if start := snapshot.Config.StartAction(); start != nil && start.ConfirmationRequired() {
+			confirmed = append(confirmed, name)
+		}
+	}
+	for _, name := range names {
+		visit(name)
+	}
+	return confirmed
+}
+
+func (l *Local) RequiresStopConfirmation(names []string) bool {
+	for _, name := range names {
+		if snapshot, ok := l.Service(name); ok && snapshot.CanStop {
+			return true
+		}
+	}
+	return false
+}
+
+func (l *Local) AffectedServices(name string) []string {
+	return l.manager.GetAffectedServices(name)
+}
+
+func (l *Local) ShutdownPlan() ShutdownPlan {
+	var plan ShutdownPlan
+	for _, svc := range l.Services() {
+		if !ServiceStartPlanned(svc) {
+			continue
+		}
+		switch {
+		case !svc.Config.IsDetached():
+			plan.Managed = append(plan.Managed, svc.Name)
+		case svc.Config.StopOnExitEnabled():
+			plan.DetachedStop = append(plan.DetachedStop, svc.Name)
+		default:
+			plan.DetachedKeep = append(plan.DetachedKeep, svc.Name)
+		}
+	}
+	return plan
+}
+
+func (l *Local) StartServicesContext(ctx context.Context, names []string) error {
+	return l.manager.StartServicesContext(ctx, names)
+}
+
+func (l *Local) StopServices(names []string) error {
+	return l.manager.StopServices(names)
+}
+
+func (l *Local) ForceStopServices(names []string) error {
+	return l.manager.ForceStopServices(names)
+}
+
+func (l *Local) ForceStartServices(names []string) error {
+	return l.manager.ForceStartServices(names)
+}
+
+func (l *Local) StopAll() error {
+	return l.manager.StopAll()
+}
+
+func (l *Local) RestartAll() error {
+	return l.manager.RestartAll()
+}
+
+func (l *Local) RestartService(name string) error {
+	return l.manager.RestartService(name)
+}
+
+func (l *Local) HasRunningServices() bool {
+	return l.manager.HasRunningServices()
+}
+
+func (l *Local) ProjectExitRequested() (bool, int) {
+	return l.manager.ProjectExitRequested()
+}
+
+func (l *Local) Shutdown() error {
+	l.healthChecker.StopAll()
+	return l.manager.Shutdown()
+}
+
+func (l *Local) RunAction(ctx context.Context, id config.ActionID) (ActionResult, error) {
+	return l.manager.RunAction(ctx, id)
+}
+
+func (l *Local) ActionState(id config.ActionID) (ActionResult, bool) {
+	return l.manager.ActionState(id)
+}
+
+func (l *Local) CancelAction(id config.ActionID) bool {
+	return l.manager.CancelAction(id)
+}
+
+func (l *Local) PrepareInteractiveAction(id config.ActionID) (*exec.Cmd, func(error) ActionResult, error) {
+	return l.manager.PrepareInteractiveAction(id)
+}
+
+func (l *Local) Logs(name string) []config.LogEntry {
+	svc, ok := l.manager.GetService(name)
+	if !ok {
+		return nil
+	}
+	return svc.LogEntries()
+}
+
+func (l *Local) ClearLogs(name string) {
+	svc, ok := l.manager.GetService(name)
+	if !ok {
+		return
+	}
+	svc.ClearLogs()
+	svc.ResetNewLogCount()
+}
+
+func (l *Local) MarkLogsRead(name string) {
+	svc, ok := l.manager.GetService(name)
+	if !ok {
+		return
+	}
+	svc.ResetNewLogCount()
+}
+
+func (l *Local) HealthHistory(name string) []string {
+	if l.healthChecker == nil {
+		return nil
+	}
+	h := l.healthChecker.GetHealth(name)
+	if h == nil {
+		return nil
+	}
+	return h.History.Lines()
+}
+
+func (l *Local) InspectPorts(ports []int) (map[int]*config.PortInfo, error) {
+	l.portMu.RLock()
+	checker := l.portChecker
+	l.portMu.RUnlock()
+	return checker.CheckPorts(ports)
+}
+
+func (l *Local) ReleaseExternalPort(portNumber, expectedPID int) (bool, error) {
+	l.portMu.RLock()
+	checker := l.portChecker
+	l.portMu.RUnlock()
+	info, err := checker.CheckPort(portNumber)
+	if err != nil {
+		return false, err
+	}
+	if info == nil {
+		return true, nil
+	}
+	if info.PID != expectedPID {
+		return false, fmt.Errorf("port %d owner changed from PID %d to PID %d; refusing to stop it", portNumber, expectedPID, info.PID)
+	}
+	if owner := l.manager.ManagedServiceForPID(info.PID); owner != "" {
+		return false, fmt.Errorf("port %d is now owned by Kranz service %s; refusing to stop it as external", portNumber, owner)
+	}
+	return false, port.TerminateExternalPID(expectedPID, 3*time.Second)
+}
+
+func (l *Local) SetPortChecker(checker port.Checker) {
+	l.portMu.Lock()
+	l.portChecker = checker
+	l.portMu.Unlock()
+	l.manager.SetPortChecker(checker)
+}

--- a/internal/app/local_test.go
+++ b/internal/app/local_test.go
@@ -1,0 +1,214 @@
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kranz-org/kranz/internal/config"
+)
+
+func TestServicesSnapshotReflectsConfigAndRuntimeState(t *testing.T) {
+	confirm := true
+	cfg := &config.Config{Project: "Test", Services: map[string]config.Service{
+		"api": {Command: "exit 0", Dir: ".", Shell: "sh", Ports: []int{8080}},
+		"migration": {Lifecycle: config.LifecycleConfig{Start: &config.Action{
+			Command: "true", Confirm: &confirm,
+		}}, DependsOn: []string{"api"}},
+	}}
+	local := NewLocal(cfg, nil, Options{})
+	defer func() { _ = local.Shutdown() }()
+
+	snapshots := local.Services()
+	if len(snapshots) != 2 {
+		t.Fatalf("Services() returned %d snapshots, want 2", len(snapshots))
+	}
+	api, ok := local.Service("api")
+	if !ok {
+		t.Fatal("Service(api) not found")
+	}
+	if api.State.Status != config.StatusStopped {
+		t.Fatalf("api initial status = %v, want stopped", api.State.Status)
+	}
+	if !api.CanStart || api.CanStop {
+		t.Fatalf("api capability = start:%v stop:%v, want startable and not stoppable", api.CanStart, api.CanStop)
+	}
+}
+
+func TestStartConfirmationNamesIncludesConfirmedDependencies(t *testing.T) {
+	confirm := true
+	cfg := &config.Config{Project: "Test", Services: map[string]config.Service{
+		"migration": {Lifecycle: config.LifecycleConfig{Start: &config.Action{
+			Command: "true", Confirm: &confirm,
+		}}},
+		"api": {Command: "true", DependsOn: []string{"migration"}},
+	}}
+	local := NewLocal(cfg, nil, Options{})
+	defer func() { _ = local.Shutdown() }()
+
+	names := local.StartConfirmationNames([]string{"api"}, true)
+	if len(names) != 1 || names[0] != "migration" {
+		t.Fatalf("StartConfirmationNames(with deps) = %v, want [migration]", names)
+	}
+
+	names = local.StartConfirmationNames([]string{"api"}, false)
+	if len(names) != 0 {
+		t.Fatalf("StartConfirmationNames(without deps) = %v, want none", names)
+	}
+}
+
+func TestRequiresStopConfirmationOnlyForStoppableServices(t *testing.T) {
+	cfg := &config.Config{Project: "Test", Services: map[string]config.Service{
+		"api": {Command: "sleep 60"},
+	}}
+	local := NewLocal(cfg, nil, Options{})
+	defer func() { _ = local.Shutdown() }()
+
+	if local.RequiresStopConfirmation([]string{"api"}) {
+		t.Fatal("a stopped service should not require stop confirmation")
+	}
+	if err := local.StartServicesContext(context.Background(), []string{"api"}); err != nil {
+		t.Fatalf("start api: %v", err)
+	}
+	if !local.RequiresStopConfirmation([]string{"api"}) {
+		t.Fatal("a running service should require stop confirmation")
+	}
+}
+
+func TestShutdownPlanClassifiesManagedAndDetachedServices(t *testing.T) {
+	stopOnExit := true
+	cfg := &config.Config{Project: "Test", Services: map[string]config.Service{
+		"api": {Command: "sleep 60"},
+		// StopOnExit defaults to false for a detached resource (Kranz does not
+		// own it), so this one must opt in explicitly to land in DetachedStop.
+		"external": {
+			Supervision: config.SupervisionDetached,
+			StopOnExit:  &stopOnExit,
+			Lifecycle: config.LifecycleConfig{
+				Start: &config.Action{Command: "true"},
+				Stop:  &config.Action{Command: "true"},
+			},
+		},
+		"unmanaged": {
+			Supervision: config.SupervisionDetached,
+			Lifecycle: config.LifecycleConfig{
+				Start: &config.Action{Command: "true"},
+				Stop:  &config.Action{Command: "true"},
+			},
+		},
+	}}
+	local := NewLocal(cfg, nil, Options{})
+	defer func() { _ = local.Shutdown() }()
+
+	if err := local.StartServicesContext(context.Background(), []string{"api"}); err != nil {
+		t.Fatalf("start api: %v", err)
+	}
+	if err := local.ForceStartServices([]string{"external", "unmanaged"}); err != nil {
+		t.Fatalf("start detached services: %v", err)
+	}
+
+	plan := local.ShutdownPlan()
+	if len(plan.Managed) != 1 || plan.Managed[0] != "api" {
+		t.Fatalf("plan.Managed = %v, want [api]", plan.Managed)
+	}
+	if len(plan.DetachedStop) != 1 || plan.DetachedStop[0] != "external" {
+		t.Fatalf("plan.DetachedStop = %v, want [external]", plan.DetachedStop)
+	}
+	if len(plan.DetachedKeep) != 1 || plan.DetachedKeep[0] != "unmanaged" {
+		t.Fatalf("plan.DetachedKeep = %v, want [unmanaged]", plan.DetachedKeep)
+	}
+}
+
+func TestReloadRaisesGenerationAndKeepsLastKnownGoodOnInvalidFile(t *testing.T) {
+	directory := t.TempDir()
+	path := filepath.Join(directory, "kranz.yaml")
+	writeConfig(t, path, "project: Test\nservices:\n  api:\n    command: \"true\"\n")
+	cfg, err := config.LoadFiles([]string{path})
+	if err != nil {
+		t.Fatalf("initial load: %v", err)
+	}
+	local := NewLocal(cfg, []string{path}, Options{})
+	defer func() { _ = local.Shutdown() }()
+
+	if got := local.Project().Generation; got != 1 {
+		t.Fatalf("initial generation = %d, want 1", got)
+	}
+
+	writeConfig(t, path, "project: Test\nservices:\n  api:\n    command: \"true\"\n  worker:\n    command: \"true\"\n")
+	touchLater(t, path)
+	if _, err := local.Reload(true); err != nil {
+		t.Fatalf("reload valid change: %v", err)
+	}
+	if got := local.Project().Generation; got != 2 {
+		t.Fatalf("generation after reload = %d, want 2", got)
+	}
+	if len(local.Config().Services) != 2 {
+		t.Fatalf("services after reload = %d, want 2", len(local.Config().Services))
+	}
+
+	writeConfig(t, path, "project: Test\nservices:\n")
+	touchLater(t, path)
+	if _, err := local.Reload(true); err == nil {
+		t.Fatal("reload with no services should fail validation")
+	}
+	if got := local.Project().Generation; got != 2 {
+		t.Fatalf("generation after failed reload = %d, want unchanged 2", got)
+	}
+	if len(local.Config().Services) != 2 {
+		t.Fatalf("services after failed reload = %d, want last known good 2", len(local.Config().Services))
+	}
+	if local.Project().LastReloadError == "" {
+		t.Fatal("failed reload did not record an error")
+	}
+}
+
+func TestReloadDebouncesWithinOneSecondUnlessForced(t *testing.T) {
+	directory := t.TempDir()
+	path := filepath.Join(directory, "kranz.yaml")
+	writeConfig(t, path, "project: Test\nservices:\n  api:\n    command: \"true\"\n")
+	cfg, err := config.LoadFiles([]string{path})
+	if err != nil {
+		t.Fatalf("initial load: %v", err)
+	}
+	local := NewLocal(cfg, []string{path}, Options{})
+	defer func() { _ = local.Shutdown() }()
+
+	writeConfig(t, path, "project: Test\nservices:\n  api:\n    command: \"true\"\n  worker:\n    command: \"true\"\n")
+	touchLater(t, path)
+	if _, err := local.Reload(false); err != nil {
+		t.Fatalf("first reload: %v", err)
+	}
+	if got := local.Project().Generation; got != 2 {
+		t.Fatalf("generation after first reload = %d, want 2", got)
+	}
+
+	writeConfig(t, path, "project: Test\nservices:\n  api:\n    command: \"true\"\n")
+	touchLater(t, path)
+	if _, err := local.Reload(false); err != nil {
+		t.Fatalf("debounced reload: %v", err)
+	}
+	if got := local.Project().Generation; got != 2 {
+		t.Fatalf("generation after debounced reload = %d, want still 2", got)
+	}
+}
+
+func writeConfig(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// touchLater backdates the config's mtime stamp so a fast test run still sees
+// a change: the reload pipeline detects edits by mtime and size, and two
+// writes within the same nanosecond-granularity tick would otherwise look
+// identical to it.
+func touchLater(t *testing.T, path string) {
+	t.Helper()
+	future := time.Now().Add(time.Second)
+	if err := os.Chtimes(path, future, future); err != nil {
+		t.Fatalf("chtimes %s: %v", path, err)
+	}
+}

--- a/internal/app/reload.go
+++ b/internal/app/reload.go
@@ -27,6 +27,10 @@ const reloadDebounce = time.Second
 // in flight is a no-op, reported as (ReloadResult{}, nil).
 func (l *Local) Reload(force bool) (ReloadResult, error) {
 	l.cfgMu.Lock()
+	if len(l.configPaths) == 0 {
+		l.cfgMu.Unlock()
+		return ReloadResult{}, nil
+	}
 	if l.reloadBusy {
 		l.cfgMu.Unlock()
 		return ReloadResult{}, nil
@@ -82,6 +86,13 @@ func (l *Local) Reload(force bool) (ReloadResult, error) {
 		l.recordReloadStamps(stamps)
 	}
 	return result, nil
+}
+
+// AcknowledgeExternalWrite implements API.AcknowledgeExternalWrite.
+func (l *Local) AcknowledgeExternalWrite() {
+	if stamps, err := readConfigStamps(l.watchPathsSnapshot()); err == nil {
+		l.recordReloadStamps(stamps)
+	}
 }
 
 func (l *Local) watchPathsSnapshot() []string {

--- a/internal/app/reload.go
+++ b/internal/app/reload.go
@@ -1,0 +1,154 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/kranz-org/kranz/internal/config"
+)
+
+// Configuration hot reload. This is the same stamping and debounce pipeline
+// that used to live in the TUI (internal/ui/model_config.go): watch a set of
+// paths by mtime and size, and only re-parse when one of them actually
+// changed. An invalid file leaves the last known good runtime untouched.
+
+type configStamp struct {
+	Modified int64
+	Size     int64
+}
+
+// Reload debounces to at most once per second unless force is true, matching
+// the interval the TUI's polling tick used to enforce on its own.
+const reloadDebounce = time.Second
+
+// Reload re-reads the configuration if a watched path changed, and applies
+// it to the running services. A concurrent Reload call while one is already
+// in flight is a no-op, reported as (ReloadResult{}, nil).
+func (l *Local) Reload(force bool) (ReloadResult, error) {
+	l.cfgMu.Lock()
+	if l.reloadBusy {
+		l.cfgMu.Unlock()
+		return ReloadResult{}, nil
+	}
+	if !force && time.Since(l.lastConfigScan) < reloadDebounce {
+		l.cfgMu.Unlock()
+		return ReloadResult{}, nil
+	}
+	l.lastConfigScan = time.Now()
+	l.reloadBusy = true
+	paths := append([]string(nil), l.configPaths...)
+	watchPaths := append([]string(nil), l.watchPaths...)
+	previousStamps := cloneConfigStamps(l.stamps)
+	l.cfgMu.Unlock()
+
+	defer func() {
+		l.cfgMu.Lock()
+		l.reloadBusy = false
+		l.cfgMu.Unlock()
+	}()
+
+	stamps, err := readConfigStamps(watchPaths)
+	if err != nil {
+		l.recordReloadStamps(stamps)
+		return ReloadResult{}, err
+	}
+	changed := force || !equalConfigStamps(previousStamps, stamps)
+	l.recordReloadStamps(stamps)
+	if !changed {
+		return ReloadResult{}, nil
+	}
+
+	next, err := config.LoadFiles(paths)
+	if err != nil {
+		l.recordReloadError(err)
+		return ReloadResult{}, err
+	}
+
+	result, err := l.manager.ApplyConfig(next)
+	if err != nil {
+		l.recordReloadError(err)
+		return result, err
+	}
+
+	l.cfgMu.Lock()
+	l.cfg = next
+	l.watchPaths = watchedConfigPaths(l.configPaths, next.WatchPaths)
+	l.generation++
+	l.loadedAt = time.Now()
+	l.lastReloadErr = ""
+	l.cfgMu.Unlock()
+	if stamps, err := readConfigStamps(l.watchPathsSnapshot()); err == nil {
+		l.recordReloadStamps(stamps)
+	}
+	return result, nil
+}
+
+func (l *Local) watchPathsSnapshot() []string {
+	l.cfgMu.RLock()
+	defer l.cfgMu.RUnlock()
+	return append([]string(nil), l.watchPaths...)
+}
+
+func (l *Local) recordReloadStamps(stamps map[string]configStamp) {
+	l.cfgMu.Lock()
+	l.stamps = stamps
+	l.cfgMu.Unlock()
+}
+
+func (l *Local) recordReloadError(err error) {
+	l.cfgMu.Lock()
+	l.lastReloadErr = err.Error()
+	l.cfgMu.Unlock()
+}
+
+func readConfigStamps(paths []string) (map[string]configStamp, error) {
+	result := make(map[string]configStamp, len(paths))
+	for _, path := range paths {
+		info, err := os.Stat(path)
+		if os.IsNotExist(err) {
+			result[path] = configStamp{}
+			continue
+		}
+		if err != nil {
+			return result, fmt.Errorf("stat %s: %w", path, err)
+		}
+		result[path] = configStamp{Modified: info.ModTime().UnixNano(), Size: info.Size()}
+	}
+	return result, nil
+}
+
+func watchedConfigPaths(configPaths, auxiliaryPaths []string) []string {
+	result := append([]string(nil), configPaths...)
+	seen := make(map[string]bool, len(result)+len(auxiliaryPaths))
+	for _, path := range result {
+		seen[path] = true
+	}
+	for _, path := range auxiliaryPaths {
+		if path != "" && !seen[path] {
+			seen[path] = true
+			result = append(result, path)
+		}
+	}
+	return result
+}
+
+func cloneConfigStamps(source map[string]configStamp) map[string]configStamp {
+	result := make(map[string]configStamp, len(source))
+	for path, stamp := range source {
+		result[path] = stamp
+	}
+	return result
+}
+
+func equalConfigStamps(left, right map[string]configStamp) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for path, stamp := range left {
+		if right[path] != stamp {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/app/types.go
+++ b/internal/app/types.go
@@ -1,0 +1,108 @@
+// Package app is the shared application layer between Kranz's delivery
+// surfaces. It owns the runtime (service.Manager, health.Checker, and
+// port.Checker) and exposes it as value snapshots and plain operations, so a
+// TUI, a CLI, and a future MCP adapter can drive the same lifecycle, action,
+// and configuration contracts without any of them reaching into the runtime
+// packages directly.
+package app
+
+import (
+	"time"
+
+	"github.com/kranz-org/kranz/internal/config"
+	"github.com/kranz-org/kranz/internal/service"
+)
+
+// ActionResult, ActionStatus, ReloadResult, and PortConflictError are already
+// plain value types in internal/service. Aliasing them here (rather than
+// redeclaring the type) keeps their behaviour, including ActionStatus's
+// String method, while letting every other package reference them through
+// app instead of importing internal/service itself.
+type (
+	ActionResult      = service.ActionResult
+	ActionStatus      = service.ActionStatus
+	ReloadResult      = service.ReloadResult
+	PortConflictError = service.PortConflictError
+	ActionBusyError   = service.ActionBusyError
+	ActionExitError   = service.ActionExitError
+)
+
+// Re-exported so a caller never has to import internal/service for a
+// constant it needs to compare an ActionResult.Status against.
+const (
+	ActionReady     = service.ActionReady
+	ActionRunning   = service.ActionRunning
+	ActionSucceeded = service.ActionSucceeded
+	ActionFailed    = service.ActionFailed
+	ActionTimedOut  = service.ActionTimedOut
+	ActionCancelled = service.ActionCancelled
+)
+
+var (
+	ErrActionNotFound       = service.ErrActionNotFound
+	ErrActionRunnerStopping = service.ErrActionRunnerStopping
+	ErrInteractiveAction    = service.ErrInteractiveAction
+)
+
+// HealthSnapshot is a value copy of a service's readiness/liveness state.
+// Observed is false until health monitoring has produced a first result for
+// the service, mirroring health.Checker.GetHealth returning nil.
+type HealthSnapshot struct {
+	Observed   bool
+	Ready      bool
+	Alive      bool
+	ReadySince time.Time
+	LastCheck  time.Time
+}
+
+// ServiceSnapshot is a point-in-time, concurrency-safe copy of one service's
+// configuration and runtime state. It intentionally carries no live pointer
+// back into the runtime: every field is a value, so the same type can later
+// travel across the IPC boundary a future stream adds without redesign.
+type ServiceSnapshot struct {
+	Name           string
+	Config         config.Service
+	State          config.ServiceState
+	DetectedPorts  []int
+	DesiredRunning bool
+	StatusObserved bool
+	CanStart       bool
+	CanStop        bool
+	Health         HealthSnapshot
+}
+
+// ServiceStartPlanned reports whether a service is running, starting, or
+// queued to start — the same "counts as active for toggle purposes" test the
+// dashboard's start/stop button and quit plan both need.
+func ServiceStartPlanned(svc *ServiceSnapshot) bool {
+	if svc == nil {
+		return false
+	}
+	if svc.State.Status == config.StatusUnknown {
+		return svc.DesiredRunning
+	}
+	return svc.State.Status != config.StatusStopped || svc.DesiredRunning
+}
+
+// ProjectSnapshot describes the currently loaded configuration and the
+// health of its hot-reload pipeline.
+type ProjectSnapshot struct {
+	Name            string
+	Version         string
+	Source          config.SourceFormat
+	ConfigPaths     []string
+	WatchPaths      []string
+	Generation      uint64
+	LoadedAt        time.Time
+	LastReloadError string
+}
+
+// ShutdownPlan describes what a full shutdown will do to every active
+// service: which managed processes stop, which detached resources run their
+// configured stop command, and which detached resources are left running
+// because Kranz never owned their lifecycle.
+type ShutdownPlan struct {
+	Managed      []string
+	DetachedStop []string
+	DetachedKeep []string
+}

--- a/internal/app/types.go
+++ b/internal/app/types.go
@@ -10,8 +10,16 @@ import (
 	"time"
 
 	"github.com/kranz-org/kranz/internal/config"
+	"github.com/kranz-org/kranz/internal/health"
 	"github.com/kranz-org/kranz/internal/service"
 )
+
+// ResolveCheckTarget re-exports health.ResolveCheckTarget: it resolves a
+// dynamic-port health check against a service's currently detected ports. It
+// is a pure function over config values, not runtime state, but a delivery
+// surface still reaches it through app rather than importing internal/health
+// itself, to keep the boundary a single, checkable rule.
+var ResolveCheckTarget = health.ResolveCheckTarget
 
 // ActionResult, ActionStatus, ReloadResult, and PortConflictError are already
 // plain value types in internal/service. Aliasing them here (rather than

--- a/internal/service/manager_dependencies.go
+++ b/internal/service/manager_dependencies.go
@@ -170,6 +170,14 @@ func (m *Manager) groupByDependencyLevel(order []string) [][]string {
 	return groups
 }
 
+// StartDependencyClosure exposes the dependency expansion a start operation
+// would use, so a caller outside this package (the application layer's start
+// confirmation and planning) can compute the same closure instead of walking
+// config.Service.DependsOn on its own.
+func (m *Manager) StartDependencyClosure(names []string) (map[string]bool, error) {
+	return m.expandWithDependencies(names)
+}
+
 // StartByTags starts services matching at least one tag and their dependencies.
 
 func (m *Manager) expandWithDependencies(names []string) (map[string]bool, error) {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -10,11 +10,9 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/kranz-org/kranz/internal/app"
 	"github.com/kranz-org/kranz/internal/config"
-	"github.com/kranz-org/kranz/internal/health"
 	kranzlog "github.com/kranz-org/kranz/internal/log"
-	"github.com/kranz-org/kranz/internal/port"
-	"github.com/kranz-org/kranz/internal/service"
 	usersettings "github.com/kranz-org/kranz/internal/settings"
 )
 
@@ -64,7 +62,7 @@ const (
 
 type tagListRow struct {
 	Tag     string
-	Service *service.Service
+	Service *app.ServiceSnapshot
 }
 
 type actionListRowKind uint8
@@ -77,7 +75,7 @@ const (
 
 type actionListRow struct {
 	Kind    actionListRowKind
-	Service *service.Service
+	Service *app.ServiceSnapshot
 	Group   string
 	Action  config.ActionID
 }
@@ -111,7 +109,7 @@ type operationResultMsg struct {
 
 type actionResultMsg struct {
 	id     config.ActionID
-	result service.ActionResult
+	result app.ActionResult
 	err    error
 }
 
@@ -135,15 +133,11 @@ type tickMsg time.Time
 
 const mouseTrackingRefreshInterval = 250 * time.Millisecond
 
-type configStamp struct {
-	Modified int64
-	Size     int64
-}
 type configReloadMsg struct {
-	cfg     *config.Config
-	stamps  map[string]configStamp
-	err     error
-	changed bool
+	result     app.ReloadResult
+	err        error
+	generation uint64
+	changed    bool
 }
 
 type portDetailsMsg struct {
@@ -160,9 +154,9 @@ type Model struct {
 	version          string
 	workingDirectory string
 
-	manager             *service.Manager
-	services            []*service.Service
-	allServices         []*service.Service
+	app                 app.API
+	services            []*app.ServiceSnapshot
+	allServices         []*app.ServiceSnapshot
 	focused             int
 	selected            map[string]bool
 	detailOffset        int
@@ -176,14 +170,12 @@ type Model struct {
 	focusedActionGroup  string
 	expandedActionOwner map[string]bool
 
-	healthChecker *health.Checker
-	portChecker   port.Checker
-	portDetails   map[int]*config.PortInfo
-	portError     error
-	portService   string
-	portChecked   time.Time
-	portScanID    int
-	portScanBusy  bool
+	portDetails  map[int]*config.PortInfo
+	portError    error
+	portService  string
+	portChecked  time.Time
+	portScanID   int
+	portScanBusy bool
 
 	logSearcher  *kranzlog.Searcher
 	searchInput  textinput.Model
@@ -274,10 +266,6 @@ type Model struct {
 	themeColorReplace  bool
 	themeColorError    string
 	configPaths        []string
-	configWatchPaths   []string
-	configStamps       map[string]configStamp
-	lastConfigScan     time.Time
-	reloadBusy         bool
 	projectExitHandled bool
 
 	shutdownOnce sync.Once
@@ -292,6 +280,10 @@ type ModelOptions struct {
 	// DarkBackground is detected by the executable. Nil keeps the historical
 	// dark default for embedders and deterministic tests.
 	DarkBackground *bool
+	// App is the application-layer runtime the model drives. When nil, one
+	// is constructed from cfg and ConfigPaths with production defaults —
+	// the shape every existing caller and test relies on.
+	App app.API
 }
 
 // NewModel creates a model with default user settings and terminal detection.
@@ -311,23 +303,19 @@ func NewModelWithOptions(cfg *config.Config, version string, options ModelOption
 	if themeErr != nil {
 		activeTheme, _ = applyAppearance(DefaultTheme, "", backgroundTerminal, colorModeAuto, terminalDark)
 	}
-	manager := service.NewManager(cfg)
-	healthChecker := health.NewChecker()
-	portChecker := port.NewChecker()
-	manager.SetHealthChecker(healthChecker)
-	manager.SetPortChecker(portChecker)
-	manager.SetListenerScanner(port.NewListenerScanner())
-	services := manager.Services()
+	application := options.App
+	if application == nil {
+		application = app.NewLocal(cfg, options.ConfigPaths, app.Options{})
+	}
+	services := application.Services()
 
 	model := &Model{
-		cfg:                 cfg,
+		cfg:                 application.Config(),
 		version:             version,
 		workingDirectory:    workingDirectory,
-		manager:             manager,
+		app:                 application,
 		services:            services,
 		allServices:         services,
-		healthChecker:       healthChecker,
-		portChecker:         portChecker,
 		portDetails:         make(map[int]*config.PortInfo),
 		selected:            make(map[string]bool),
 		expandedTags:        make(map[string]bool),
@@ -357,8 +345,6 @@ func NewModelWithOptions(cfg *config.Config, version string, options ModelOption
 	if len(model.configPaths) == 0 {
 		model.configPaths = append([]string(nil), cfg.Paths...)
 	}
-	model.configWatchPaths = watchedConfigPaths(model.configPaths, cfg.WatchPaths)
-	model.configStamps, _ = readConfigStamps(model.configWatchPaths)
 	if themeErr != nil {
 		model.addNotification("appearance", themeErr.Error()+"; using the Kranz theme", config.LogWarn)
 	}
@@ -402,7 +388,7 @@ func (m *Model) refreshMouseTracking(now time.Time) tea.Cmd {
 
 // RequestedExitCode returns the exit code requested by an availability policy.
 func (m *Model) RequestedExitCode() int {
-	requested, code := m.manager.ProjectExitRequested()
+	requested, code := m.app.ProjectExitRequested()
 	if !requested {
 		return 0
 	}
@@ -498,7 +484,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		now := time.Time(msg)
 		m.refreshServices()
 		m.expireToast()
-		if requested, _ := m.manager.ProjectExitRequested(); requested && !m.projectExitHandled {
+		if requested, _ := m.app.ProjectExitRequested(); requested && !m.projectExitHandled {
 			m.projectExitHandled = true
 			return m.beginShutdown()
 		}
@@ -540,7 +526,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) refreshServices() {
-	m.allServices = m.manager.Services()
+	m.allServices = m.app.Services()
 	m.services = m.allServices
 	rows := m.tagRows()
 	m.tagCursor = min(max(0, len(rows)-1), max(0, m.tagCursor))
@@ -579,7 +565,7 @@ const (
 type searchNudgeMsg time.Time
 
 // FocusedService returns the service selected by the list cursor.
-func (m *Model) FocusedService() *service.Service {
+func (m *Model) FocusedService() *app.ServiceSnapshot {
 	if m.focused < 0 || m.focused >= len(m.services) {
 		return nil
 	}
@@ -600,10 +586,18 @@ func (m *Model) addNotification(serviceName, message string, level config.LogLev
 }
 
 // PinnedService returns the service shown in the fixed upper log panel.
-func (m *Model) PinnedService() *service.Service {
+func (m *Model) PinnedService() *app.ServiceSnapshot {
 	if m.pinnedLog == "" {
 		return nil
 	}
-	svc, _ := m.manager.GetService(m.pinnedLog)
-	return svc
+	// Look up within this tick's already-fetched snapshots rather than
+	// querying app fresh, so PinnedService and FocusedService return the
+	// same pointer for the same service within one render — some callers
+	// compare them by identity.
+	for _, svc := range m.allServices {
+		if svc.Name == m.pinnedLog {
+			return svc
+		}
+	}
+	return nil
 }

--- a/internal/ui/model_actions.go
+++ b/internal/ui/model_actions.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/kranz-org/kranz/internal/app"
 	"github.com/kranz-org/kranz/internal/config"
-	"github.com/kranz-org/kranz/internal/service"
 )
 
 func actionOwnerKey(kind config.ActionOwnerKind, owner string) string {
@@ -168,7 +168,7 @@ func (m *Model) toggleFocusedAction() (tea.Cmd, bool) {
 		m.addNotification("action", "Action is no longer configured", config.LogWarn)
 		return nil, true
 	}
-	if state, ok := m.manager.ActionState(id); ok && state.Status == service.ActionRunning {
+	if state, ok := m.app.ActionState(id); ok && state.Status == app.ActionRunning {
 		m.beginActionConfirmation(id, true)
 		return nil, true
 	}
@@ -187,7 +187,7 @@ func (m *Model) toggleFocusedAction() (tea.Cmd, bool) {
 // the command owns the terminal until it exits, and the outcome is recorded
 // like any other action.
 func (m *Model) runInteractiveAction(id config.ActionID) tea.Cmd {
-	command, finish, err := m.manager.PrepareInteractiveAction(id)
+	command, finish, err := m.app.PrepareInteractiveAction(id)
 	if err != nil {
 		m.addNotification("action", id.Name+": "+err.Error(), config.LogError)
 		return nil
@@ -212,7 +212,7 @@ func (m *Model) runAction(id config.ActionID, action config.Action) tea.Cmd {
 	}
 	m.addNotification("action", "Running "+id.Name, config.LogInfo)
 	return func() tea.Msg {
-		result, err := m.manager.RunAction(context.Background(), id)
+		result, err := m.app.RunAction(context.Background(), id)
 		return actionResultMsg{id: id, result: result, err: err}
 	}
 }
@@ -227,7 +227,7 @@ func (m *Model) confirmPendingAction() tea.Cmd {
 		return nil
 	}
 	if stop {
-		if m.manager.CancelAction(*id) {
+		if m.app.CancelAction(*id) {
 			m.addNotification("action", "Stopping "+id.Name, config.LogWarn)
 		} else {
 			m.addNotification("action", id.Name+" is no longer running", config.LogWarn)
@@ -266,15 +266,15 @@ func (m *Model) handleActionResult(msg actionResultMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m *Model) focusedActionDefinition() (config.ActionID, config.Action, service.ActionResult, bool) {
+func (m *Model) focusedActionDefinition() (config.ActionID, config.Action, app.ActionResult, bool) {
 	if m.focusedAction == nil {
-		return config.ActionID{}, config.Action{}, service.ActionResult{}, false
+		return config.ActionID{}, config.Action{}, app.ActionResult{}, false
 	}
 	id := *m.focusedAction
 	action, exists := m.cfg.ResolveAction(id)
 	if !exists {
-		return config.ActionID{}, config.Action{}, service.ActionResult{}, false
+		return config.ActionID{}, config.Action{}, app.ActionResult{}, false
 	}
-	state, _ := m.manager.ActionState(id)
+	state, _ := m.app.ActionState(id)
 	return id, action, state, true
 }

--- a/internal/ui/model_actions_test.go
+++ b/internal/ui/model_actions_test.go
@@ -8,8 +8,8 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/kranz-org/kranz/internal/app"
 	"github.com/kranz-org/kranz/internal/config"
-	"github.com/kranz-org/kranz/internal/service"
 )
 
 func TestSConfirmsBeforeStoppingRunningAction(t *testing.T) {
@@ -31,14 +31,14 @@ func TestSConfirmsBeforeStoppingRunningAction(t *testing.T) {
 	go func() { done <- command() }()
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		state, _ := model.manager.ActionState(*model.focusedAction)
-		if state.Status == service.ActionRunning && state.PID > 0 && strings.Contains(strings.Join(state.Stdout, ""), "started") {
+		state, _ := model.app.ActionState(*model.focusedAction)
+		if state.Status == app.ActionRunning && state.PID > 0 && strings.Contains(strings.Join(state.Stdout, ""), "started") {
 			break
 		}
 		time.Sleep(time.Millisecond)
 	}
-	state, _ := model.manager.ActionState(*model.focusedAction)
-	if state.Status != service.ActionRunning || state.PID <= 0 || !strings.Contains(strings.Join(state.Stdout, ""), "started") {
+	state, _ := model.app.ActionState(*model.focusedAction)
+	if state.Status != app.ActionRunning || state.PID <= 0 || !strings.Contains(strings.Join(state.Stdout, ""), "started") {
 		t.Fatalf("long-running action state = %#v", state)
 	}
 	buttons := model.actionButtons()
@@ -62,8 +62,8 @@ func TestSConfirmsBeforeStoppingRunningAction(t *testing.T) {
 	if stopCommand != nil || model.mode != ModeNormal || model.pendingAction != nil || model.pendingActionStop {
 		t.Fatalf("cancel stop = command %v, mode %v, action %#v, stop %v", stopCommand, model.mode, model.pendingAction, model.pendingActionStop)
 	}
-	state, _ = model.manager.ActionState(*model.focusedAction)
-	if state.Status != service.ActionRunning {
+	state, _ = model.app.ActionState(*model.focusedAction)
+	if state.Status != app.ActionRunning {
 		t.Fatalf("cancelled stop changed action state = %#v", state)
 	}
 
@@ -81,8 +81,8 @@ func TestSConfirmsBeforeStoppingRunningAction(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("stopped action did not finish")
 	}
-	state, _ = model.manager.ActionState(*model.focusedAction)
-	if state.Status != service.ActionCancelled {
+	state, _ = model.app.ActionState(*model.focusedAction)
+	if state.Status != app.ActionCancelled {
 		t.Fatalf("stopped action state = %#v", state)
 	}
 }
@@ -104,8 +104,8 @@ func TestEnterExpandsOwnerAndSRunsFocusedAction(t *testing.T) {
 	if command != nil {
 		t.Fatal("Enter scheduled a focused action")
 	}
-	state, _ := model.manager.ActionState(*model.focusedAction)
-	if state.Status != service.ActionReady {
+	state, _ := model.app.ActionState(*model.focusedAction)
+	if state.Status != app.ActionReady {
 		t.Fatalf("Enter changed action state = %#v", state)
 	}
 	if output := ansi.Strip(model.renderActionLogPanel(60, 8)); !strings.Contains(output, "Press s to run") || strings.Contains(output, "Press Enter") {
@@ -121,8 +121,8 @@ func TestEnterExpandsOwnerAndSRunsFocusedAction(t *testing.T) {
 		t.Fatal("s did not schedule focused action")
 	}
 	_, _ = model.Update(command())
-	state, _ = model.manager.ActionState(*model.focusedAction)
-	if state.Status != service.ActionSucceeded {
+	state, _ = model.app.ActionState(*model.focusedAction)
+	if state.Status != app.ActionSucceeded {
 		t.Fatalf("keyboard action state = %#v", state)
 	}
 }
@@ -171,7 +171,7 @@ func TestMouseClickFocusesActionForFooterRun(t *testing.T) {
 			t.Fatalf("%s scheduled a service command for focused action", action)
 		}
 	}
-	if status := model.FocusedService().Status(); status != config.StatusStopped {
+	if status := model.FocusedService().State.Status; status != config.StatusStopped {
 		t.Fatalf("service changed before action run: %s", status)
 	}
 	_, command := model.triggerAction("toggle")
@@ -179,11 +179,11 @@ func TestMouseClickFocusesActionForFooterRun(t *testing.T) {
 		t.Fatal("clicked action footer did not schedule the action")
 	}
 	_, _ = model.Update(command())
-	state, _ := model.manager.ActionState(*model.focusedAction)
-	if state.Status != service.ActionSucceeded {
+	state, _ := model.app.ActionState(*model.focusedAction)
+	if state.Status != app.ActionSucceeded {
 		t.Fatalf("clicked action status = %#v", state)
 	}
-	if status := model.FocusedService().Status(); status != config.StatusStopped {
+	if status := model.FocusedService().State.Status; status != config.StatusStopped {
 		t.Fatalf("action footer changed service status to %s", status)
 	}
 }
@@ -221,7 +221,7 @@ func TestActionGroupFooterCannotOperatePreviouslyFocusedService(t *testing.T) {
 			t.Fatalf("%s scheduled a service command for focused group", action)
 		}
 	}
-	if status := model.FocusedService().Status(); status != config.StatusStopped {
+	if status := model.FocusedService().State.Status; status != config.StatusStopped {
 		t.Fatalf("focused group changed service status to %s", status)
 	}
 	if len(model.selected) != selectedBefore {
@@ -252,7 +252,7 @@ func TestServiceActionsExpandNavigateRunAndRenderOutput(t *testing.T) {
 	}
 	model.moveServiceListCursor(1)
 	id, _, state, exists := model.focusedActionDefinition()
-	if !exists || id.Name != "inspect" || state.Status != service.ActionReady {
+	if !exists || id.Name != "inspect" || state.Status != app.ActionReady {
 		t.Fatalf("focused action = %#v, %#v, %v", id, state, exists)
 	}
 
@@ -267,7 +267,7 @@ func TestServiceActionsExpandNavigateRunAndRenderOutput(t *testing.T) {
 	_, _ = model.Update(message)
 
 	_, _, state, _ = model.focusedActionDefinition()
-	if state.Status != service.ActionSucceeded || state.ExitCode != 0 {
+	if state.Status != app.ActionSucceeded || state.ExitCode != 0 {
 		t.Fatalf("completed action state = %#v", state)
 	}
 	model.selected["app"] = true
@@ -402,13 +402,13 @@ func TestSelectionAndActionSuccessUseDistinctMarkers(t *testing.T) {
 	}{
 		"not selected": {selectionIndicator(false), 3},
 		"selected":     {selectionIndicator(true), 3},
-		"succeeded":    {actionStatusIndicator(service.ActionSucceeded), 1},
+		"succeeded":    {actionStatusIndicator(app.ActionSucceeded), 1},
 	} {
 		if width := lipgloss.Width(testCase.marker); width != testCase.width {
 			t.Errorf("%s marker width = %d, want %d", name, width, testCase.width)
 		}
 	}
-	if selected, succeeded := ansi.Strip(selectionIndicator(true)), ansi.Strip(actionStatusIndicator(service.ActionSucceeded)); selected != "[✓]" || succeeded != "✓" || selected == succeeded {
+	if selected, succeeded := ansi.Strip(selectionIndicator(true)), ansi.Strip(actionStatusIndicator(app.ActionSucceeded)); selected != "[✓]" || succeeded != "✓" || selected == succeeded {
 		t.Fatalf("selection/action markers = %q/%q, want distinct [✓]/✓", selected, succeeded)
 	}
 }
@@ -444,7 +444,7 @@ func TestActionOnlyGroupIsFocusableAndRunnable(t *testing.T) {
 	}
 	_, _ = model.Update(command())
 	_, _, state, exists := model.focusedActionDefinition()
-	if !exists || state.Status != service.ActionSucceeded || strings.TrimSpace(strings.Join(state.Stdout, "")) != "v1" {
+	if !exists || state.Status != app.ActionSucceeded || strings.TrimSpace(strings.Join(state.Stdout, "")) != "v1" {
 		t.Fatalf("group action state = %#v, %v", state, exists)
 	}
 }
@@ -480,7 +480,7 @@ func TestExpandedActionsDoNotInsertBlankRows(t *testing.T) {
 }
 
 func TestActionOutputCannotRepositionOrGrowTheDashboard(t *testing.T) {
-	state := service.ActionResult{
+	state := app.ActionResult{
 		Stdout: []string{"\x1b[2Jtransforming...\rnext\nbuilt\n"},
 		Stderr: []string{"warning\bretry\rfailed\n"},
 	}
@@ -534,8 +534,8 @@ func TestConfiguredActionConfirmationCanCancelOrRun(t *testing.T) {
 	if command != nil || model.mode != ModeNormal || model.pendingAction != nil {
 		t.Fatalf("cancel confirmation = command %v, mode %v, action %#v", command, model.mode, model.pendingAction)
 	}
-	state, _ := model.manager.ActionState(config.ActionID{OwnerKind: config.ActionOwnerService, Owner: "app", Name: "confirm"})
-	if state.Status != service.ActionReady {
+	state, _ := model.app.ActionState(config.ActionID{OwnerKind: config.ActionOwnerService, Owner: "app", Name: "confirm"})
+	if state.Status != app.ActionReady {
 		t.Fatalf("cancelled confirmation changed action state = %#v", state)
 	}
 
@@ -547,8 +547,8 @@ func TestConfiguredActionConfirmationCanCancelOrRun(t *testing.T) {
 		t.Fatalf("accept confirmation = command %v, mode %v, action %#v", command, model.mode, model.pendingAction)
 	}
 	_, _ = model.Update(command())
-	state, _ = model.manager.ActionState(config.ActionID{OwnerKind: config.ActionOwnerService, Owner: "app", Name: "confirm"})
-	if state.Status != service.ActionSucceeded {
+	state, _ = model.app.ActionState(config.ActionID{OwnerKind: config.ActionOwnerService, Owner: "app", Name: "confirm"})
+	if state.Status != app.ActionSucceeded {
 		t.Fatalf("confirmed action state = %#v", state)
 	}
 
@@ -571,8 +571,8 @@ func TestConfiguredActionConfirmationCanCancelOrRun(t *testing.T) {
 	}
 	// Cancelling leaves the action untouched.
 	_, _ = model.handleConfirmActionKeys(tea.KeyMsg{Type: tea.KeyEsc})
-	state, _ = model.manager.ActionState(interactiveID)
-	if state.Status != service.ActionReady {
+	state, _ = model.app.ActionState(interactiveID)
+	if state.Status != app.ActionReady {
 		t.Fatalf("cancelled handoff state = %#v, want ready", state)
 	}
 
@@ -584,8 +584,8 @@ func TestConfiguredActionConfirmationCanCancelOrRun(t *testing.T) {
 	if command == nil {
 		t.Fatal("accepted handoff produced no command")
 	}
-	state, _ = model.manager.ActionState(interactiveID)
-	if state.Status != service.ActionRunning {
+	state, _ = model.app.ActionState(interactiveID)
+	if state.Status != app.ActionRunning {
 		t.Fatalf("accepted handoff state = %#v, want running while the terminal is handed over", state)
 	}
 }
@@ -607,8 +607,8 @@ func TestStartConfirmFlagDoesNotBypassStopConfirmation(t *testing.T) {
 	go func() { done <- command() }()
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		state, _ := model.manager.ActionState(id)
-		if state.Status == service.ActionRunning {
+		state, _ := model.app.ActionState(id)
+		if state.Status == app.ActionRunning {
 			break
 		}
 		time.Sleep(time.Millisecond)
@@ -628,8 +628,8 @@ func TestStartConfirmFlagDoesNotBypassStopConfirmation(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("stopped confirmed action did not finish")
 	}
-	state, _ := model.manager.ActionState(id)
-	if state.Status != service.ActionCancelled {
+	state, _ := model.app.ActionState(id)
+	if state.Status != app.ActionCancelled {
 		t.Fatalf("stopped confirmed action state = %#v", state)
 	}
 }

--- a/internal/ui/model_appearance.go
+++ b/internal/ui/model_appearance.go
@@ -570,7 +570,7 @@ func (m *Model) saveThemePickerToProject() {
 		}
 		m.addNotification("appearance", "Project appearance saved to "+path, config.LogInfo)
 	}
-	m.configStamps, _ = readConfigStamps(m.configWatchPaths)
+	m.app.AcknowledgeExternalWrite()
 	m.mode = ModeNormal
 }
 

--- a/internal/ui/model_appearance_test.go
+++ b/internal/ui/model_appearance_test.go
@@ -980,11 +980,7 @@ func TestThemePickerSurvivesConfigReload(t *testing.T) {
 			model.activeTheme.Accent, model.themePickerBackground(), model.themeColorMode)
 	}
 
-	reloaded, err := config.Load(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, _ = model.Update(configReloadMsg{cfg: reloaded, changed: true})
+	reloadModelForTest(t, model)
 
 	if model.activeTheme.Accent != "#FF0000" {
 		t.Errorf("reload reverted the typed accent to %q while the panel still shows %q",

--- a/internal/ui/model_config.go
+++ b/internal/ui/model_config.go
@@ -2,77 +2,52 @@ package ui
 
 import (
 	"fmt"
-	"os"
-	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/kranz-org/kranz/internal/config"
 )
 
-// Configuration hot reload. Edits are reconciled into the running manager, and
-// an invalid file leaves the last known good runtime untouched.
+// Configuration hot reload. The stamping, debounce, and ApplyConfig work
+// itself lives in internal/app; this file only reacts to the result on the
+// Bubble Tea goroutine — reconciling focus, appearance, and notifications.
 
 func (m *Model) reloadConfig(force bool) tea.Cmd {
-	if len(m.configPaths) == 0 || m.reloadBusy || m.operation != "" {
+	if m.operation != "" {
 		return nil
 	}
-	if !force && time.Since(m.lastConfigScan) < time.Second {
-		return nil
-	}
-	m.lastConfigScan = time.Now()
-	m.reloadBusy = true
-	paths := append([]string(nil), m.configPaths...)
-	watchPaths := append([]string(nil), m.configWatchPaths...)
-	previous := cloneConfigStamps(m.configStamps)
+	before := m.app.Project().Generation
 	return func() tea.Msg {
-		stamps, err := readConfigStamps(watchPaths)
+		result, err := m.app.Reload(force)
 		if err != nil {
-			return configReloadMsg{stamps: stamps, err: err}
+			return configReloadMsg{err: err}
 		}
-		changed := force || !equalConfigStamps(previous, stamps)
-		if !changed {
-			return configReloadMsg{stamps: stamps}
-		}
-		cfg, err := config.LoadFiles(paths)
-		return configReloadMsg{cfg: cfg, stamps: stamps, err: err, changed: true}
+		project := m.app.Project()
+		return configReloadMsg{result: result, generation: project.Generation, changed: project.Generation != before}
 	}
 }
 
 func (m *Model) handleConfigReload(msg configReloadMsg) (tea.Model, tea.Cmd) {
-	m.reloadBusy = false
-	if msg.stamps != nil {
-		m.configStamps = msg.stamps
-	}
 	if msg.err != nil {
 		m.addNotification("config", "Reload failed: "+msg.err.Error(), config.LogError)
 		return m, nil
 	}
-	if !msg.changed || msg.cfg == nil {
+	if !msg.changed {
 		return m, nil
 	}
 	focusedName := ""
 	if svc := m.FocusedService(); svc != nil {
 		focusedName = svc.Name
 	}
-	result, err := m.manager.ApplyConfig(msg.cfg)
-	if err != nil {
-		m.addNotification("config", "Reload failed: "+err.Error(), config.LogError)
-		return m, nil
-	}
-	m.cfg = msg.cfg
+	m.cfg = m.app.Config()
 	if m.focusedAction != nil {
-		if _, exists := msg.cfg.ResolveAction(*m.focusedAction); !exists {
+		if _, exists := m.cfg.ResolveAction(*m.focusedAction); !exists {
 			m.focusedAction = nil
 		}
 	}
 	if m.focusedActionGroup != "" {
-		if _, exists := msg.cfg.ActionGroups[m.focusedActionGroup]; !exists {
+		if _, exists := m.cfg.ActionGroups[m.focusedActionGroup]; !exists {
 			m.focusedActionGroup = ""
 		}
-	}
-	m.configWatchPaths = watchedConfigPaths(m.configPaths, msg.cfg.WatchPaths)
-	if stamps, stampErr := readConfigStamps(m.configWatchPaths); stampErr == nil {
-		m.configStamps = stamps
 	}
 	m.refreshServices()
 	for index, svc := range m.services {
@@ -99,58 +74,7 @@ func (m *Model) handleConfigReload(msg configReloadMsg) (tea.Model, tea.Cmd) {
 		m.addNotification("appearance", err.Error(), config.LogWarn)
 	}
 	message := fmt.Sprintf("Configuration reloaded: %d added, %d removed, %d updated, %d restarted",
-		len(result.Added), len(result.Removed), len(result.Updated), len(result.Restarted))
+		len(msg.result.Added), len(msg.result.Removed), len(msg.result.Updated), len(msg.result.Restarted))
 	m.addNotification("config", message, config.LogInfo)
 	return m, m.scanFocusedPorts(true)
-}
-
-func readConfigStamps(paths []string) (map[string]configStamp, error) {
-	result := make(map[string]configStamp, len(paths))
-	for _, path := range paths {
-		info, err := os.Stat(path)
-		if os.IsNotExist(err) {
-			result[path] = configStamp{}
-			continue
-		}
-		if err != nil {
-			return result, fmt.Errorf("stat %s: %w", path, err)
-		}
-		result[path] = configStamp{Modified: info.ModTime().UnixNano(), Size: info.Size()}
-	}
-	return result, nil
-}
-
-func watchedConfigPaths(configPaths, auxiliaryPaths []string) []string {
-	result := append([]string(nil), configPaths...)
-	seen := make(map[string]bool, len(result)+len(auxiliaryPaths))
-	for _, path := range result {
-		seen[path] = true
-	}
-	for _, path := range auxiliaryPaths {
-		if path != "" && !seen[path] {
-			seen[path] = true
-			result = append(result, path)
-		}
-	}
-	return result
-}
-
-func cloneConfigStamps(source map[string]configStamp) map[string]configStamp {
-	result := make(map[string]configStamp, len(source))
-	for path, stamp := range source {
-		result[path] = stamp
-	}
-	return result
-}
-
-func equalConfigStamps(left, right map[string]configStamp) bool {
-	if len(left) != len(right) {
-		return false
-	}
-	for path, stamp := range left {
-		if right[path] != stamp {
-			return false
-		}
-	}
-	return true
 }

--- a/internal/ui/model_details_test.go
+++ b/internal/ui/model_details_test.go
@@ -10,8 +10,8 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/kranz-org/kranz/internal/app"
 	"github.com/kranz-org/kranz/internal/config"
-	"github.com/kranz-org/kranz/internal/service"
 	"github.com/muesli/termenv"
 )
 
@@ -97,7 +97,7 @@ func TestExternalPortConflictOffersVerifiedStopAction(t *testing.T) {
 	defer model.Shutdown()
 	model.width, model.height, model.ready = 100, 32, true
 	model.operationID = 7
-	conflict := &service.PortConflictError{
+	conflict := &app.PortConflictError{
 		Service: "api", Port: 8080, PID: 4242, Process: "outside", Command: "outside --serve", External: true,
 	}
 	_, _ = model.Update(operationResultMsg{id: 7, target: "selection", err: conflict})
@@ -110,7 +110,7 @@ func TestExternalPortConflictOffersVerifiedStopAction(t *testing.T) {
 			t.Errorf("port conflict modal does not contain %q:\n%s", expected, plain)
 		}
 	}
-	model.portChecker = fakePortChecker{details: map[int]*config.PortInfo{8080: {Port: 8080, PID: 4242}}}
+	model.app.SetPortChecker(fakePortChecker{details: map[int]*config.PortInfo{8080: {Port: 8080, PID: 4242}}})
 	_, command := model.handleKeyMsg(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
 	if command == nil {
 		t.Fatal("k did not schedule a verified external-process stop")
@@ -120,7 +120,7 @@ func TestExternalPortConflictOffersVerifiedStopAction(t *testing.T) {
 func TestPortReleaseRefusesChangedOwner(t *testing.T) {
 	model := newTestModel()
 	defer model.Shutdown()
-	model.portChecker = fakePortChecker{details: map[int]*config.PortInfo{8080: {Port: 8080, PID: 5252}}}
+	model.app.SetPortChecker(fakePortChecker{details: map[int]*config.PortInfo{8080: {Port: 8080, PID: 5252}}})
 	message := model.releaseExternalPort(8080, 4242)().(releasePortResultMsg)
 	if message.err == nil || !strings.Contains(message.err.Error(), "owner changed") {
 		t.Fatalf("changed-owner result = %v", message.err)
@@ -145,9 +145,9 @@ func TestServiceDetailsUseAsyncPortInspection(t *testing.T) {
 		Readiness: &config.CheckConfig{Type: config.CheckHTTP, URL: "http://127.0.0.1:8080/ready"},
 		Liveness:  &config.CheckConfig{Type: config.CheckTCP, Port: 8080},
 	}
-	model.portChecker = fakePortChecker{details: map[int]*config.PortInfo{
+	model.app.SetPortChecker(fakePortChecker{details: map[int]*config.PortInfo{
 		8080: {Port: 8080, Address: "127.0.0.1", Protocol: "tcp", PID: 4321, Process: "test-api"},
-	}}
+	}})
 
 	command := model.scanFocusedPorts(true)
 	if command == nil {

--- a/internal/ui/model_keys.go
+++ b/internal/ui/model_keys.go
@@ -87,7 +87,7 @@ func (m *Model) handleNormalKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	if key.Matches(msg, m.keys.Quit) {
-		if m.manager.HasRunningServices() || m.operation != "" {
+		if m.app.HasRunningServices() || m.operation != "" {
 			m.mode = ModeConfirmQuit
 			return m, nil
 		}
@@ -272,7 +272,7 @@ func (m *Model) triggerAction(action string) (tea.Model, tea.Cmd) {
 		m.toggleAllSelection()
 		return m, nil
 	case "quit":
-		if m.manager.HasRunningServices() || m.operation != "" {
+		if m.app.HasRunningServices() || m.operation != "" {
 			m.mode = ModeConfirmQuit
 			return m, nil
 		}

--- a/internal/ui/model_lifecycle.go
+++ b/internal/ui/model_lifecycle.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/kranz-org/kranz/internal/app"
 	"github.com/kranz-org/kranz/internal/config"
-	"github.com/kranz-org/kranz/internal/service"
 )
 
 // Service lifecycle from the dashboard: resolving what a key targets, running
@@ -22,8 +22,7 @@ func (m *Model) Shutdown() error {
 		if m.operationCancel != nil {
 			m.operationCancel()
 		}
-		m.shutdownErr = m.manager.Shutdown()
-		m.healthChecker.StopAll()
+		m.shutdownErr = m.app.Shutdown()
 	})
 	return m.shutdownErr
 }
@@ -59,20 +58,20 @@ func (m *Model) handleLifecycleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 			m.pendingStopAll = true
 			return model, command, true
 		}
-		model, command := m.beginOperation(operationStopAll, "all services", "Stopping all services", m.manager.StopAll)
+		model, command := m.beginOperation(operationStopAll, "all services", "Stopping all services", m.app.StopAll)
 		return model, command, true
 	case key.Matches(msg, m.keys.Restart):
 		model, command := m.restartSelectedService()
 		return model, command, true
 	case key.Matches(msg, m.keys.RestartAll):
-		if m.manager.HasRunningServices() {
+		if m.app.HasRunningServices() {
 			m.mode = ModeConfirmRestart
 			m.confirmTarget = "running services"
 			m.confirmAction = ""
 			m.confirmRestartAll = true
 			return m, nil, true
 		}
-		model, command := m.beginOperation(operationRestartAll, "running services", "Restarting services", m.manager.RestartAll)
+		model, command := m.beginOperation(operationRestartAll, "running services", "Restarting services", m.app.RestartAll)
 		return model, command, true
 	default:
 		return m, nil, false
@@ -80,7 +79,7 @@ func (m *Model) handleLifecycleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 }
 
 func (m *Model) beginClearLogs() bool {
-	var svc *service.Service
+	var svc *app.ServiceSnapshot
 	switch m.panelFocus {
 	case panelLogs:
 		svc = m.FocusedService()
@@ -99,10 +98,10 @@ func (m *Model) beginClearLogs() bool {
 }
 
 func (m *Model) clearConfirmedLogs() {
-	svc, ok := m.manager.GetService(m.clearTarget)
+	svc, ok := m.app.Service(m.clearTarget)
 	if ok {
-		svc.ClearLogs()
-		svc.ResetNewLogCount()
+		m.app.ClearLogs(svc.Name)
+		svc.State.NewLogCount = 0
 		if focused := m.FocusedService(); focused != nil && focused.Name == svc.Name {
 			m.logOffset, m.logAnchor, m.followMode, m.logPaused = 0, 0, true, false
 			m.currentMatch = -1
@@ -122,7 +121,7 @@ func (m *Model) startSelectedService() (tea.Model, tea.Cmd) {
 	if svc == nil {
 		return m, nil
 	}
-	if !svc.CanStart() {
+	if !svc.CanStart {
 		m.addNotification(svc.Name, "Service is already running. Press s to stop it.", config.LogInfo)
 		return m, nil
 	}
@@ -131,7 +130,7 @@ func (m *Model) startSelectedService() (tea.Model, tea.Cmd) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	return m.beginCancelableOperation(operationStart, svc.Name, "Starting "+svc.Name, cancel, func() error {
-		return m.manager.StartServicesContext(ctx, []string{svc.Name})
+		return m.app.StartServicesContext(ctx, []string{svc.Name})
 	})
 }
 
@@ -202,8 +201,8 @@ func (m *Model) toggleSelectedServices() (tea.Model, tea.Cmd) {
 
 	allActive := true
 	for _, name := range names {
-		svc, ok := m.manager.GetService(name)
-		if !ok || !serviceStartPlanned(svc) {
+		svc, ok := m.app.Service(name)
+		if !ok || !app.ServiceStartPlanned(svc) {
 			allActive = false
 			break
 		}
@@ -211,8 +210,8 @@ func (m *Model) toggleSelectedServices() (tea.Model, tea.Cmd) {
 	target := m.selectedTargetLabel(names)
 	if allActive {
 		for _, name := range names {
-			svc, ok := m.manager.GetService(name)
-			if ok && !svc.CanStop() {
+			svc, ok := m.app.Service(name)
+			if ok && !svc.CanStop {
 				m.addNotification(name, "Service has no stop capability", config.LogWarn)
 				return m, nil
 			}
@@ -222,12 +221,12 @@ func (m *Model) toggleSelectedServices() (tea.Model, tea.Cmd) {
 			return m.beginServiceStopConfirmation(names, target, false)
 		}
 		return m.beginOperation(operationStopSet, target, "Stopping "+target, func() error {
-			return m.manager.StopServices(names)
+			return m.app.StopServices(names)
 		})
 	}
 	for _, name := range names {
-		svc, ok := m.manager.GetService(name)
-		if ok && !serviceStartPlanned(svc) && !svc.CanStart() {
+		svc, ok := m.app.Service(name)
+		if ok && !app.ServiceStartPlanned(svc) && !svc.CanStart {
 			m.addNotification(name, "Service has no start capability", config.LogWarn)
 			return m, nil
 		}
@@ -237,16 +236,8 @@ func (m *Model) toggleSelectedServices() (tea.Model, tea.Cmd) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	return m.beginCancelableOperation(operationStartSet, target, "Starting "+target, cancel, func() error {
-		return m.manager.StartServicesContext(ctx, names)
+		return m.app.StartServicesContext(ctx, names)
 	})
-}
-
-func serviceStartPlanned(svc *service.Service) bool {
-	status := svc.Status()
-	if status == config.StatusUnknown {
-		return svc.DesiredRunning()
-	}
-	return status != config.StatusStopped || svc.DesiredRunning()
 }
 
 func (m *Model) forceToggleSelectedServices() (tea.Model, tea.Cmd) {
@@ -261,16 +252,16 @@ func (m *Model) forceToggleSelectedServices() (tea.Model, tea.Cmd) {
 	target := m.selectedTargetLabel(names)
 	allRunning := true
 	for _, name := range names {
-		svc, ok := m.manager.GetService(name)
-		if !ok || svc.CanStart() {
+		svc, ok := m.app.Service(name)
+		if !ok || svc.CanStart {
 			allRunning = false
 			break
 		}
 	}
 	if allRunning {
 		for _, name := range names {
-			svc, ok := m.manager.GetService(name)
-			if ok && !svc.CanStop() {
+			svc, ok := m.app.Service(name)
+			if ok && !svc.CanStop {
 				m.addNotification(name, "Service has no stop capability", config.LogWarn)
 				return m, nil
 			}
@@ -279,12 +270,12 @@ func (m *Model) forceToggleSelectedServices() (tea.Model, tea.Cmd) {
 			return m.beginServiceStopConfirmation(names, target, true)
 		}
 		return m.beginOperation(operationForceStop, target, "Force stopping "+target, func() error {
-			return m.manager.ForceStopServices(names)
+			return m.app.ForceStopServices(names)
 		})
 	}
 	for _, name := range names {
-		svc, ok := m.manager.GetService(name)
-		if ok && !serviceStartPlanned(svc) && !svc.CanStart() {
+		svc, ok := m.app.Service(name)
+		if ok && !app.ServiceStartPlanned(svc) && !svc.CanStart {
 			m.addNotification(name, "Service has no start capability", config.LogWarn)
 			return m, nil
 		}
@@ -293,40 +284,12 @@ func (m *Model) forceToggleSelectedServices() (tea.Model, tea.Cmd) {
 		return m.beginServiceStartConfirmation(names, target, true)
 	}
 	return m.beginOperation(operationForceStart, target, "Force starting "+target, func() error {
-		return m.manager.ForceStartServices(names)
+		return m.app.ForceStartServices(names)
 	})
 }
 
 func (m *Model) requiresStartConfirmation(names []string, includeDependencies bool) bool {
-	return len(m.startConfirmationServiceNames(names, includeDependencies)) > 0
-}
-
-func (m *Model) startConfirmationServiceNames(names []string, includeDependencies bool) []string {
-	selected := make(map[string]bool)
-	confirmed := make([]string, 0, len(names))
-	var visit func(string)
-	visit = func(name string) {
-		if selected[name] {
-			return
-		}
-		selected[name] = true
-		if includeDependencies {
-			for _, dependency := range m.cfg.Services[name].DependsOn {
-				visit(dependency)
-			}
-		}
-		svc, ok := m.manager.GetService(name)
-		if !ok || !svc.CanStart() {
-			return
-		}
-		if start := svc.Config.StartAction(); start != nil && start.ConfirmationRequired() {
-			confirmed = append(confirmed, name)
-		}
-	}
-	for _, name := range names {
-		visit(name)
-	}
-	return confirmed
+	return len(m.app.StartConfirmationNames(names, includeDependencies)) > 0
 }
 
 func (m *Model) beginServiceStartConfirmation(names []string, target string, force bool) (tea.Model, tea.Cmd) {
@@ -344,12 +307,12 @@ func (m *Model) confirmServiceStart() (tea.Model, tea.Cmd) {
 	m.cancelServiceStartConfirmation()
 	if force {
 		return m.beginOperation(operationForceStart, target, "Force starting "+target, func() error {
-			return m.manager.ForceStartServices(names)
+			return m.app.ForceStartServices(names)
 		})
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	return m.beginCancelableOperation(operationStartSet, target, "Starting "+target, cancel, func() error {
-		return m.manager.StartServicesContext(ctx, names)
+		return m.app.StartServicesContext(ctx, names)
 	})
 }
 
@@ -375,10 +338,10 @@ func (m *Model) restartSelectedService() (tea.Model, tea.Cmd) {
 	if svc == nil {
 		return m, nil
 	}
-	if svc.CanStart() {
+	if svc.CanStart {
 		return m.startSelectedService()
 	}
-	affected := m.manager.GetAffectedServices(svc.Name)
+	affected := m.app.AffectedServices(svc.Name)
 	m.mode = ModeConfirmRestart
 	m.confirmTarget = svc.Name
 	m.confirmRestartAll = false
@@ -391,13 +354,7 @@ func (m *Model) restartSelectedService() (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) requiresStopConfirmation(names []string) bool {
-	for _, name := range names {
-		svc, ok := m.manager.GetService(name)
-		if ok && svc.CanStop() {
-			return true
-		}
-	}
-	return false
+	return m.app.RequiresStopConfirmation(names)
 }
 
 func (m *Model) beginServiceStopConfirmation(names []string, target string, force bool) (tea.Model, tea.Cmd) {
@@ -415,15 +372,15 @@ func (m *Model) confirmServiceStop() (tea.Model, tea.Cmd) {
 	stopAll := m.pendingStopAll
 	m.cancelServiceStopConfirmation()
 	if stopAll {
-		return m.beginOperation(operationStopAll, target, "Stopping all services", m.manager.StopAll)
+		return m.beginOperation(operationStopAll, target, "Stopping all services", m.app.StopAll)
 	}
 	if force {
 		return m.beginOperation(operationForceStop, target, "Force stopping "+target, func() error {
-			return m.manager.ForceStopServices(names)
+			return m.app.ForceStopServices(names)
 		})
 	}
 	return m.beginOperation(operationStopSet, target, "Stopping "+target, func() error {
-		return m.manager.StopServices(names)
+		return m.app.StopServices(names)
 	})
 }
 
@@ -448,7 +405,7 @@ func (m *Model) handleConfirmServiceStopKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd
 func (m *Model) beginRestart(name string) (tea.Model, tea.Cmd) {
 	m.mode = ModeNormal
 	return m.beginOperation(operationRestart, name, "Restarting "+name, func() error {
-		return m.manager.RestartService(name)
+		return m.app.RestartService(name)
 	})
 }
 
@@ -493,8 +450,12 @@ func (m *Model) handleOperationResult(msg operationResultMsg) (tea.Model, tea.Cm
 	m.operation = ""
 	m.operationKind = ""
 	m.operationCancel = nil
+	// A snapshot taken before this operation ran is now stale: refresh
+	// immediately rather than waiting for the next 250ms tick, so a test or
+	// a fast follow-up keypress sees the state the operation just produced.
+	m.refreshServices()
 	if msg.err != nil {
-		var conflict *service.PortConflictError
+		var conflict *app.PortConflictError
 		if errors.As(msg.err, &conflict) {
 			m.conflictService = conflict.Service
 			if m.conflictService == "" {
@@ -573,7 +534,7 @@ func (m *Model) confirmRestart() (tea.Model, tea.Cmd) {
 	if m.confirmRestartAll {
 		m.confirmRestartAll = false
 		m.mode = ModeNormal
-		return m.beginOperation(operationRestartAll, "running services", "Restarting services", m.manager.RestartAll)
+		return m.beginOperation(operationRestartAll, "running services", "Restarting services", m.app.RestartAll)
 	}
 	return m.beginRestart(m.confirmTarget)
 }

--- a/internal/ui/model_lifecycle_test.go
+++ b/internal/ui/model_lifecycle_test.go
@@ -9,8 +9,8 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/kranz-org/kranz/internal/app"
 	"github.com/kranz-org/kranz/internal/config"
-	"github.com/kranz-org/kranz/internal/service"
 )
 
 // Tests for service lifecycle actions driven from the dashboard.
@@ -24,8 +24,8 @@ func TestEnterDoesNotControlServiceLifecycle(t *testing.T) {
 	if command != nil {
 		t.Fatal("Enter scheduled a lifecycle operation")
 	}
-	if serviceInstance.Status() != config.StatusStopped {
-		t.Fatalf("Enter changed status to %s", serviceInstance.Status())
+	if serviceInstance.State.Status != config.StatusStopped {
+		t.Fatalf("Enter changed status to %s", serviceInstance.State.Status)
 	}
 }
 
@@ -43,16 +43,16 @@ func TestDetachedServiceStartsFromUnknownAndConfirmsStop(t *testing.T) {
 	}}, "test")
 	defer model.Shutdown()
 	model.width, model.height, model.ready = 100, 30, true
-	if model.FocusedService().Status() != config.StatusUnknown {
-		t.Fatalf("initial status = %s", model.FocusedService().Status())
+	if model.FocusedService().State.Status != config.StatusUnknown {
+		t.Fatalf("initial status = %s", model.FocusedService().State.Status)
 	}
 	_, command := model.handleKeyMsg(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
 	if command == nil {
 		t.Fatal("detached start was not scheduled")
 	}
 	_, _ = model.Update(command())
-	if model.FocusedService().Status() != config.StatusRunning {
-		t.Fatalf("started status = %s", model.FocusedService().Status())
+	if model.FocusedService().State.Status != config.StatusRunning {
+		t.Fatalf("started status = %s", model.FocusedService().State.Status)
 	}
 	_, command = model.handleKeyMsg(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'A'}})
 	if command != nil || model.mode != ModeConfirmServiceStop || !model.pendingStopAll {
@@ -68,7 +68,7 @@ func TestDetachedServiceStartsFromUnknownAndConfirmsStop(t *testing.T) {
 		t.Fatalf("detached stop modal:\n%s", view)
 	}
 	_, command = model.handleConfirmServiceStopKeys(tea.KeyMsg{Type: tea.KeyEsc})
-	if command != nil || model.FocusedService().Status() != config.StatusRunning {
+	if command != nil || model.FocusedService().State.Status != config.StatusRunning {
 		t.Fatal("cancelled stop changed service")
 	}
 	_, _ = model.handleKeyMsg(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
@@ -77,20 +77,24 @@ func TestDetachedServiceStartsFromUnknownAndConfirmsStop(t *testing.T) {
 		t.Fatal("confirmed stop was not scheduled")
 	}
 	_, _ = model.Update(command())
-	if model.FocusedService().Status() != config.StatusStopped {
-		t.Fatalf("stopped status = %s", model.FocusedService().Status())
+	if model.FocusedService().State.Status != config.StatusStopped {
+		t.Fatalf("stopped status = %s", model.FocusedService().State.Status)
 	}
 }
 
 func TestUnobservedDetachedServiceUsesNeutralExternalVisualState(t *testing.T) {
 	model := &Model{}
-	unobserved := service.NewService("remote", config.Service{
-		Supervision: config.SupervisionDetached,
-		Lifecycle: config.LifecycleConfig{
-			Start: &config.Action{Command: "true"},
-			Stop:  &config.Action{Command: "true"},
+	unobserved := &app.ServiceSnapshot{
+		Name: "remote",
+		Config: config.Service{
+			Supervision: config.SupervisionDetached,
+			Lifecycle: config.LifecycleConfig{
+				Start: &config.Action{Command: "true"},
+				Stop:  &config.Action{Command: "true"},
+			},
 		},
-	}, 10)
+		State: config.ServiceState{Status: config.StatusUnknown},
+	}
 	if state := model.serviceVisualState(unobserved); state != visualExternal {
 		t.Fatalf("unobserved detached visual state = %v, want external", state)
 	}
@@ -98,12 +102,16 @@ func TestUnobservedDetachedServiceUsesNeutralExternalVisualState(t *testing.T) {
 		t.Fatalf("unobserved detached label = %q, want External", label)
 	}
 
-	observed := service.NewService("remote", config.Service{
-		Supervision: config.SupervisionDetached,
-		Lifecycle: config.LifecycleConfig{Status: &config.LifecycleStatusConfig{
-			CheckConfig: config.CheckConfig{Type: config.CheckCommand, Command: "exit 4"},
-		}},
-	}, 10)
+	observed := &app.ServiceSnapshot{
+		Name: "remote",
+		Config: config.Service{
+			Supervision: config.SupervisionDetached,
+			Lifecycle: config.LifecycleConfig{Status: &config.LifecycleStatusConfig{
+				CheckConfig: config.CheckConfig{Type: config.CheckCommand, Command: "exit 4"},
+			}},
+		},
+		State: config.ServiceState{Status: config.StatusUnknown},
+	}
 	if state := model.serviceVisualState(observed); state != visualChecking {
 		t.Fatalf("unobserved status probe visual state = %v, want checking", state)
 	}
@@ -199,7 +207,8 @@ func TestStartConfirmationIdentifiesConfirmedDependencyCommand(t *testing.T) {
 func TestRestartOperationsConfirmTheirStopPhase(t *testing.T) {
 	model := newTestModel()
 	defer model.Shutdown()
-	model.FocusedService().SetStatus(config.StatusRunning)
+	model.app.SetServiceStatusForTest(model.FocusedService().Name, config.StatusRunning)
+	model.refreshServices()
 
 	_, command := model.handleKeyMsg(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
 	if command != nil || model.mode != ModeConfirmRestart || model.confirmRestartAll {
@@ -242,9 +251,10 @@ func TestSStopsTargetsWhenAllAreActive(t *testing.T) {
 	model := newTestModel()
 	defer model.Shutdown()
 	for _, svc := range model.allServices {
-		svc.SetStatus(config.StatusRunning)
+		model.app.SetServiceStatusForTest(svc.Name, config.StatusRunning)
 		model.selected[svc.Name] = true
 	}
+	model.refreshServices()
 
 	_, command := model.handleKeyMsg(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
 	command = acceptServiceStop(t, model, command)
@@ -252,9 +262,10 @@ func TestSStopsTargetsWhenAllAreActive(t *testing.T) {
 	if message.kind != operationStopSet || message.err != nil {
 		t.Fatalf("selection result = kind %q, error %v", message.kind, message.err)
 	}
+	model.refreshServices()
 	for _, svc := range model.allServices {
-		if svc.Status() != config.StatusStopped {
-			t.Errorf("service %s status = %s", svc.Name, svc.Status())
+		if svc.State.Status != config.StatusStopped {
+			t.Errorf("service %s status = %s", svc.Name, svc.State.Status)
 		}
 	}
 }
@@ -338,14 +349,14 @@ func TestStopInterruptsReadinessGatedStart(t *testing.T) {
 	_, startCommand := model.toggleSelectedServices()
 	startResult := make(chan operationResultMsg, 1)
 	go func() { startResult <- startCommand().(operationResultMsg) }()
-	waitForServiceStatus(t, model.FocusedService(), config.StatusRunning)
+	waitForServiceStatus(t, model, model.FocusedService().Name, config.StatusRunning)
 
 	_, stopCommand := model.toggleSelectedServices()
 	stopCommand = acceptServiceStop(t, model, stopCommand)
 	stopMessage := stopCommand().(operationResultMsg)
 	_, _ = model.Update(stopMessage)
-	if model.FocusedService().Status() != config.StatusStopped {
-		t.Fatalf("service status = %s after interrupted stop", model.FocusedService().Status())
+	if model.FocusedService().State.Status != config.StatusStopped {
+		t.Fatalf("service status = %s after interrupted stop", model.FocusedService().State.Status)
 	}
 	select {
 	case stale := <-startResult:
@@ -369,10 +380,10 @@ func TestShiftSForceStartsOnlySelectedService(t *testing.T) {
 	}
 	message := command().(operationResultMsg)
 	_, _ = model.Update(message)
-	api, _ := model.manager.GetService("api")
-	database, _ := model.manager.GetService("database")
-	if api.Status() != config.StatusRunning || database.Status() != config.StatusStopped {
-		t.Fatalf("force start statuses: api=%s database=%s", api.Status(), database.Status())
+	api, _ := model.app.Service("api")
+	database, _ := model.app.Service("database")
+	if api.State.Status != config.StatusRunning || database.State.Status != config.StatusStopped {
+		t.Fatalf("force start statuses: api=%s database=%s", api.State.Status, database.State.Status)
 	}
 	if !strings.Contains(model.toastMessage, "without dependencies") {
 		t.Fatalf("force start notification = %q", model.toastMessage)
@@ -386,7 +397,7 @@ func TestSStopsDependentsAndShiftSStopsOnlySelectedService(t *testing.T) {
 			"backend":  {Command: "sleep 60", Dir: ".", Shell: "sh"},
 			"frontend": {Command: "sleep 60", Dir: ".", Shell: "sh", DependsOn: []string{"backend"}},
 		}}, "test")
-		if err := model.manager.ForceStartServices([]string{"backend", "frontend"}); err != nil {
+		if err := model.app.ForceStartServices([]string{"backend", "frontend"}); err != nil {
 			model.Shutdown()
 			t.Fatal(err)
 		}
@@ -404,9 +415,9 @@ func TestSStopsDependentsAndShiftSStopsOnlySelectedService(t *testing.T) {
 		}
 		_, _ = model.Update(command().(operationResultMsg))
 		for _, name := range []string{"backend", "frontend"} {
-			svc, _ := model.manager.GetService(name)
-			if svc.Status() != config.StatusStopped {
-				t.Errorf("%s status = %s, want stopped", name, svc.Status())
+			svc, _ := model.app.Service(name)
+			if svc.State.Status != config.StatusStopped {
+				t.Errorf("%s status = %s, want stopped", name, svc.State.Status)
 			}
 		}
 		if !strings.Contains(model.toastMessage, "dependent services stopped") {
@@ -423,10 +434,10 @@ func TestSStopsDependentsAndShiftSStopsOnlySelectedService(t *testing.T) {
 			t.Fatal("Shift+S did not schedule force stop")
 		}
 		_, _ = model.Update(command().(operationResultMsg))
-		backend, _ := model.manager.GetService("backend")
-		frontend, _ := model.manager.GetService("frontend")
-		if backend.Status() != config.StatusStopped || frontend.Status() != config.StatusRunning {
-			t.Fatalf("force stop statuses: backend=%s frontend=%s", backend.Status(), frontend.Status())
+		backend, _ := model.app.Service("backend")
+		frontend, _ := model.app.Service("frontend")
+		if backend.State.Status != config.StatusStopped || frontend.State.Status != config.StatusRunning {
+			t.Fatalf("force stop statuses: backend=%s frontend=%s", backend.State.Status, frontend.State.Status)
 		}
 		if !strings.Contains(model.toastMessage, "without stopping dependents") {
 			t.Fatalf("force stop notification = %q", model.toastMessage)
@@ -462,13 +473,14 @@ func TestShiftSOverridesQueuedDependencyStart(t *testing.T) {
 	_, queuedCommand := model.toggleSelectedServices()
 	queuedResult := make(chan operationResultMsg, 1)
 	go func() { queuedResult <- queuedCommand().(operationResultMsg) }()
-	api, _ := model.manager.GetService("api")
+	api, _ := model.app.Service("api")
 	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) && (api.Status() != config.StatusStopped || !api.DesiredRunning()) {
+	for time.Now().Before(deadline) && (api.State.Status != config.StatusStopped || !api.DesiredRunning) {
 		time.Sleep(10 * time.Millisecond)
+		api, _ = model.app.Service("api")
 	}
-	if api.Status() != config.StatusStopped || !api.DesiredRunning() {
-		t.Fatalf("api did not enter queued state: status=%s desired=%v", api.Status(), api.DesiredRunning())
+	if api.State.Status != config.StatusStopped || !api.DesiredRunning {
+		t.Fatalf("api did not enter queued state: status=%s desired=%v", api.State.Status, api.DesiredRunning)
 	}
 
 	_, forceCommand := model.handleKeyMsg(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'S'}})
@@ -476,8 +488,9 @@ func TestShiftSOverridesQueuedDependencyStart(t *testing.T) {
 		t.Fatal("Shift+S did not replace the queued start")
 	}
 	_, _ = model.Update(forceCommand().(operationResultMsg))
-	if api.Status() != config.StatusRunning {
-		t.Fatalf("force-started api status = %s", api.Status())
+	api, _ = model.app.Service("api")
+	if api.State.Status != config.StatusRunning {
+		t.Fatalf("force-started api status = %s", api.State.Status)
 	}
 	select {
 	case stale := <-queuedResult:
@@ -499,8 +512,8 @@ func TestMouseCanForceStartFocusedService(t *testing.T) {
 		t.Fatal("force-start button did not schedule the operation")
 	}
 	_, _ = model.Update(command().(operationResultMsg))
-	if model.FocusedService().Status() != config.StatusRunning {
-		t.Fatalf("focused service status = %s", model.FocusedService().Status())
+	if model.FocusedService().State.Status != config.StatusRunning {
+		t.Fatalf("focused service status = %s", model.FocusedService().State.Status)
 	}
 }
 
@@ -520,10 +533,10 @@ func TestMouseClickChangesServiceStartedByFooterAction(t *testing.T) {
 	}
 	_, _ = model.Update(command().(operationResultMsg))
 
-	api, _ := model.manager.GetService("api")
-	worker, _ := model.manager.GetService("worker")
-	if api.Status() != config.StatusStopped || worker.Status() != config.StatusRunning {
-		t.Fatalf("after clicking worker, statuses api=%s worker=%s", api.Status(), worker.Status())
+	api, _ := model.app.Service("api")
+	worker, _ := model.app.Service("worker")
+	if api.State.Status != config.StatusStopped || worker.State.Status != config.StatusRunning {
+		t.Fatalf("after clicking worker, statuses api=%s worker=%s", api.State.Status, worker.State.Status)
 	}
 }
 
@@ -560,10 +573,10 @@ func TestMouseClickInTagGroupChangesServiceStartedByFooterAction(t *testing.T) {
 	}
 	_, _ = model.Update(command().(operationResultMsg))
 
-	api, _ := model.manager.GetService("api")
-	worker, _ := model.manager.GetService("worker")
-	if api.Status() != config.StatusStopped || worker.Status() != config.StatusRunning {
-		t.Fatalf("after clicking grouped worker, statuses api=%s worker=%s", api.Status(), worker.Status())
+	api, _ := model.app.Service("api")
+	worker, _ := model.app.Service("worker")
+	if api.State.Status != config.StatusStopped || worker.State.Status != config.StatusRunning {
+		t.Fatalf("after clicking grouped worker, statuses api=%s worker=%s", api.State.Status, worker.State.Status)
 	}
 }
 
@@ -585,12 +598,13 @@ func TestDetailsShowLifecycleConfiguration(t *testing.T) {
 			model.focused = index
 		}
 	}
-	state := model.FocusedService().GetState()
+	state := model.FocusedService().State
 	state.StartedAt = time.Now().Add(-2 * time.Minute)
 	state.Completed = true
 	state.ExitCode = 1
 	state.RestartCount = 2
-	model.FocusedService().SetState(state)
+	model.app.SetServiceStateForTest(model.FocusedService().Name, state)
+	model.FocusedService().State = state
 	plain := ansi.Strip(strings.Join(model.serviceDetailLines(model.FocusedService(), 80), "\n"))
 	for _, expected := range []string{
 		"LAST START", "LAST EXIT code 1",
@@ -607,14 +621,15 @@ func TestDetailsShowLifecycleConfiguration(t *testing.T) {
 	}
 }
 
-func waitForServiceStatus(t *testing.T, svc interface{ Status() config.ServiceStatus }, expected config.ServiceStatus) {
+func waitForServiceStatus(t *testing.T, model *Model, name string, expected config.ServiceStatus) {
 	t.Helper()
 	deadline := time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {
-		if svc.Status() == expected {
+		if svc, ok := model.app.Service(name); ok && svc.State.Status == expected {
 			return
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatalf("service status = %s, want %s", svc.Status(), expected)
+	svc, _ := model.app.Service(name)
+	t.Fatalf("service status = %s, want %s", svc.State.Status, expected)
 }

--- a/internal/ui/model_logs_test.go
+++ b/internal/ui/model_logs_test.go
@@ -17,23 +17,26 @@ import (
 func TestFocusingServiceClearsUnreadLogs(t *testing.T) {
 	model := newTestModel()
 	defer model.Shutdown()
-	first := model.services[0]
-	second := model.services[1]
-	first.AppendLog("first unread")
-	second.AppendLog("second unread")
+	firstName := model.services[0].Name
+	secondName := model.services[1].Name
+	model.app.AppendLogForTest(firstName, "first unread")
+	model.app.AppendLogForTest(secondName, "second unread")
 
 	model.moveFocus(1)
-	if first.NewLogCount() != 0 {
-		t.Fatalf("previously focused service has %d unread logs", first.NewLogCount())
+	first, _ := model.app.Service(firstName)
+	second, _ := model.app.Service(secondName)
+	if first.State.NewLogCount != 0 {
+		t.Fatalf("previously focused service has %d unread logs", first.State.NewLogCount)
 	}
-	if second.NewLogCount() != 0 {
-		t.Fatalf("newly focused service has %d unread logs", second.NewLogCount())
+	if second.State.NewLogCount != 0 {
+		t.Fatalf("newly focused service has %d unread logs", second.State.NewLogCount)
 	}
 
-	second.AppendLog("visible while focused")
+	model.app.AppendLogForTest(secondName, "visible while focused")
 	model.refreshServices()
-	if second.NewLogCount() != 0 {
-		t.Fatalf("focused service accumulated %d unread logs", second.NewLogCount())
+	second, _ = model.app.Service(secondName)
+	if second.State.NewLogCount != 0 {
+		t.Fatalf("focused service accumulated %d unread logs", second.State.NewLogCount)
 	}
 }
 
@@ -41,24 +44,24 @@ func TestClearLogsRequiresConfirmationForFocusedAndPinnedPanels(t *testing.T) {
 	model := newTestModel()
 	defer model.Shutdown()
 	api := model.FocusedService()
-	api.AppendLog("api output")
+	model.app.AppendLogForTest(api.Name, "api output")
 	model.panelFocus = panelLogs
 
 	pressKey(model, 'c')
 	if model.mode != ModeConfirmClearLogs || model.clearTarget != api.Name || model.clearPinned {
 		t.Fatalf("focused clear state = mode %v target %q pinned %v", model.mode, model.clearTarget, model.clearPinned)
 	}
-	if api.Logs.Len() != 1 {
+	if len(model.app.Logs(api.Name)) != 1 {
 		t.Fatal("focused logs were cleared before confirmation")
 	}
 	_, _ = model.handleKeyMsg(tea.KeyMsg{Type: tea.KeyEsc})
-	if model.mode != ModeNormal || api.Logs.Len() != 1 {
+	if model.mode != ModeNormal || len(model.app.Logs(api.Name)) != 1 {
 		t.Fatal("Escape did not preserve focused logs")
 	}
 
 	model.moveFocus(1)
 	worker := model.FocusedService()
-	worker.AppendLog("worker output")
+	model.app.AppendLogForTest(worker.Name, "worker output")
 	model.pinnedLog = api.Name
 	model.panelFocus = panelPinnedLogs
 	pressKey(model, 'c')
@@ -66,10 +69,10 @@ func TestClearLogsRequiresConfirmationForFocusedAndPinnedPanels(t *testing.T) {
 		t.Fatalf("pinned clear state = mode %v target %q pinned %v", model.mode, model.clearTarget, model.clearPinned)
 	}
 	_, _ = model.handleKeyMsg(tea.KeyMsg{Type: tea.KeyEnter})
-	if api.Logs.Len() != 0 {
+	if len(model.app.Logs(api.Name)) != 0 {
 		t.Fatal("Enter did not clear pinned logs")
 	}
-	if worker.Logs.Len() != 1 {
+	if len(model.app.Logs(worker.Name)) != 1 {
 		t.Fatal("clearing pinned logs cleared focused service logs")
 	}
 }
@@ -84,7 +87,8 @@ func TestLogTitleShowsColorCodedServiceStatus(t *testing.T) {
 		t.Fatalf("stopped log title does not expose service state: %q", title)
 	}
 
-	model.FocusedService().SetStatus(config.StatusRunning)
+	model.app.SetServiceStatusForTest(model.FocusedService().Name, config.StatusRunning)
+	model.refreshServices()
 	title = ansi.Strip(model.renderLogPanel(model.FocusedService(), 70, 10))
 	if !strings.Contains(title, "[3] LOGS │ ● api · running") {
 		t.Fatalf("running log title does not expose service state: %q", title)
@@ -117,7 +121,7 @@ func TestShiftThreePinsLogsAboveFocusedLogs(t *testing.T) {
 	defer model.Shutdown()
 	model.width, model.height, model.ready = 100, 28, true
 	api := model.FocusedService()
-	api.AppendLog("api log remains visible")
+	model.app.AppendLogForTest(api.Name, "api log remains visible")
 
 	pressKey(model, '#')
 	if model.pinnedLog != "api" || model.PinnedService() != api {
@@ -125,8 +129,8 @@ func TestShiftThreePinsLogsAboveFocusedLogs(t *testing.T) {
 	}
 	model.moveFocus(1)
 	worker := model.FocusedService()
-	worker.AppendLog("hidden worker line")
-	worker.AppendLog("WORKER matched line")
+	model.app.AppendLogForTest(worker.Name, "hidden worker line")
+	model.app.AppendLogForTest(worker.Name, "WORKER matched line")
 	if err := model.logSearcher.SetPattern("WORKER"); err != nil {
 		t.Fatal(err)
 	}
@@ -155,12 +159,12 @@ func TestThreeSwitchesAndScrollsPinnedLogsIndependently(t *testing.T) {
 	defer model.Shutdown()
 	model.width, model.height, model.ready = 100, 28, true
 	for index := range 40 {
-		model.FocusedService().AppendLog(fmt.Sprintf("pinned line %d", index))
+		model.app.AppendLogForTest(model.FocusedService().Name, fmt.Sprintf("pinned line %d", index))
 	}
 	pressKey(model, '#')
 	model.moveFocus(1)
 	for index := range 40 {
-		model.FocusedService().AppendLog(fmt.Sprintf("current line %d", index))
+		model.app.AppendLogForTest(model.FocusedService().Name, fmt.Sprintf("current line %d", index))
 	}
 
 	pressKey(model, '3')
@@ -216,7 +220,7 @@ func TestMouseHoverAndWheelFocusLogPanel(t *testing.T) {
 	defer model.Shutdown()
 	model.width, model.height, model.ready = 100, 24, true
 	for index := range 40 {
-		model.FocusedService().AppendLog(fmt.Sprintf("line %d", index))
+		model.app.AppendLogForTest(model.FocusedService().Name, fmt.Sprintf("line %d", index))
 	}
 	model.panelFocus = panelServices
 	serviceIndex := model.focused
@@ -245,10 +249,10 @@ func TestManualLogPauseFreezesVisibleTail(t *testing.T) {
 	defer model.Shutdown()
 	model.width, model.height, model.ready = 80, 10, true
 	for index := range 10 {
-		model.FocusedService().AppendLog(fmt.Sprintf("before %02d", index))
+		model.app.AppendLogForTest(model.FocusedService().Name, fmt.Sprintf("before %02d", index))
 	}
 	pressKey(model, 'f')
-	model.FocusedService().AppendLog("after pause")
+	model.app.AppendLogForTest(model.FocusedService().Name, "after pause")
 
 	plain := ansi.Strip(model.renderLogPanel(model.FocusedService(), 70, 8))
 	if !strings.Contains(plain, "PAUSED") || strings.Contains(plain, "after pause") {
@@ -262,7 +266,7 @@ func TestLogWrappingKeepsPanelAndDashboardGeometry(t *testing.T) {
 	model.width, model.height, model.ready = 80, 24, true
 	model.panelFocus = panelLogs
 	for range 3 {
-		model.FocusedService().AppendLog(strings.Repeat("long-log-value ", 40))
+		model.app.AppendLogForTest(model.FocusedService().Name, strings.Repeat("long-log-value ", 40))
 	}
 
 	plainRows := model.displayedLogLineCount()
@@ -293,7 +297,7 @@ func TestLogTimestampToggleUsesCaptureTimeWithoutChangingSearchText(t *testing.T
 	defer model.Shutdown()
 	model.width, model.height, model.ready = 90, 24, true
 	captured := time.Date(2026, 7, 20, 12, 34, 56, 789000000, time.Local)
-	model.FocusedService().AppendLogAt(captured, "request complete")
+	model.app.AppendLogAtForTest(model.FocusedService().Name, captured, "request complete")
 
 	pressKey(model, 'i')
 	plain := ansi.Strip(model.renderLogPanel(model.FocusedService(), 70, 10))
@@ -303,8 +307,8 @@ func TestLogTimestampToggleUsesCaptureTimeWithoutChangingSearchText(t *testing.T
 	if err := model.logSearcher.SetPattern(`^request complete$`); err != nil {
 		t.Fatal(err)
 	}
-	if matches := model.logSearcher.Search(serviceLogLines(model.FocusedService())); len(matches) != 1 {
-		t.Fatalf("timestamp polluted regex source: matches=%v lines=%v", matches, serviceLogLines(model.FocusedService()))
+	if matches := model.logSearcher.Search(model.serviceLogLines(model.FocusedService())); len(matches) != 1 {
+		t.Fatalf("timestamp polluted regex source: matches=%v lines=%v", matches, model.serviceLogLines(model.FocusedService()))
 	}
 
 	pressKey(model, 'i')
@@ -318,7 +322,7 @@ func TestServiceLogCannotClearOrRepositionTheTUI(t *testing.T) {
 	model := newTestModel()
 	defer model.Shutdown()
 	model.width, model.height, model.ready = 90, 24, true
-	model.FocusedService().AppendLog("\x1b[2J\x1b[H\x1b[31mserver ready\x1b[0m")
+	model.app.AppendLogForTest(model.FocusedService().Name, "\x1b[2J\x1b[H\x1b[31mserver ready\x1b[0m")
 
 	rendered := model.View()
 	if strings.Contains(rendered, "\x1b[2J") || strings.Contains(rendered, "\x1b[H") {

--- a/internal/ui/model_ports.go
+++ b/internal/ui/model_ports.go
@@ -1,12 +1,10 @@
 package ui
 
 import (
-	"fmt"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/kranz-org/kranz/internal/config"
-	"github.com/kranz-org/kranz/internal/port"
 )
 
 // Port inspection and the external-process conflict dialog. Terminating a
@@ -37,9 +35,9 @@ func (m *Model) scanFocusedPorts(force bool) tea.Cmd {
 	ports := append([]int(nil), svc.Config.Ports...)
 	m.portService = serviceName
 	m.portScanBusy = true
-	checker := m.portChecker
+	application := m.app
 	return func() tea.Msg {
-		details, err := checker.CheckPorts(ports)
+		details, err := application.InspectPorts(ports)
 		if details == nil {
 			details = make(map[int]*config.PortInfo)
 		}
@@ -73,30 +71,15 @@ func (m *Model) handlePortConflictKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) releaseExternalPort(portNumber, expectedPID int) tea.Cmd {
-	checker := m.portChecker
-	manager := m.manager
+	application := m.app
 	return func() tea.Msg {
-		info, err := checker.CheckPort(portNumber)
+		alreadyFree, err := application.ReleaseExternalPort(portNumber, expectedPID)
 		if err != nil {
 			return releasePortResultMsg{port: portNumber, pid: expectedPID, err: err}
 		}
-		if info == nil {
+		if alreadyFree {
 			return releasePortResultMsg{port: portNumber, pid: expectedPID, alreadyFree: true}
 		}
-		if info.PID != expectedPID {
-			return releasePortResultMsg{port: portNumber, pid: expectedPID, err: fmt.Errorf(
-				"port %d owner changed from PID %d to PID %d; refusing to stop it", portNumber, expectedPID, info.PID,
-			)}
-		}
-		if owner := manager.ManagedServiceForPID(info.PID); owner != "" {
-			return releasePortResultMsg{port: portNumber, pid: expectedPID, err: fmt.Errorf(
-				"port %d is now owned by Kranz service %s; refusing to stop it as external", portNumber, owner,
-			)}
-		}
-		return releasePortResultMsg{
-			port: portNumber,
-			pid:  expectedPID,
-			err:  port.TerminateExternalPID(expectedPID, 3*time.Second),
-		}
+		return releasePortResultMsg{port: portNumber, pid: expectedPID}
 	}
 }

--- a/internal/ui/model_search.go
+++ b/internal/ui/model_search.go
@@ -22,11 +22,11 @@ func (m *Model) handleSearchNavigationKey(msg tea.KeyMsg) bool {
 	}
 	switch msg.String() {
 	case "n":
-		m.currentMatch = m.logSearcher.FindNext(serviceLogLines(svc), m.currentMatch)
+		m.currentMatch = m.logSearcher.FindNext(m.serviceLogLines(svc), m.currentMatch)
 		m.focusLogMatch(m.currentMatch)
 		return true
 	case "N":
-		m.currentMatch = m.logSearcher.FindPrev(serviceLogLines(svc), m.currentMatch)
+		m.currentMatch = m.logSearcher.FindPrev(m.serviceLogLines(svc), m.currentMatch)
 		m.focusLogMatch(m.currentMatch)
 		return true
 	default:
@@ -113,7 +113,7 @@ func (m *Model) applySearchQuery() bool {
 	m.logPaused = false
 	if m.searchMode == searchHighlight && m.logSearcher.HasPattern() {
 		if svc := m.FocusedService(); svc != nil {
-			m.currentMatch = m.logSearcher.FindNext(serviceLogLines(svc), -1)
+			m.currentMatch = m.logSearcher.FindNext(m.serviceLogLines(svc), -1)
 			m.focusLogMatch(m.currentMatch)
 		}
 	}
@@ -153,7 +153,7 @@ func (m *Model) handleSearchKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// a match instead of waiting for the next apply.
 		if m.searchMode == searchHighlight && m.logSearcher.HasPattern() {
 			if svc := m.FocusedService(); svc != nil {
-				m.currentMatch = m.logSearcher.FindNext(serviceLogLines(svc), -1)
+				m.currentMatch = m.logSearcher.FindNext(m.serviceLogLines(svc), -1)
 				m.focusLogMatch(m.currentMatch)
 			}
 		}

--- a/internal/ui/model_search_test.go
+++ b/internal/ui/model_search_test.go
@@ -34,8 +34,8 @@ func TestRegexSearchFiltersMatchingLogsByDefault(t *testing.T) {
 	model := newTestModel()
 	defer model.Shutdown()
 	model.width, model.height, model.ready = 80, 24, true
-	model.FocusedService().AppendLog("request complete")
-	model.FocusedService().AppendLog("ERROR database unavailable")
+	model.app.AppendLogForTest(model.FocusedService().Name, "request complete")
+	model.app.AppendLogForTest(model.FocusedService().Name, "ERROR database unavailable")
 
 	_, _ = model.handleKeyMsg(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
 	for _, character := range "ERROR" {
@@ -61,8 +61,8 @@ func newFilteredSearchModel(t *testing.T) *Model {
 	t.Helper()
 	model := newTestModel()
 	model.width, model.height, model.ready = 80, 24, true
-	model.FocusedService().AppendLog("request complete")
-	model.FocusedService().AppendLog("ERROR database unavailable")
+	model.app.AppendLogForTest(model.FocusedService().Name, "request complete")
+	model.app.AppendLogForTest(model.FocusedService().Name, "ERROR database unavailable")
 	pressKey(model, '/')
 	for _, character := range "ERROR" {
 		pressKey(model, character)
@@ -392,7 +392,7 @@ func TestRegexTabEnablesHighlightModeWithoutFalsePausedLabel(t *testing.T) {
 		if index == 3 {
 			line = "ERROR database unavailable"
 		}
-		model.FocusedService().AppendLog(line)
+		model.app.AppendLogForTest(model.FocusedService().Name, line)
 	}
 
 	pressKey(model, '/')

--- a/internal/ui/model_selection.go
+++ b/internal/ui/model_selection.go
@@ -5,25 +5,34 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kranz-org/kranz/internal/app"
 	"github.com/kranz-org/kranz/internal/config"
-	"github.com/kranz-org/kranz/internal/service"
 )
 
 // Cursor, panel focus, and what is selected. Tags expand into their services
 // here, so a tag can be acted on as a single target.
 
+// markServiceLogsRead resets a service's unread log count. It updates the
+// local snapshot immediately so the count clears on this render — the
+// authoritative reset already happened synchronously in the same call — and
+// still reset again on the next tick's refresh, exactly as before.
+func (m *Model) markServiceLogsRead(svc *app.ServiceSnapshot) {
+	m.app.MarkLogsRead(svc.Name)
+	svc.State.NewLogCount = 0
+}
+
 func (m *Model) markFocusedRead() {
 	if svc := m.FocusedService(); svc != nil {
-		svc.ResetNewLogCount()
+		m.markServiceLogsRead(svc)
 	}
 	if svc := m.PinnedService(); svc != nil {
-		svc.ResetNewLogCount()
+		m.markServiceLogsRead(svc)
 	}
 }
 
 func (m *Model) moveFocus(next int) {
 	if current := m.FocusedService(); current != nil {
-		current.ResetNewLogCount()
+		m.markServiceLogsRead(current)
 	}
 	m.focused = next
 	m.focusedAction = nil
@@ -129,7 +138,7 @@ func (m *Model) togglePinnedLog() {
 	}
 	m.pinnedLog = svc.Name
 	m.pinnedOffset, m.pinnedAnchor, m.pinnedFollow = 0, 0, true
-	svc.ResetNewLogCount()
+	m.markServiceLogsRead(svc)
 	m.addNotification("logs", "Pinned logs: "+svc.Name, config.LogInfo)
 }
 
@@ -206,7 +215,7 @@ func (m *Model) focusedTag() string {
 	return row.Tag
 }
 
-func (m *Model) servicesForTag(tag string) []*service.Service {
+func (m *Model) servicesForTag(tag string) []*app.ServiceSnapshot {
 	if tag == "" {
 		return nil
 	}
@@ -214,7 +223,7 @@ func (m *Model) servicesForTag(tag string) []*service.Service {
 	for _, name := range m.cfg.GetServicesByTags([]string{tag}) {
 		names[name] = true
 	}
-	services := make([]*service.Service, 0, len(names))
+	services := make([]*app.ServiceSnapshot, 0, len(names))
 	for _, svc := range m.allServices {
 		if names[svc.Name] {
 			services = append(services, svc)
@@ -245,7 +254,7 @@ func (m *Model) focusedTagRow() (tagListRow, bool) {
 	return rows[m.tagCursor], true
 }
 
-func (m *Model) focusedTagService() *service.Service {
+func (m *Model) focusedTagService() *app.ServiceSnapshot {
 	row, ok := m.focusedTagRow()
 	if !ok {
 		return nil

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -112,7 +112,8 @@ func TestServiceStatusUsesQueuedAndRuntimeVisualStates(t *testing.T) {
 		t.Fatalf("stopped service visual state = %v", state)
 	}
 	svc.Config.DependsOn = []string{"database"}
-	svc.SetDesiredRunning(true)
+	model.app.SetServiceDesiredRunningForTest(svc.Name, true)
+	svc.DesiredRunning = true
 	if state := model.serviceVisualState(svc); state != visualQueued {
 		t.Fatalf("queued service visual state = %v", state)
 	}
@@ -128,8 +129,10 @@ func TestServiceStatusUsesQueuedAndRuntimeVisualStates(t *testing.T) {
 	if controls := ansi.Strip(model.renderStatusBar()); !strings.Contains(controls, "Stop") {
 		t.Fatalf("queued service controls = %q", controls)
 	}
-	svc.SetDesiredRunning(false)
-	svc.SetStatus(config.StatusRunning)
+	model.app.SetServiceDesiredRunningForTest(svc.Name, false)
+	svc.DesiredRunning = false
+	model.app.SetServiceStatusForTest(svc.Name, config.StatusRunning)
+	svc.State.Status = config.StatusRunning
 	if state := model.serviceVisualState(svc); state != visualRunning {
 		t.Fatalf("running service visual state = %v", state)
 	}
@@ -137,7 +140,8 @@ func TestServiceStatusUsesQueuedAndRuntimeVisualStates(t *testing.T) {
 	if state := model.serviceVisualState(svc); state != visualStarting {
 		t.Fatalf("waiting service visual state = %v", state)
 	}
-	svc.SetStatus(config.StatusUnhealthy)
+	model.app.SetServiceStatusForTest(svc.Name, config.StatusUnhealthy)
+	svc.State.Status = config.StatusUnhealthy
 	if state := model.serviceVisualState(svc); state != visualUnhealthy {
 		t.Fatalf("unhealthy service visual state = %v", state)
 	}
@@ -177,7 +181,7 @@ func TestPanelFocusUsesNumbersAndContextualArrows(t *testing.T) {
 	}
 
 	for index := range 40 {
-		model.FocusedService().AppendLog(fmt.Sprintf("line %d", index))
+		model.app.AppendLogForTest(model.FocusedService().Name, fmt.Sprintf("line %d", index))
 	}
 	_, _ = model.handleKeyMsg(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
 	_, _ = model.handleKeyMsg(tea.KeyMsg{Type: tea.KeyUp})
@@ -668,8 +672,9 @@ func TestQuitConfirmationDescribesManagedAndDetachedExitPlan(t *testing.T) {
 	defer model.Shutdown()
 	model.width, model.height, model.ready = 100, 40, true
 	for _, name := range []string{"api", "remote-kept", "remote-stopped"} {
-		svc, _ := model.manager.GetService(name)
-		svc.SetStatus(config.StatusRunning)
+		svc, _ := model.app.Service(name)
+		model.app.SetServiceStatusForTest(svc.Name, config.StatusRunning)
+		svc.State.Status = config.StatusRunning
 	}
 
 	plain := ansi.Strip(model.renderConfirmQuitView())
@@ -700,8 +705,9 @@ func TestQuitConfirmationCanLeaveOnlyDetachedResourcesRunning(t *testing.T) {
 	}}, "test")
 	defer model.Shutdown()
 	model.width, model.height, model.ready = 100, 40, true
-	svc, _ := model.manager.GetService("mk-backend-stack")
-	svc.SetStatus(config.StatusRunning)
+	svc, _ := model.app.Service("mk-backend-stack")
+	model.app.SetServiceStatusForTest(svc.Name, config.StatusRunning)
+	svc.State.Status = config.StatusRunning
 
 	plain := ansi.Strip(model.renderConfirmQuitView())
 	for _, expected := range []string{
@@ -879,9 +885,6 @@ func TestManualConfigReloadReconcilesModel(t *testing.T) {
 	if got := model.FocusedService().Config.Command; got != "sleep 61" {
 		t.Fatalf("reloaded command = %q", got)
 	}
-	if model.reloadBusy {
-		t.Fatal("reload remained busy")
-	}
 }
 
 func TestProcfileAndDotenvReloadReconcileModel(t *testing.T) {
@@ -909,8 +912,9 @@ func TestProcfileAndDotenvReloadReconcileModel(t *testing.T) {
 	}
 	model := NewModelWithOptions(cfg, "test", ModelOptions{ConfigPaths: []string{procfilePath}})
 	defer model.Shutdown()
-	if !containsPath(model.configWatchPaths, procfilePath) || !containsPath(model.configWatchPaths, dotenvPath) {
-		t.Fatalf("watch paths = %v", model.configWatchPaths)
+	watchPaths := model.app.Project().WatchPaths
+	if !containsPath(watchPaths, procfilePath) || !containsPath(watchPaths, dotenvPath) {
+		t.Fatalf("watch paths = %v", watchPaths)
 	}
 
 	writeProcfile("sleep 61")

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -8,8 +8,8 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 
+	"github.com/kranz-org/kranz/internal/app"
 	"github.com/kranz-org/kranz/internal/config"
-	"github.com/kranz-org/kranz/internal/service"
 )
 
 const (
@@ -212,14 +212,14 @@ func (m *Model) actionButtons() []actionButton {
 	allRunning := len(targets) > 0
 	canToggle := len(targets) > 0
 	for _, name := range targets {
-		svc, ok := m.manager.GetService(name)
-		if !ok || !serviceStartPlanned(svc) {
+		svc, ok := m.app.Service(name)
+		if !ok || !app.ServiceStartPlanned(svc) {
 			allActive = false
 		}
-		if !ok || svc.Status() == config.StatusStopped {
+		if !ok || svc.State.Status == config.StatusStopped {
 			allRunning = false
 		}
-		if !ok || (serviceStartPlanned(svc) && !svc.CanStop()) || (!serviceStartPlanned(svc) && !svc.CanStart()) {
+		if !ok || (app.ServiceStartPlanned(svc) && !svc.CanStop) || (!app.ServiceStartPlanned(svc) && !svc.CanStart) {
 			canToggle = false
 		}
 	}
@@ -244,7 +244,7 @@ func (m *Model) actionButtons() []actionButton {
 		toggleStyle = PrimaryButtonStyle
 		toggleLabel = "▶ Run action: s"
 		compactToggle = "Run: s"
-		if state, exists := m.manager.ActionState(*m.focusedAction); exists && state.Status == service.ActionRunning {
+		if state, exists := m.app.ActionState(*m.focusedAction); exists && state.Status == app.ActionRunning {
 			toggleStyle = DangerButtonStyle
 			toggleLabel = "■ Stop action: s"
 			compactToggle = "Stop: s"

--- a/internal/ui/view_details.go
+++ b/internal/ui/view_details.go
@@ -10,9 +10,8 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/kranz-org/kranz/internal/app"
 	"github.com/kranz-org/kranz/internal/config"
-	"github.com/kranz-org/kranz/internal/health"
-	"github.com/kranz-org/kranz/internal/service"
 )
 
 // The Details panel. Every field is width-aware because the panel is the
@@ -26,7 +25,7 @@ func (m *Model) mouseInDetails(x, y int) bool {
 	return y >= 1+listHeight
 }
 
-func (m *Model) renderServiceDetails(svc *service.Service, width, height int) string {
+func (m *Model) renderServiceDetails(svc *app.ServiceSnapshot, width, height int) string {
 	contentWidth := max(1, width-2)
 	contentHeight := max(1, height-2)
 	if svc == nil {
@@ -60,7 +59,7 @@ func (m *Model) renderActionDetails(width, height int) string {
 	return renderDetailViewport(m, "[2] ACTION", lines, contentWidth, contentHeight)
 }
 
-func (m *Model) actionDetailLines(id config.ActionID, action config.Action, state service.ActionResult, contentWidth int) []string {
+func (m *Model) actionDetailLines(id config.ActionID, action config.Action, state app.ActionResult, contentWidth int) []string {
 	lines := []string{actionStatusIndicator(state.Status) + " " + ServiceNameStyle.Render(id.Name) + "  " + ContextBarStyle.Render(state.Status.String())}
 	owner := "service " + id.Owner
 	if id.OwnerKind == config.ActionOwnerGroup {
@@ -84,7 +83,7 @@ func (m *Model) actionDetailLines(id config.ActionID, action config.Action, stat
 	lines = append(lines, detailFieldLines("MODE", mode, contentWidth)...)
 	if !state.StartedAt.IsZero() {
 		lines = append(lines, detailFieldLines("LAST RUN", state.StartedAt.Local().Format("15:04:05"), contentWidth)...)
-		if state.Status != service.ActionRunning {
+		if state.Status != app.ActionRunning {
 			lines = append(lines, detailFieldLines("RESULT", fmt.Sprintf("exit %d · %s", state.ExitCode, state.Duration.Round(time.Millisecond)), contentWidth)...)
 		}
 	}
@@ -153,7 +152,7 @@ func (m *Model) tagDetailLines(tag string, contentWidth int) []string {
 	serviceNames := make(map[string]bool)
 	for _, svc := range services {
 		serviceNames[svc.Name] = true
-		state := serviceStatusLabel(svc.Status(), m.serviceVisualState(svc))
+		state := serviceStatusLabel(svc.State.Status, m.serviceVisualState(svc))
 		stateCounts[state]++
 		for _, portNumber := range svc.Config.Ports {
 			ports[portNumber] = true
@@ -179,7 +178,7 @@ func (m *Model) tagDetailLines(tag string, contentWidth int) []string {
 	serviceParts := make([]string, 0, len(services))
 	externalDependencies := make(map[string]bool)
 	for _, svc := range services {
-		state := serviceStatusLabel(svc.Status(), m.serviceVisualState(svc))
+		state := serviceStatusLabel(svc.State.Status, m.serviceVisualState(svc))
 		part := serviceStatusIndicator(m.serviceVisualState(svc)) + " " + svc.Name + " · " + strings.ToLower(state)
 		if len(svc.Config.Ports) > 0 {
 			configuredPorts := make([]string, 0, len(svc.Config.Ports))
@@ -218,11 +217,11 @@ func (m *Model) tagDetailLines(tag string, contentWidth int) []string {
 	return lines
 }
 
-func (m *Model) serviceDetailLines(svc *service.Service, contentWidth int) []string {
+func (m *Model) serviceDetailLines(svc *app.ServiceSnapshot, contentWidth int) []string {
 	visualState := m.serviceVisualState(svc)
 	lines := []string{
 		serviceStatusIndicator(visualState) + " " + ServiceNameStyle.Render(svc.Name) + "  " +
-			ContextBarStyle.Render(serviceStatusLabel(svc.Status(), visualState)),
+			ContextBarStyle.Render(serviceStatusLabel(svc.State.Status, visualState)),
 	}
 	if svc.Config.Disabled {
 		lines = append(lines, StartingBadgeStyle.Render("DISABLED")+" "+detailValue("manual start only"))
@@ -235,7 +234,7 @@ func (m *Model) serviceDetailLines(svc *service.Service, contentWidth int) []str
 		lines = append(lines, detailFieldLines("START", StartingBadgeStyle.Render(reason), contentWidth)...)
 	}
 	directory := displayServiceDirectory(svc.Config.Dir, m.workingDirectory)
-	lines = append(lines, pidDirectoryDetailLines(svc.PID(), directory, contentWidth)...)
+	lines = append(lines, pidDirectoryDetailLines(svc.State.PID, directory, contentWidth)...)
 	lines = append(lines, runtimeDetailLines(svc, contentWidth)...)
 	if svc.Config.Description != "" {
 		lines = append(lines, detailFieldLines("ABOUT", svc.Config.Description, contentWidth)...)
@@ -273,8 +272,8 @@ func (m *Model) serviceDetailLines(svc *service.Service, contentWidth int) []str
 	lines = append(lines, dependencyDetailLines(svc, contentWidth)...)
 	lines = append(lines, prerequisiteDetailLines(svc, contentWidth)...)
 	lines = append(lines, m.renderPortDetailLines(svc, contentWidth)...)
-	detectedPorts := svc.DetectedPorts()
-	serviceActive := svc.Status() != config.StatusStopped
+	detectedPorts := svc.DetectedPorts
+	serviceActive := svc.State.Status != config.StatusStopped
 	lines = append(lines, m.healthDetailLines("READINESS", healthReadiness(svc), m.readinessSummary(svc), detectedPorts, serviceActive, contentWidth)...)
 	lines = append(lines, m.healthDetailLines("LIVENESS", healthLiveness(svc), m.livenessSummary(svc), detectedPorts, serviceActive, contentWidth)...)
 	if svc.Config.ReadyLogLine != "" {
@@ -298,7 +297,7 @@ func (m *Model) serviceDetailLines(svc *service.Service, contentWidth int) []str
 
 // prerequisiteDetailLines renders before_start so the reason a service runs
 // extra work before starting is visible without opening the configuration.
-func prerequisiteDetailLines(svc *service.Service, contentWidth int) []string {
+func prerequisiteDetailLines(svc *app.ServiceSnapshot, contentWidth int) []string {
 	if len(svc.Config.BeforeStart) == 0 {
 		return nil
 	}
@@ -322,7 +321,7 @@ func prerequisiteDetailLines(svc *service.Service, contentWidth int) []string {
 	return lines
 }
 
-func dependencyDetailLines(svc *service.Service, contentWidth int) []string {
+func dependencyDetailLines(svc *app.ServiceSnapshot, contentWidth int) []string {
 	if len(svc.Config.DependsOn) == 0 {
 		return detailFieldLines("DEPENDS", "—", contentWidth)
 	}
@@ -354,7 +353,7 @@ func dependencyDetailLines(svc *service.Service, contentWidth int) []string {
 	return lines
 }
 
-func availabilityDetailLines(svc *service.Service, contentWidth int) []string {
+func availabilityDetailLines(svc *app.ServiceSnapshot, contentWidth int) []string {
 	availability := svc.Config.Availability
 	policy := availability.Restart
 	if policy == "" {
@@ -370,7 +369,7 @@ func availabilityDetailLines(svc *service.Service, contentWidth int) []string {
 		if availability.MaxRestarts > 0 {
 			limit = strconv.Itoa(availability.MaxRestarts)
 		}
-		parts = append(parts, "backoff "+backoff.String(), fmt.Sprintf("restarts %d/%s", svc.GetState().RestartCount, limit))
+		parts = append(parts, "backoff "+backoff.String(), fmt.Sprintf("restarts %d/%s", svc.State.RestartCount, limit))
 	}
 	if availability.ExitOnEnd {
 		parts = append(parts, "exit on end")
@@ -381,14 +380,14 @@ func availabilityDetailLines(svc *service.Service, contentWidth int) []string {
 	return detailSectionLines("RECOVERY", parts, contentWidth)
 }
 
-func runtimeDetailLines(svc *service.Service, contentWidth int) []string {
-	state := svc.GetState()
+func runtimeDetailLines(svc *app.ServiceSnapshot, contentWidth int) []string {
+	state := svc.State
 	if state.StartedAt.IsZero() {
 		return nil
 	}
 
 	lines := detailFieldLines("LAST START", state.StartedAt.Local().Format("15:04:05"), contentWidth)
-	if svc.Status() != config.StatusStopped {
+	if svc.State.Status != config.StatusStopped {
 		elapsed := time.Since(state.StartedAt)
 		if elapsed < 0 {
 			elapsed = 0
@@ -409,7 +408,7 @@ func runtimeDetailLines(svc *service.Service, contentWidth int) []string {
 	return lines
 }
 
-func shutdownDetailLines(svc *service.Service, contentWidth int) []string {
+func shutdownDetailLines(svc *app.ServiceSnapshot, contentWidth int) []string {
 	shutdown := svc.Config.Shutdown
 	timeout := shutdown.Timeout
 	if timeout <= 0 {
@@ -453,14 +452,14 @@ func (m *Model) healthDetailLines(label string, check *config.CheckConfig, statu
 	return lines
 }
 
-func healthReadiness(svc *service.Service) *config.CheckConfig {
+func healthReadiness(svc *app.ServiceSnapshot) *config.CheckConfig {
 	if svc.Config.HealthCheck == nil {
 		return nil
 	}
 	return svc.Config.HealthCheck.Readiness
 }
 
-func healthLiveness(svc *service.Service) *config.CheckConfig {
+func healthLiveness(svc *app.ServiceSnapshot) *config.CheckConfig {
 	if svc.Config.HealthCheck == nil {
 		return nil
 	}
@@ -492,8 +491,8 @@ func (m *Model) scrollDetails(direction int) {
 	m.detailOffset = min(maxOffset, max(0, m.detailOffset+direction))
 }
 
-func (m *Model) renderPortDetailLines(svc *service.Service, contentWidth int) []string {
-	entries := mergePortDetailEntries(svc.Config.Ports, svc.DetectedPorts())
+func (m *Model) renderPortDetailLines(svc *app.ServiceSnapshot, contentWidth int) []string {
+	entries := mergePortDetailEntries(svc.Config.Ports, svc.DetectedPorts)
 	if len(entries) == 0 {
 		if !svc.Config.PortDiscoveryEnabled() {
 			return []string{DetailLabelStyle.Render("PORTS") + " " + ContextBarStyle.Render("detection off")}
@@ -564,7 +563,7 @@ func renderDetectedPortDetail(entry portDetailEntry, label string, portWidth, co
 	return renderPortStatus(base, role, RunningBadgeStyle.Render("listening"), contentWidth)
 }
 
-func (m *Model) renderPortDetail(svc *service.Service, portNumber int, label string, portWidth, contentWidth int) []string {
+func (m *Model) renderPortDetail(svc *app.ServiceSnapshot, portNumber int, label string, portWidth, contentWidth int) []string {
 	base := DetailLabelStyle.Render(label) + " " + PortStyle.Render(fmt.Sprintf("%*d", portWidth, portNumber)) + " "
 	if m.portService != svc.Name || (m.portScanBusy && m.portChecked.IsZero()) {
 		return renderPortStatus(base, "declared", StartingBadgeStyle.Render("checking…"), contentWidth)
@@ -575,10 +574,10 @@ func (m *Model) renderPortDetail(svc *service.Service, portNumber int, label str
 	if info := m.portDetails[portNumber]; info != nil {
 		prefix := base + ContextBarStyle.Render("declared · ")
 		if lipgloss.Width(prefix+"listening") <= contentWidth {
-			return renderListeningPort(prefix, info, m.manager.ManagedServiceForPID(info.PID), contentWidth)
+			return renderListeningPort(prefix, info, m.app.ManagedServiceForPID(info.PID), contentWidth)
 		}
 		lines := []string{base + ContextBarStyle.Render("declared")}
-		return append(lines, renderListeningPort(ContextBarStyle.Render("  ↳ "), info, m.manager.ManagedServiceForPID(info.PID), contentWidth)...)
+		return append(lines, renderListeningPort(ContextBarStyle.Render("  ↳ "), info, m.app.ManagedServiceForPID(info.PID), contentWidth)...)
 	}
 	return renderPortStatus(base, "declared", StoppedBadgeStyle.Render("free"), contentWidth)
 }
@@ -736,39 +735,37 @@ func listenerEndpoint(info *config.PortInfo) string {
 	return strings.ToLower(info.Protocol) + "://" + address + fmt.Sprintf(":%d", info.Port)
 }
 
-func (m *Model) readinessSummary(svc *service.Service) string {
+func (m *Model) readinessSummary(svc *app.ServiceSnapshot) string {
 	if svc.Config.HealthCheck == nil || svc.Config.HealthCheck.Readiness == nil {
 		return detailValue("not configured")
 	}
-	healthData := m.healthChecker.GetHealth(svc.Name)
-	if healthData == nil {
+	if !svc.Health.Observed {
 		return StoppedBadgeStyle.Render("inactive")
 	}
-	if !healthData.IsReady() {
+	if !svc.Health.Ready {
 		return StartingBadgeStyle.Render("waiting")
 	}
 	return RunningBadgeStyle.Render("ready")
 }
 
-func (m *Model) livenessSummary(svc *service.Service) string {
+func (m *Model) livenessSummary(svc *app.ServiceSnapshot) string {
 	if svc.Config.HealthCheck == nil || svc.Config.HealthCheck.Liveness == nil {
 		return detailValue("not configured")
 	}
-	healthData := m.healthChecker.GetHealth(svc.Name)
-	if healthData == nil {
+	if !svc.Health.Observed {
 		return StoppedBadgeStyle.Render("inactive")
 	}
-	if healthData.GetLastCheck().IsZero() {
+	if svc.Health.LastCheck.IsZero() {
 		return StartingBadgeStyle.Render("checking")
 	}
-	if healthData.IsAlive() {
+	if svc.Health.Alive {
 		return RunningBadgeStyle.Render("alive")
 	}
 	return FailedBadgeStyle.Render("failed")
 }
 
 func checkDescription(check *config.CheckConfig, detectedPorts []int, serviceActive bool) string {
-	resolved, err := health.ResolveCheckTarget(check, detectedPorts)
+	resolved, err := app.ResolveCheckTarget(check, detectedPorts)
 	if err != nil {
 		if strings.HasPrefix(err.Error(), "waiting for") {
 			return detectingCheckDescription(check, serviceActive)

--- a/internal/ui/view_logs.go
+++ b/internal/ui/view_logs.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/kranz-org/kranz/internal/app"
 	"github.com/kranz-org/kranz/internal/config"
-	"github.com/kranz-org/kranz/internal/service"
 )
 
 // Log panels: layout, scrolling and the follow/browse distinction, filtering and
@@ -62,15 +62,15 @@ func (m *Model) renderActionLogPanel(width, height int) string {
 		return renderTitledPanel(m.panelStyle(panelLogs), m.panelTitleStyle(panelLogs), contentWidth, contentHeight, "[3] ACTION OUTPUT", []string{"", "Select an action"})
 	}
 	title := "[3] ACTION OUTPUT" + ContextBarStyle.Render(" │ ") + actionStatusIndicator(state.Status) + " " + ServiceNameStyle.Render(id.Name) + ContextBarStyle.Render(" · "+state.Status.String())
-	if state.Status == service.ActionRunning {
+	if state.Status == app.ActionRunning {
 		title += StartingBadgeStyle.Render(" RUNNING")
 	}
 	outputLines := actionOutputLines(state)
 	lines := outputLines
-	if state.Status != service.ActionReady {
+	if state.Status != app.ActionReady {
 		lines = append(appendSafeActionOutput(nil, action.Command, "$ "), lines...)
 	}
-	if state.Status == service.ActionRunning && len(outputLines) == 0 {
+	if state.Status == app.ActionRunning && len(outputLines) == 0 {
 		lines = append(lines, "Running · press s to stop")
 	}
 	if len(lines) == 0 {
@@ -97,7 +97,7 @@ func (m *Model) renderActionLogPanel(width, height int) string {
 	return renderTitledPanel(m.panelStyle(panelLogs), m.panelTitleStyle(panelLogs), contentWidth, contentHeight, title, rows[start:end])
 }
 
-func actionOutputLines(state service.ActionResult) []string {
+func actionOutputLines(state app.ActionResult) []string {
 	lines := make([]string, 0, len(state.Stdout)+len(state.Stderr))
 	for _, line := range state.Stdout {
 		lines = appendSafeActionOutput(lines, line, "")
@@ -142,15 +142,15 @@ func (m *Model) logColumnLayout(height int) (pinnedHeight, currentHeight int) {
 }
 
 // renderLogPanel renders the focused service's bounded log viewport.
-func (m *Model) renderLogPanel(svc *service.Service, width, height int) string {
+func (m *Model) renderLogPanel(svc *app.ServiceSnapshot, width, height int) string {
 	return m.renderLogPanelMode(svc, width, height, false)
 }
 
-func (m *Model) renderPinnedLogPanel(svc *service.Service, width, height int) string {
+func (m *Model) renderPinnedLogPanel(svc *app.ServiceSnapshot, width, height int) string {
 	return m.renderLogPanelMode(svc, width, height, true)
 }
 
-func (m *Model) renderLogPanelMode(svc *service.Service, width, height int, pinned bool) string {
+func (m *Model) renderLogPanelMode(svc *app.ServiceSnapshot, width, height int, pinned bool) string {
 	contentWidth := max(1, width-2)
 	contentHeight := max(1, height-2)
 	panelStyle := m.panelStyle(panelLogs)
@@ -169,7 +169,7 @@ func (m *Model) renderLogPanelMode(svc *service.Service, width, height int, pinn
 
 	visualState := m.serviceVisualState(svc)
 	title := titlePrefix + ContextBarStyle.Render(" │ ") + serviceStatusIndicator(visualState) + " " + ServiceNameStyle.Render(svc.Name) +
-		ContextBarStyle.Render(" · "+strings.ToLower(serviceStatusLabel(svc.Status(), visualState)))
+		ContextBarStyle.Render(" · "+strings.ToLower(serviceStatusLabel(svc.State.Status, visualState)))
 	if !followMode {
 		state := "BROWSING"
 		if logPaused {
@@ -184,7 +184,7 @@ func (m *Model) renderLogPanelMode(svc *service.Service, width, height int, pinn
 		title += " " + RunningBadgeStyle.Render("TIME")
 	}
 
-	sourceEntries := svc.LogEntries()
+	sourceEntries := m.app.Logs(svc.Name)
 	sourceLines := logEntryLines(sourceEntries)
 
 	var searchMatches []int
@@ -322,8 +322,8 @@ func (m *Model) displayedPinnedLogLineCount() int {
 	if svc == nil {
 		return 0
 	}
-	lines := make([]string, 0, len(svc.LogEntries()))
-	for _, entry := range svc.LogEntries() {
+	lines := make([]string, 0, len(m.app.Logs(svc.Name)))
+	for _, entry := range m.app.Logs(svc.Name) {
 		lines = append(lines, m.displayLogEntry(entry))
 	}
 	return visualLogRowCount(lines, m.currentLogContentWidth(), m.wrapLogs)
@@ -337,7 +337,7 @@ func (m *Model) displayedLogLineCount() int {
 	if svc == nil {
 		return 0
 	}
-	entries := svc.LogEntries()
+	entries := m.app.Logs(svc.Name)
 	lines := logEntryLines(entries)
 	indices := make([]int, len(lines))
 	for index := range indices {
@@ -375,7 +375,7 @@ func (m *Model) focusLogMatch(match int) {
 	if svc == nil || match < 0 {
 		return
 	}
-	entries := svc.LogEntries()
+	entries := m.app.Logs(svc.Name)
 	maxLines := max(1, m.currentLogPanelHeight()-2)
 	displayLines := make([]string, 0, min(match, len(entries)))
 	for _, entry := range entries[:min(match, len(entries))] {
@@ -397,11 +397,11 @@ func (m *Model) focusLogMatch(match int) {
 	m.panelFocus = panelLogs
 }
 
-func serviceLogLines(svc *service.Service) []string {
+func (m *Model) serviceLogLines(svc *app.ServiceSnapshot) []string {
 	if svc == nil {
 		return nil
 	}
-	return logEntryLines(svc.LogEntries())
+	return logEntryLines(m.app.Logs(svc.Name))
 }
 
 func logEntryLines(entries []config.LogEntry) []string {

--- a/internal/ui/view_modals.go
+++ b/internal/ui/view_modals.go
@@ -164,15 +164,13 @@ func (m *Model) renderHealthHistoryView() string {
 		return m.placeOverlay(renderModal("No service selected"))
 	}
 
-	healthData := m.healthChecker.GetHealth(svc.Name)
-
 	var lines []string
 	lines = append(lines, ModalTitleStyle.Render(fmt.Sprintf(" Health: %s ", svc.Name)))
 	lines = append(lines, "")
 
 	if svc.Config.HealthCheck != nil {
-		detectedPorts := svc.DetectedPorts()
-		serviceActive := svc.Status() != config.StatusStopped
+		detectedPorts := svc.DetectedPorts
+		serviceActive := svc.State.Status != config.StatusStopped
 		lines = append(lines, "  Readiness: "+m.readinessSummary(svc))
 		if check := healthReadiness(svc); check != nil {
 			lines = append(lines, checkDescription(check, detectedPorts, serviceActive))
@@ -181,10 +179,10 @@ func (m *Model) renderHealthHistoryView() string {
 		if check := healthLiveness(svc); check != nil {
 			lines = append(lines, checkDescription(check, detectedPorts, serviceActive))
 		}
-		if healthData != nil {
+		if svc.Health.Observed {
 			lines = append(lines, "")
 			lines = append(lines, "History:")
-			for _, h := range healthData.History.Lines() {
+			for _, h := range m.app.HealthHistory(svc.Name) {
 				lines = append(lines, "  "+h)
 			}
 		}
@@ -271,22 +269,8 @@ func (m *Model) renderConfirmQuitView() string {
 }
 
 func (m *Model) quitLifecyclePlan() (managed, detachedStop, detachedKeep []string) {
-	for _, svc := range m.manager.Services() {
-		status := svc.Status()
-		active := status == config.StatusRunning || status == config.StatusUnhealthy ||
-			status == config.StatusStarting || status == config.StatusStopping || svc.DesiredRunning()
-		if !active {
-			continue
-		}
-		if !svc.Config.IsDetached() {
-			managed = append(managed, svc.Name)
-		} else if svc.Config.StopOnExitEnabled() {
-			detachedStop = append(detachedStop, svc.Name)
-		} else {
-			detachedKeep = append(detachedKeep, svc.Name)
-		}
-	}
-	return managed, detachedStop, detachedKeep
+	plan := m.app.ShutdownPlan()
+	return plan.Managed, plan.DetachedStop, plan.DetachedKeep
 }
 
 func appendQuitServiceNames(lines []string, heading string, names []string) []string {
@@ -439,7 +423,7 @@ func (m *Model) renderConfirmServiceStopView() string {
 	}
 	body := []string{"Running services will be stopped."}
 	for _, name := range m.pendingStopNames {
-		if svc, ok := m.manager.GetService(name); ok && svc.Config.IsDetached() {
+		if svc, ok := m.app.Service(name); ok && svc.Config.IsDetached() {
 			body = append(body, "Configured detached lifecycle stop commands will be executed.")
 			break
 		}
@@ -467,7 +451,7 @@ func (m *Model) renderConfirmServiceStartView() string {
 }
 
 func (m *Model) renderServiceStartConfirmationBody() []string {
-	names := m.startConfirmationServiceNames(m.pendingStartNames, !m.pendingStartForce)
+	names := m.app.StartConfirmationNames(m.pendingStartNames, !m.pendingStartForce)
 	body := []string{StartingBadgeStyle.Render("⚠ CONFIRM BEFORE STARTING")}
 	if len(names) == 0 {
 		return append(body, "The lifecycle start command requires confirmation.")
@@ -478,7 +462,7 @@ func (m *Model) renderServiceStartConfirmationBody() []string {
 		if index > 0 {
 			body = append(body, "")
 		}
-		svc, ok := m.manager.GetService(name)
+		svc, ok := m.app.Service(name)
 		if !ok {
 			continue
 		}

--- a/internal/ui/view_services.go
+++ b/internal/ui/view_services.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/kranz-org/kranz/internal/app"
 	"github.com/kranz-org/kranz/internal/config"
-	"github.com/kranz-org/kranz/internal/service"
 )
 
 // The first column: the service list, the tag list with its inline expansion,
@@ -16,13 +16,13 @@ import (
 
 func (m *Model) serviceCounts() (running, pending, stopped int) {
 	for _, svc := range m.allServices {
-		switch svc.Status() {
+		switch svc.State.Status {
 		case config.StatusRunning, config.StatusUnhealthy:
 			running++
 		case config.StatusStarting, config.StatusStopping:
 			pending++
 		default:
-			if svc.DesiredRunning() {
+			if svc.DesiredRunning {
 				pending++
 			} else {
 				stopped++
@@ -162,12 +162,12 @@ func (m *Model) renderServiceListRow(index int, row actionListRow, width int) st
 		line := "   " + ContextBarStyle.Render(disclosure) + "  " + ServiceNameStyle.Render(row.Group)
 		return renderListLine(line, width, focused)
 	case actionRowAction:
-		state, _ := m.manager.ActionState(row.Action)
+		state, _ := m.app.ActionState(row.Action)
 		status := actionStatusIndicator(state.Status) + " " + row.Action.Name
-		if state.Status != service.ActionReady {
+		if state.Status != app.ActionReady {
 			status += ContextBarStyle.Render("  " + state.Status.String())
 		}
-		if state.Duration > 0 && state.Status != service.ActionRunning {
+		if state.Duration > 0 && state.Status != app.ActionRunning {
 			status += ContextBarStyle.Render(" · " + state.Duration.Round(time.Millisecond).String())
 		}
 		return renderListLine("      "+status, width, focused)
@@ -176,7 +176,7 @@ func (m *Model) renderServiceListRow(index int, row actionListRow, width int) st
 	}
 }
 
-func (m *Model) renderServiceOwnerLine(svc *service.Service, width int, focused bool) string {
+func (m *Model) renderServiceOwnerLine(svc *app.ServiceSnapshot, width int, focused bool) string {
 	disclosure := " "
 	if len(svc.Config.Actions) > 0 {
 		disclosure = "▸"
@@ -190,8 +190,8 @@ func (m *Model) renderServiceOwnerLine(svc *service.Service, width int, focused 
 	if visualState == visualQueued {
 		line += StartingBadgeStyle.Render("  queued")
 	}
-	if !focused && svc.NewLogCount() > 0 {
-		line += NewLogIndicatorStyle.Render(fmt.Sprintf(" +%d", svc.NewLogCount()))
+	if !focused && svc.State.NewLogCount > 0 {
+		line += NewLogIndicatorStyle.Render(fmt.Sprintf(" +%d", svc.State.NewLogCount))
 	}
 	if disclosure != " " {
 		line += ContextBarStyle.Render(" " + disclosure)
@@ -222,15 +222,15 @@ func selectionIndicator(selected bool) string {
 	return ContextBarStyle.Render("[ ]")
 }
 
-func actionStatusIndicator(status service.ActionStatus) string {
+func actionStatusIndicator(status app.ActionStatus) string {
 	switch status {
-	case service.ActionRunning:
+	case app.ActionRunning:
 		return StartingBadgeStyle.Render("◐")
-	case service.ActionSucceeded:
+	case app.ActionSucceeded:
 		return RunningBadgeStyle.Render("✓")
-	case service.ActionFailed, service.ActionTimedOut:
+	case app.ActionFailed, app.ActionTimedOut:
 		return FailedBadgeStyle.Render("×")
-	case service.ActionCancelled:
+	case app.ActionCancelled:
 		return StartingBadgeStyle.Render("■")
 	default:
 		return ContextBarStyle.Render("○")
@@ -309,7 +309,7 @@ func (m *Model) visibleTagRange(height int) (start, end int) {
 }
 
 // renderServiceLine renders selection, health state, name, and unread log count.
-func (m *Model) renderServiceLine(index int, svc *service.Service, width int) string {
+func (m *Model) renderServiceLine(index int, svc *app.ServiceSnapshot, width int) string {
 	return m.renderServiceOwnerLine(svc, width, index == m.focused && m.focusedAction == nil && m.focusedActionGroup == "")
 }
 
@@ -358,20 +358,20 @@ func serviceStatusLabel(status config.ServiceStatus, state serviceVisualState) s
 	}
 }
 
-func (m *Model) serviceVisualState(svc *service.Service) serviceVisualState {
-	switch svc.Status() {
+func (m *Model) serviceVisualState(svc *app.ServiceSnapshot) serviceVisualState {
+	switch svc.State.Status {
 	case config.StatusUnknown:
 		if svc.Config.IsDetached() {
 			if svc.Config.Lifecycle.Status == nil {
 				return visualExternal
 			}
-			if !svc.LifecycleStatusObserved() {
+			if !svc.StatusObserved {
 				return visualChecking
 			}
 		}
 		return visualUnknown
 	case config.StatusStopped:
-		if svc.DesiredRunning() {
+		if svc.DesiredRunning {
 			return visualQueued
 		}
 		return visualStopped
@@ -385,18 +385,17 @@ func (m *Model) serviceVisualState(svc *service.Service) serviceVisualState {
 	if checkConfig == nil {
 		return visualRunning
 	}
-	healthData := m.healthChecker.GetHealth(svc.Name)
-	if healthData == nil {
+	if !svc.Health.Observed {
 		return visualStarting
 	}
-	if checkConfig.Readiness != nil && !healthData.IsReady() {
+	if checkConfig.Readiness != nil && !svc.Health.Ready {
 		return visualStarting
 	}
 	if checkConfig.Liveness != nil {
-		if healthData.GetLastCheck().IsZero() {
+		if svc.Health.LastCheck.IsZero() {
 			return visualStarting
 		}
-		if !healthData.IsAlive() {
+		if !svc.Health.Alive {
 			return visualUnhealthy
 		}
 	}


### PR DESCRIPTION
## Summary
- Introduces `internal/app`, the shared application layer between Kranz delivery surfaces (`ProjectSnapshot`/`ServiceSnapshot` value types, an `API` interface, and `Local` — the only place that now constructs `service.Manager`, `health.Checker`, and `port.Checker`).
- Moves the configuration hot-reload pipeline (stamping, 1s debounce, `ApplyConfig`) from the TUI model into `internal/app`.
- Converts `internal/ui` to consume `app.API` and `[]app.ServiceSnapshot` instead of reaching into `internal/service`/`internal/health`/`internal/port` directly; deduplicates lifecycle-confirmation policy (`serviceStartPlanned`, dependency-confirmation names, stop-confirmation, quit plan) into `internal/app` as the single source of truth.
- `cmd/kranz/main.go` now builds the application layer and hands it to the TUI, instead of construction happening inside `ui.NewModelWithOptions`.
- Adds `internal/app/boundary_test.go`, which parses `internal/ui`'s imports and fails if production code there ever imports `internal/service`, `internal/health`, or `internal/port` again.

This is stream 1 (`refactor/runtime-application-api`) of the Kranz v0.8.0 CLI release plan (`artifacts-cli-08/releases/0.8.0/README.md`). It is an internal refactor only — no user-visible TUI behavior change, no CLI grammar change, no CHANGELOG entry. It unblocks the streams that build the CLI on top of the same runtime contracts.

## Test plan
- [x] `make verify` (gofmt, vet, `go test -race -cover ./...`, build, homebrew/release-notes checks)
- [x] `make lint` (golangci-lint, 0 issues)
- [x] Full `go test -race ./...` run clean, including 10x repeat of the one test that initially flagged a real stale-snapshot edge case (`TestShiftSOverridesQueuedDependencyStart`), now fixed rather than papered over
- [x] Manual smoke test: binary builds, loads a real project config, and constructs the application layer without panicking