### PR TITLE
feat(runtime): add discoverable session registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build run install fmt-check test vet verify lint clean snapshot release-check homebrew-formula-check release-notes-check tag
+.PHONY: all build dev run install fmt-check test vet verify lint clean snapshot release-check homebrew-formula-check release-notes-check tag
 
 APP_NAME := kranz
 BIN_DIR := bin
@@ -18,6 +18,12 @@ all: build
 build:
 	@mkdir -p $(BIN_DIR)
 	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o $(BIN_DIR)/$(APP_NAME) ./cmd/$(APP_NAME)
+
+# dev creates a deliberately separate executable so a released kranz binary
+# can stay installed while the current checkout is exercised end to end.
+dev:
+	@mkdir -p $(BIN_DIR)
+	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o $(BIN_DIR)/$(APP_NAME)-dev ./cmd/$(APP_NAME)
 
 run: build
 	./$(BIN_DIR)/$(APP_NAME)

--- a/cmd/kranz/main.go
+++ b/cmd/kranz/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -9,6 +10,8 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"text/tabwriter"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -49,6 +52,12 @@ func execute(args []string, stdout, stderr io.Writer) int {
 	if invocation.Command() == "version" {
 		return writeVersion(stdout, stderr, invocation.Globals.Output)
 	}
+	if invocation.Command() == "ps" {
+		if len(invocation.Args) != 0 {
+			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, &kranzcli.Error{Code: "invalid_arguments", Message: "ps does not accept arguments", ExitCode: kranzcli.ExitUsage})
+		}
+		return runPS(invocation.Globals, stdout, stderr)
+	}
 	if invocation.Command() != "" {
 		err := &kranzcli.Error{
 			Code: "not_implemented", Message: fmt.Sprintf("command %q is not implemented yet", invocation.Command()),
@@ -76,6 +85,62 @@ func execute(args []string, stdout, stderr io.Writer) int {
 		return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
 	}
 	return 0
+}
+
+func runPS(options kranzcli.GlobalOptions, stdout, stderr io.Writer) int {
+	registry, err := kranzruntime.DefaultRegistry()
+	if err != nil {
+		return kranzcli.WriteError(stdout, stderr, options.Output, err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	records, err := registry.List(ctx, version)
+	if err != nil {
+		return kranzcli.WriteError(stdout, stderr, options.Output, err)
+	}
+	if options.Project != "" {
+		filtered := records[:0]
+		for _, record := range records {
+			if record.Name == options.Project || record.ID == options.Project || strings.HasPrefix(record.ID, options.Project) {
+				filtered = append(filtered, record)
+			}
+		}
+		records = filtered
+	}
+	if options.Output == kranzcli.OutputJSON {
+		if err := kranzcli.WriteJSON(stdout, records); err != nil {
+			return kranzcli.WriteError(stdout, stderr, options.Output, err)
+		}
+		return 0
+	}
+	w := tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "ID\tNAME\tPROJECT\tMODE\tSERVICES\tSTATE\tUPTIME")
+	for _, record := range records {
+		services := "-"
+		if record.Services != nil {
+			services = fmt.Sprint(*record.Services)
+		}
+		id := record.ID
+		if len(id) > 8 {
+			id = id[:8]
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", id, record.Name, record.Project, record.Mode, services, record.State, shortDuration(time.Since(record.StartedAt)))
+	}
+	if err := w.Flush(); err != nil {
+		return kranzcli.WriteError(stdout, stderr, options.Output, err)
+	}
+	return 0
+}
+
+func shortDuration(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	d = d.Round(time.Second)
+	if d < time.Minute {
+		return d.String()
+	}
+	return d.Round(time.Minute).String()
 }
 
 func writeVersion(stdout, stderr io.Writer, format kranzcli.OutputFormat) int {
@@ -123,6 +188,27 @@ func runTUI(options kranzcli.GlobalOptions) (runErr error) {
 	if err != nil {
 		return &kranzcli.Error{Code: "invalid_config", Message: "load configuration", ExitCode: kranzcli.ExitConfig, Cause: err}
 	}
+	directory, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolve runtime directory: %w", err)
+	}
+	registry, err := kranzruntime.DefaultRegistry()
+	if err != nil {
+		return fmt.Errorf("open runtime registry: %w", err)
+	}
+	session, err := registry.Acquire(cfg.RuntimeName())
+	if err != nil {
+		var conflict *kranzruntime.SessionConflictError
+		if errors.As(err, &conflict) {
+			return &kranzcli.Error{Code: "runtime_conflict", Message: conflict.Error(), Hint: "Use `kranz -p " + cfg.RuntimeName() + " attach` or `kranz -p " + cfg.RuntimeName() + " down`.", ExitCode: kranzcli.ExitConflict}
+		}
+		return fmt.Errorf("acquire runtime session: %w", err)
+	}
+	defer func() { runErr = errors.Join(runErr, session.Close()) }()
+	metadata, err := session.Prepare(cfg.Project, version, "tui", directory)
+	if err != nil {
+		return fmt.Errorf("prepare runtime session: %w", err)
+	}
 
 	settingsPath, settingsPathErr := settings.DefaultPath()
 	if settingsPathErr != nil {
@@ -135,21 +221,16 @@ func runTUI(options kranzcli.GlobalOptions) (runErr error) {
 	}
 
 	// The runtime always speaks the socket protocol, even for an ordinary
-	// foreground `kranz` with no other client: this is the one place that
-	// constructs a Supervisor, so a future `up -d`/`attach` pair reuses this
-	// same wiring instead of a separate in-process path that could drift
-	// from it. поток 4 replaces this throwaway per-run directory with the
-	// session registry's stable path.
-	_, socketPath, cleanupSocketDir, err := kranzruntime.NewSocketDir()
-	if err != nil {
-		return fmt.Errorf("create runtime socket: %w", err)
-	}
-	defer cleanupSocketDir()
-
+	// foreground `kranz` with no other client. The published registry session
+	// lets ps and later attach/down clients discover this same supervisor.
 	local := app.NewLocal(cfg, cfgPaths, app.Options{})
 	supervisor := kranzruntime.NewSupervisor(local)
-	if err := supervisor.Listen(socketPath); err != nil {
+	if err := supervisor.Listen(metadata.Socket); err != nil {
 		return fmt.Errorf("start runtime supervisor: %w", err)
+	}
+	if err := session.Publish(); err != nil {
+		_ = supervisor.Close()
+		return fmt.Errorf("publish runtime session: %w", err)
 	}
 	serveErr := make(chan error, 1)
 	go func() { serveErr <- supervisor.Serve() }()
@@ -160,10 +241,27 @@ func runTUI(options kranzcli.GlobalOptions) (runErr error) {
 		}
 	}()
 
-	client, err := kranzruntime.Dial(socketPath, version)
+	client, err := kranzruntime.Dial(metadata.Socket, version)
 	if err != nil {
 		return fmt.Errorf("connect to runtime: %w", err)
 	}
+	defer func() { runErr = errors.Join(runErr, client.Close()) }()
+	stopOwnership := make(chan struct{})
+	ownershipDone := make(chan struct{})
+	go func() {
+		defer close(ownershipDone)
+		ticker := time.NewTicker(250 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			_ = session.UpdateOwnership(client.Services())
+			select {
+			case <-ticker.C:
+			case <-stopOwnership:
+				return
+			}
+		}
+	}()
+	defer func() { close(stopOwnership); <-ownershipDone }()
 
 	darkBackground := lipgloss.HasDarkBackground()
 	model := ui.NewModelWithOptions(cfg, version, ui.ModelOptions{

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -126,6 +126,9 @@ func mergeConfig(base, override *Config) error {
 	if override.Version != "" {
 		base.Version = override.Version
 	}
+	if override.Runtime.Name != "" {
+		base.Runtime.Name = override.Runtime.Name
+	}
 	if override.UI.Theme != "" {
 		base.UI.Theme = override.UI.Theme
 	}

--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -1,0 +1,27 @@
+package config
+
+import (
+	"regexp"
+	"strings"
+)
+
+var runtimeSlugSeparators = regexp.MustCompile(`[^a-z0-9_.-]+`)
+
+// RuntimeName returns the explicit runtime name or a stable slug derived from
+// the project title. Validate guarantees explicit names already use the
+// public 63-character alphabet.
+func (c *Config) RuntimeName() string {
+	if c.Runtime.Name != "" {
+		return c.Runtime.Name
+	}
+	name := strings.ToLower(strings.TrimSpace(c.Project))
+	name = runtimeSlugSeparators.ReplaceAllString(name, "-")
+	name = strings.Trim(name, "-._")
+	if name == "" {
+		name = "kranz"
+	}
+	if len(name) > 63 {
+		name = strings.TrimRight(name[:63], "-._")
+	}
+	return name
+}

--- a/internal/config/runtime_test.go
+++ b/internal/config/runtime_test.go
@@ -1,0 +1,24 @@
+package config
+
+import "testing"
+
+func TestRuntimeName(t *testing.T) {
+	tests := []struct{ project, explicit, want string }{
+		{"Shop API", "", "shop-api"},
+		{"  Démo / API  ", "", "d-mo-api"},
+		{"Shop", "shop-dev", "shop-dev"},
+	}
+	for _, test := range tests {
+		cfg := &Config{Project: test.project, Runtime: RuntimeConfig{Name: test.explicit}}
+		if got := cfg.RuntimeName(); got != test.want {
+			t.Errorf("RuntimeName(%q, %q) = %q, want %q", test.project, test.explicit, got, test.want)
+		}
+	}
+}
+
+func TestValidateRejectsInvalidRuntimeName(t *testing.T) {
+	cfg := &Config{Project: "Shop", Runtime: RuntimeConfig{Name: "Shop Dev"}, Services: map[string]Service{"web": {Command: "true"}}}
+	if err := Validate(cfg); err == nil {
+		t.Fatal("Validate accepted an invalid runtime.name")
+	}
+}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -11,6 +11,7 @@ import (
 type Config struct {
 	Project          string                 `yaml:"project"`
 	Version          string                 `yaml:"version,omitempty"`
+	Runtime          RuntimeConfig          `yaml:"runtime,omitempty"`
 	UI               UIConfig               `yaml:"ui,omitempty"`
 	Defaults         Defaults               `yaml:"defaults,omitempty"`
 	Services         map[string]Service     `yaml:"services,omitempty"`
@@ -23,6 +24,11 @@ type Config struct {
 	WatchPaths       []string               `yaml:"-"`
 	dotenvEnv        map[string]string      `yaml:"-"`
 	explicitEnv      map[string]string      `yaml:"-"`
+}
+
+// RuntimeConfig controls the discoverable local runtime identity.
+type RuntimeConfig struct {
+	Name string `yaml:"name,omitempty"`
 }
 
 // UIConfig defines project-specific presentation defaults.

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -12,6 +12,9 @@ func Validate(cfg *Config) error {
 	if cfg.Project == "" {
 		return fmt.Errorf("field 'project' is required")
 	}
+	if cfg.Runtime.Name != "" && !regexp.MustCompile(`^[a-z0-9][a-z0-9_.-]{0,62}$`).MatchString(cfg.Runtime.Name) {
+		return fmt.Errorf("runtime.name must match [a-z0-9][a-z0-9_.-]{0,62}, got %q", cfg.Runtime.Name)
+	}
 	switch cfg.UI.Background {
 	case "", UIBackgroundTerminal, UIBackgroundTheme:
 	default:

--- a/internal/runtime/client.go
+++ b/internal/runtime/client.go
@@ -36,7 +36,9 @@ type Client struct {
 	pendingMu sync.Mutex
 	pending   map[uint64]chan envelope
 
-	readErr atomic.Value // error
+	readErr   atomic.Value // error
+	closeOnce sync.Once
+	closeErr  error
 }
 
 // Dial connects to a Supervisor listening on socketPath and performs the
@@ -44,7 +46,12 @@ type Client struct {
 // diagnostics; it does not affect protocol negotiation in this stream, since
 // client and server are always built from the same binary.
 func Dial(socketPath, clientVersion string) (*Client, error) {
-	conn, err := net.Dial("unix", socketPath)
+	return DialContext(context.Background(), socketPath, clientVersion)
+}
+
+// DialContext bounds both connection establishment and the hello handshake.
+func DialContext(ctx context.Context, socketPath, clientVersion string) (*Client, error) {
+	conn, err := (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
 	if err != nil {
 		return nil, fmt.Errorf("dial %s: %w", socketPath, err)
 	}
@@ -57,6 +64,14 @@ func Dial(socketPath, clientVersion string) (*Client, error) {
 		conn:    unixConn,
 		c:       newCodec(unixConn),
 		pending: make(map[uint64]chan envelope),
+	}
+	deadline, hasDeadline := ctx.Deadline()
+	if !hasDeadline {
+		deadline = time.Now().Add(time.Second)
+	}
+	if err := unixConn.SetDeadline(deadline); err != nil {
+		_ = conn.Close()
+		return nil, err
 	}
 
 	helloBody, err := json.Marshal(helloRequest{ProtocolMin: protocolVersion, ProtocolMax: protocolVersion, ClientVersion: clientVersion})
@@ -99,6 +114,10 @@ func Dial(socketPath, clientVersion string) (*Client, error) {
 			ServerVersion:  hello.ServerVersion,
 		}
 	}
+	if err := unixConn.SetDeadline(time.Time{}); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
 
 	go client.readLoop()
 	return client, nil
@@ -107,7 +126,13 @@ func Dial(socketPath, clientVersion string) (*Client, error) {
 // Close closes the underlying connection. In-flight calls fail with the
 // connection error once the read loop observes the close.
 func (c *Client) Close() error {
-	return c.conn.Close()
+	c.closeOnce.Do(func() {
+		c.closeErr = c.conn.Close()
+		if errors.Is(c.closeErr, net.ErrClosed) {
+			c.closeErr = nil
+		}
+	})
+	return c.closeErr
 }
 
 func (c *Client) readLoop() {

--- a/internal/runtime/process_identity_darwin.go
+++ b/internal/runtime/process_identity_darwin.go
@@ -1,0 +1,18 @@
+//go:build darwin
+
+package runtime
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+func processIdentity(pid int) (int, string, error) {
+	info, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	if err != nil {
+		return 0, "", err
+	}
+	started := info.Proc.P_starttime
+	return int(info.Eproc.Pgid), fmt.Sprintf("darwin-start:%d.%06d", started.Sec, started.Usec), nil
+}

--- a/internal/runtime/process_identity_linux.go
+++ b/internal/runtime/process_identity_linux.go
@@ -1,0 +1,35 @@
+//go:build linux
+
+package runtime
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+func processIdentity(pid int) (int, string, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return 0, "", err
+	}
+	end := strings.LastIndex(string(data), ") ")
+	if end < 0 {
+		return 0, "", fmt.Errorf("invalid proc stat for %d", pid)
+	}
+	fields := strings.Fields(string(data)[end+2:])
+	if len(fields) <= 19 {
+		return 0, "", fmt.Errorf("short proc stat for %d", pid)
+	}
+	start, err := strconv.ParseUint(fields[19], 10, 64)
+	if err != nil {
+		return 0, "", err
+	}
+	pgid, err := syscall.Getpgid(pid)
+	if err != nil {
+		return 0, "", err
+	}
+	return pgid, fmt.Sprintf("linux-proc-start:%d", start), nil
+}

--- a/internal/runtime/process_identity_other.go
+++ b/internal/runtime/process_identity_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !linux
+
+package runtime
+
+import "fmt"
+
+func processIdentity(pid int) (int, string, error) {
+	return 0, "", fmt.Errorf("process identity is unsupported on this platform")
+}

--- a/internal/runtime/registry.go
+++ b/internal/runtime/registry.go
@@ -1,0 +1,385 @@
+package runtime
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/kranz-org/kranz/internal/app"
+)
+
+const metadataVersion = 1
+
+type SessionState string
+
+const (
+	SessionRunning      SessionState = "running"
+	SessionIncompatible SessionState = "incompatible"
+	SessionUnreachable  SessionState = "unreachable"
+)
+
+type SessionMetadata struct {
+	MetadataVersion int       `json:"metadata_version"`
+	ID              string    `json:"id"`
+	Name            string    `json:"name"`
+	Project         string    `json:"project"`
+	PID             int       `json:"pid"`
+	ProcessStarted  time.Time `json:"process_started_at"`
+	KranzVersion    string    `json:"kranz_version"`
+	ProtocolMin     int       `json:"protocol_min"`
+	ProtocolMax     int       `json:"protocol_max"`
+	Socket          string    `json:"socket"`
+	Mode            string    `json:"mode"`
+	StartedAt       time.Time `json:"started_at"`
+	Directory       string    `json:"directory"`
+}
+
+type SessionRecord struct {
+	SessionMetadata
+	State    SessionState `json:"state"`
+	Services *int         `json:"services"`
+}
+
+type Registry struct {
+	root       string
+	socketRoot string
+}
+
+func DefaultRegistry() (*Registry, error) {
+	return NewRegistry(filepath.Join(os.TempDir(), fmt.Sprintf("kranz-%d", os.Getuid())))
+}
+
+func NewRegistry(root string) (*Registry, error) {
+	if err := ensureOwnedDirectory(root); err != nil {
+		return nil, fmt.Errorf("create runtime registry: %w", err)
+	}
+	socketRoot := root
+	if len(filepath.Join(socketRoot, "s-0000000000000000.sock")) >= 104 {
+		socketRoot = filepath.Join("/tmp", fmt.Sprintf("kz-%d", os.Getuid()))
+		if err := ensureOwnedDirectory(socketRoot); err != nil {
+			return nil, fmt.Errorf("create runtime socket directory: %w", err)
+		}
+	}
+	return &Registry{root: root, socketRoot: socketRoot}, nil
+}
+
+func ensureOwnedDirectory(path string) error {
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		return err
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("%s is not a real directory", path)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || int(stat.Uid) != os.Getuid() {
+		return fmt.Errorf("%s is not owned by the current user", path)
+	}
+	if err := os.Chmod(path, 0o700); err != nil {
+		return err
+	}
+	return nil
+}
+
+type SessionConflictError struct{ Name string }
+
+func (e *SessionConflictError) Error() string {
+	return fmt.Sprintf("runtime %q is already active", e.Name)
+}
+
+type SessionHandle struct {
+	registry      *Registry
+	lock          *os.File
+	meta          SessionMetadata
+	mu            sync.Mutex
+	lastOwnership string
+	closed        bool
+}
+
+type OwnershipSnapshot struct {
+	Version   int            `json:"ownership_version"`
+	SessionID string         `json:"session_id"`
+	Processes []OwnedProcess `json:"processes"`
+}
+
+type OwnedProcess struct {
+	Service     string `json:"service"`
+	PID         int    `json:"pid"`
+	PGID        int    `json:"pgid"`
+	Fingerprint string `json:"birth_fingerprint"`
+}
+
+func (r *Registry) Acquire(name string) (*SessionHandle, error) {
+	return r.acquire(name, nil)
+}
+
+func (r *Registry) acquire(name string, afterOpen func()) (*SessionHandle, error) {
+	lockPath := r.lockPath(name)
+	for attempts := 0; attempts < 8; attempts++ {
+		file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR|syscall.O_CLOEXEC, 0o600)
+		if err != nil {
+			return nil, fmt.Errorf("open runtime lock: %w", err)
+		}
+		if afterOpen != nil {
+			afterOpen()
+			afterOpen = nil
+		}
+		if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+			if errors.Is(err, syscall.EWOULDBLOCK) {
+				matched, statErr := sameOpenFile(file, lockPath)
+				_ = file.Close()
+				if statErr == nil && matched {
+					return nil, &SessionConflictError{Name: name}
+				}
+				continue
+			}
+			_ = file.Close()
+			return nil, fmt.Errorf("lock runtime %q: %w", name, err)
+		}
+		matched, err := sameOpenFile(file, lockPath)
+		if err == nil && matched {
+			live, socket := r.existingSessionLive(name)
+			if live {
+				_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+				_ = file.Close()
+				return nil, &SessionConflictError{Name: name}
+			}
+			if socket != "" {
+				_ = os.Remove(socket)
+			}
+			_ = os.Remove(r.metadataPath(name))
+			_ = os.Remove(r.ownershipPath(name))
+			return &SessionHandle{registry: r, lock: file}, nil
+		}
+		_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+		_ = file.Close()
+	}
+	return nil, fmt.Errorf("runtime lock %q kept changing", name)
+}
+
+func (r *Registry) existingSessionLive(name string) (bool, string) {
+	data, err := os.ReadFile(r.metadataPath(name))
+	if err != nil {
+		return false, ""
+	}
+	var metadata SessionMetadata
+	if json.Unmarshal(data, &metadata) != nil || metadata.Socket == "" {
+		return false, ""
+	}
+	conn, err := net.DialTimeout("unix", metadata.Socket, 150*time.Millisecond)
+	if err != nil {
+		return false, metadata.Socket
+	}
+	_ = conn.Close()
+	return true, metadata.Socket
+}
+
+func sameOpenFile(file *os.File, path string) (bool, error) {
+	opened, err := file.Stat()
+	if err != nil {
+		return false, err
+	}
+	current, err := os.Stat(path)
+	if err != nil {
+		return false, err
+	}
+	return os.SameFile(opened, current), nil
+}
+
+func (h *SessionHandle) Prepare(project, version, mode, directory string) (SessionMetadata, error) {
+	idBytes := make([]byte, 16)
+	if _, err := rand.Read(idBytes); err != nil {
+		return SessionMetadata{}, fmt.Errorf("create session id: %w", err)
+	}
+	now := time.Now().UTC()
+	hash := sha256.Sum256([]byte(h.registry.root + "\x00" + hex.EncodeToString(idBytes)))
+	socket := filepath.Join(h.registry.socketRoot, "s-"+hex.EncodeToString(hash[:8])+".sock")
+	_ = os.Remove(socket)
+	h.meta = SessionMetadata{MetadataVersion: metadataVersion, ID: hex.EncodeToString(idBytes), Name: strings.TrimSuffix(filepath.Base(h.lock.Name()), ".lock"), Project: project, PID: os.Getpid(), ProcessStarted: now, KranzVersion: version, ProtocolMin: protocolVersion, ProtocolMax: protocolVersion, Socket: socket, Mode: mode, StartedAt: now, Directory: directory}
+	return h.meta, nil
+}
+
+// Publish atomically makes a listening session discoverable. Call it only
+// after the socket has been bound and permissioned.
+func (h *SessionHandle) Publish() error {
+	if h.meta.ID == "" {
+		return errors.New("runtime metadata was not prepared")
+	}
+	if err := atomicJSON(h.registry.metadataPath(h.meta.Name), h.meta); err != nil {
+		return err
+	}
+	return h.UpdateOwnership(nil)
+}
+
+// UpdateOwnership replaces the recovery snapshot without recording commands,
+// environment, or other secrets. A birth fingerprint makes PID reuse safe to
+// reject during a later forced shutdown.
+func (h *SessionHandle) UpdateOwnership(services []*app.ServiceSnapshot) error {
+	processes := make([]OwnedProcess, 0, len(services))
+	for _, service := range services {
+		if service == nil || service.State.PID <= 0 {
+			continue
+		}
+		pgid, fingerprint, err := processIdentity(service.State.PID)
+		if err != nil {
+			continue
+		}
+		processes = append(processes, OwnedProcess{Service: service.Name, PID: service.State.PID, PGID: pgid, Fingerprint: fingerprint})
+	}
+	sort.Slice(processes, func(i, j int) bool { return processes[i].Service < processes[j].Service })
+	snapshot := OwnershipSnapshot{Version: 1, SessionID: h.meta.ID, Processes: processes}
+	encoded, err := json.Marshal(snapshot)
+	if err != nil {
+		return err
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if string(encoded) == h.lastOwnership {
+		return nil
+	}
+	if err := atomicJSON(h.registry.ownershipPath(h.meta.Name), snapshot); err != nil {
+		return err
+	}
+	h.lastOwnership = string(encoded)
+	return nil
+}
+
+func (h *SessionHandle) Close() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		return nil
+	}
+	h.closed = true
+	if h.meta.Socket != "" {
+		_ = os.Remove(h.meta.Socket)
+	}
+	if h.meta.Name != "" {
+		_ = os.Remove(h.registry.metadataPath(h.meta.Name))
+		_ = os.Remove(h.registry.ownershipPath(h.meta.Name))
+	}
+	err := syscall.Flock(int(h.lock.Fd()), syscall.LOCK_UN)
+	return errors.Join(err, h.lock.Close())
+}
+
+func atomicJSON(path string, value any) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".kranz-meta-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	err = json.NewEncoder(tmp).Encode(value)
+	if err == nil {
+		err = tmp.Sync()
+	}
+	if closeErr := tmp.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+func (r *Registry) List(ctx context.Context, clientVersion string) ([]SessionRecord, error) {
+	paths, err := filepath.Glob(filepath.Join(r.root, "*.json"))
+	if err != nil {
+		return nil, err
+	}
+	records := make([]SessionRecord, 0, len(paths))
+	for _, path := range paths {
+		if strings.HasSuffix(path, ".ownership.json") {
+			continue
+		}
+		var metadata SessionMetadata
+		data, readErr := os.ReadFile(path)
+		if readErr != nil || json.Unmarshal(data, &metadata) != nil || metadata.MetadataVersion != metadataVersion {
+			continue
+		}
+		locked, probeErr := r.isLocked(metadata.Name)
+		if probeErr != nil {
+			continue
+		}
+		record := SessionRecord{SessionMetadata: metadata, State: SessionUnreachable}
+		client, dialErr := DialContext(ctx, metadata.Socket, clientVersion)
+		if dialErr == nil {
+			count := len(client.Services())
+			record.Services = &count
+			record.State = SessionRunning
+			_ = client.Close()
+		} else {
+			var mismatch *VersionMismatchError
+			if errors.As(dialErr, &mismatch) {
+				record.State = SessionIncompatible
+			}
+		}
+		if !locked && dialErr != nil && record.State == SessionUnreachable {
+			_ = os.Remove(metadata.Socket)
+			_ = os.Remove(path)
+			_ = os.Remove(r.ownershipPath(metadata.Name))
+			continue
+		}
+		records = append(records, record)
+	}
+	sort.Slice(records, func(i, j int) bool { return records[i].Name < records[j].Name })
+	return records, nil
+}
+
+func (r *Registry) isLocked(name string) (bool, error) {
+	path := r.lockPath(name)
+	for attempts := 0; attempts < 8; attempts++ {
+		file, err := os.OpenFile(path, os.O_RDWR|syscall.O_CLOEXEC, 0)
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		err = syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			matched, statErr := sameOpenFile(file, path)
+			_ = file.Close()
+			if statErr == nil && matched {
+				return true, nil
+			}
+			continue
+		}
+		if err != nil {
+			_ = file.Close()
+			return false, err
+		}
+		matched, statErr := sameOpenFile(file, path)
+		_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+		_ = file.Close()
+		if statErr == nil && matched {
+			return false, nil
+		}
+	}
+	return false, fmt.Errorf("runtime lock %q kept changing", name)
+}
+
+func (r *Registry) lockPath(name string) string     { return filepath.Join(r.root, name+".lock") }
+func (r *Registry) metadataPath(name string) string { return filepath.Join(r.root, name+".json") }
+func (r *Registry) ownershipPath(name string) string {
+	return filepath.Join(r.root, name+".ownership.json")
+}

--- a/internal/runtime/registry_test.go
+++ b/internal/runtime/registry_test.go
@@ -1,0 +1,322 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/kranz-org/kranz/internal/app"
+	"github.com/kranz-org/kranz/internal/config"
+	"golang.org/x/sys/unix"
+)
+
+func TestRegistrySessionLifecycleAndPermissions(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "registry")
+	registry, err := NewRegistry(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertMode(t, root, 0o700)
+	handle, err := registry.Acquire("shop-dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lockPath := registry.lockPath("shop-dev")
+	assertMode(t, lockPath, 0o600)
+	flags, err := unix.FcntlInt(handle.lock.Fd(), unix.F_GETFD, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if flags&unix.FD_CLOEXEC == 0 {
+		t.Fatal("runtime lock is inherited across exec")
+	}
+	metadata, err := handle.Prepare("Shop", "dev", "tui", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.GOOS == "darwin" && len(metadata.Socket) >= 104 {
+		t.Fatalf("socket path is %d bytes", len(metadata.Socket))
+	}
+	listener, err := listenUnix(metadata.Socket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = listener.Close() }()
+	assertMode(t, metadata.Socket, 0o600)
+	if err := handle.Publish(); err != nil {
+		t.Fatal(err)
+	}
+	assertMode(t, registry.metadataPath("shop-dev"), 0o600)
+	assertMode(t, registry.ownershipPath("shop-dev"), 0o600)
+	services := []*app.ServiceSnapshot{{Name: "web", State: config.ServiceState{PID: os.Getpid()}}}
+	if err := handle.UpdateOwnership(services); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(registry.ownershipPath("shop-dev"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ownership OwnershipSnapshot
+	if err := json.Unmarshal(data, &ownership); err != nil {
+		t.Fatal(err)
+	}
+	if ownership.SessionID != metadata.ID || len(ownership.Processes) != 1 || ownership.Processes[0].PID != os.Getpid() || ownership.Processes[0].Fingerprint == "" {
+		t.Fatalf("ownership snapshot = %+v", ownership)
+	}
+	if _, err := registry.Acquire("shop-dev"); err == nil {
+		t.Fatal("duplicate runtime acquired")
+	} else {
+		var conflict *SessionConflictError
+		if !errors.As(err, &conflict) {
+			t.Fatalf("duplicate error = %T: %v", err, err)
+		}
+	}
+	if err := handle.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("stable lock path disappeared: %v", err)
+	}
+	if _, err := os.Stat(metadata.Socket); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("socket remains after close: %v", err)
+	}
+}
+
+func TestRegistryListCleansStaleMetadataWithoutRemovingLock(t *testing.T) {
+	registry, err := NewRegistry(filepath.Join(t.TempDir(), "registry"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	handle, err := registry.Acquire("stale")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = handle.Prepare("Stale", "dev", "background", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := handle.Publish(); err != nil {
+		t.Fatal(err)
+	}
+	if err := syscallUnlockAndClose(handle); err != nil {
+		t.Fatal(err)
+	}
+	records, err := registry.List(context.Background(), "dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("List returned stale session: %+v", records)
+	}
+	if _, err := os.Stat(registry.lockPath("stale")); err != nil {
+		t.Fatalf("cleanup removed lock: %v", err)
+	}
+	if _, err := os.Stat(registry.metadataPath("stale")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("metadata was not cleaned: %v", err)
+	}
+}
+
+func syscallUnlockAndClose(handle *SessionHandle) error {
+	if err := unix.Flock(int(handle.lock.Fd()), unix.LOCK_UN); err != nil {
+		return err
+	}
+	handle.closed = true
+	return handle.lock.Close()
+}
+
+func assertMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("%s mode = %o, want %o", path, got, want)
+	}
+}
+
+func TestDialContextBoundsHello(t *testing.T) {
+	dir := t.TempDir()
+	socket := filepath.Join(dir, "slow.sock")
+	listener, err := listenUnix(socket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = listener.Close() }()
+	go func() {
+		conn, acceptErr := listener.AcceptUnix()
+		if acceptErr == nil {
+			defer func() { _ = conn.Close() }()
+			time.Sleep(time.Second)
+		}
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	_, err = DialContext(ctx, socket, "dev")
+	if err == nil {
+		t.Fatal("DialContext unexpectedly completed")
+	}
+	if time.Since(started) > 500*time.Millisecond {
+		t.Fatalf("DialContext ignored deadline")
+	}
+}
+
+func TestClientCloseIsIdempotentAfterPeerCloses(t *testing.T) {
+	dir, err := os.MkdirTemp("/tmp", "kz-close-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if cleanupErr := os.RemoveAll(dir); cleanupErr != nil {
+			t.Error(cleanupErr)
+		}
+	})
+	socket := filepath.Join(dir, "close.sock")
+	listener, err := listenUnix(socket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn, acceptErr := listener.AcceptUnix()
+		if acceptErr != nil {
+			return
+		}
+		codec := newCodec(conn)
+		request, receiveErr := codec.receive()
+		if receiveErr == nil && request.Method == methodHello {
+			body, _ := json.Marshal(helloResponse{ProtocolMin: protocolVersion, ProtocolMax: protocolVersion, AgreedProtocol: protocolVersion, ServerVersion: "dev"})
+			_ = codec.send(envelope{Type: messageResponse, ID: request.ID, Body: body})
+		}
+		_ = conn.Close()
+		_ = listener.Close()
+	}()
+	client, err := Dial(socket, "dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-done
+	time.Sleep(10 * time.Millisecond)
+	if err := client.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}
+
+func TestAcquireRetriesWhenLockPathIsReplaced(t *testing.T) {
+	registry, err := NewRegistry(filepath.Join(t.TempDir(), "registry"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var replacement *os.File
+	_, err = registry.acquire("race", func() {
+		if removeErr := os.Remove(registry.lockPath("race")); removeErr != nil {
+			t.Fatal(removeErr)
+		}
+		replacement, err = os.OpenFile(registry.lockPath("race"), os.O_CREATE|os.O_RDWR, 0o600)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err = unix.Flock(int(replacement.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if replacement != nil {
+		defer func() { _ = unix.Flock(int(replacement.Fd()), unix.LOCK_UN); _ = replacement.Close() }()
+	}
+	var conflict *SessionConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("Acquire after replacement = %T %v, want conflict", err, err)
+	}
+}
+
+func TestRegistryListDiscoversRunningSupervisor(t *testing.T) {
+	registry, err := NewRegistry(filepath.Join(t.TempDir(), "registry"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	handle, err := registry.Acquire("shop")
+	if err != nil {
+		t.Fatal(err)
+	}
+	metadata, err := handle.Prepare("Shop", "dev", "background", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{Project: "Shop", Services: map[string]config.Service{"web": {Command: "true"}}}
+	supervisor := NewSupervisor(app.NewLocal(cfg, nil, app.Options{}))
+	if err := supervisor.Listen(metadata.Socket); err != nil {
+		t.Fatal(err)
+	}
+	if err := handle.Publish(); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- supervisor.Serve() }()
+	defer func() { _ = supervisor.Close(); <-done; _ = handle.Close() }()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	records, err := registry.List(ctx, "dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 || records[0].State != SessionRunning || records[0].Services == nil || *records[0].Services != 1 {
+		t.Fatalf("List = %+v", records)
+	}
+}
+
+func TestAcquireDoesNotReplaceLiveSessionAfterLockPathReplacement(t *testing.T) {
+	registry, err := NewRegistry(filepath.Join(t.TempDir(), "registry"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	owner, err := registry.Acquire("live")
+	if err != nil {
+		t.Fatal(err)
+	}
+	metadata, err := owner.Prepare("Live", "dev", "tui", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	listener, err := listenUnix(metadata.Socket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = listener.Close() }()
+	if err := owner.Publish(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(registry.lockPath("live")); err != nil {
+		t.Fatal(err)
+	}
+	replacement, err := os.OpenFile(registry.lockPath("live"), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := replacement.Close(); err != nil {
+		t.Fatal(err)
+	}
+	_, err = registry.Acquire("live")
+	var conflict *SessionConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("Acquire = %T %v, want conflict", err, err)
+	}
+	if _, err := os.Stat(metadata.Socket); err != nil {
+		t.Fatalf("live socket was removed: %v", err)
+	}
+	if _, err := os.Stat(registry.metadataPath("live")); err != nil {
+		t.Fatalf("live metadata was removed: %v", err)
+	}
+	if err := owner.Close(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/runtime/supervisor.go
+++ b/internal/runtime/supervisor.go
@@ -37,6 +37,7 @@ type Supervisor struct {
 
 	stopWatch chan struct{}
 	watchDone chan struct{}
+	watching  atomic.Bool
 
 	connWG sync.WaitGroup
 
@@ -81,6 +82,7 @@ func (s *Supervisor) Serve() error {
 	if s.listener == nil {
 		return errors.New("runtime: Serve called before Listen")
 	}
+	s.watching.Store(true)
 	go s.runReloadWatcher()
 
 	for {
@@ -115,7 +117,9 @@ func (s *Supervisor) Close() error {
 	if s.listener != nil {
 		err = s.listener.Close()
 	}
-	<-s.watchDone
+	if s.watching.Load() {
+		<-s.watchDone
+	}
 	return err
 }
 


### PR DESCRIPTION
## Summary
- add owner-only named runtime registry with stable locks, short sockets, atomic metadata, and ownership snapshots
- publish foreground TUI sessions and expose them through text/JSON `kranz ps`
- add bounded IPC dialing, idempotent client shutdown, and a separate `make dev` / `bin/kranz-dev` build

## Validation
- `make verify`
- `make lint`
- race tests for duplicate ownership, lock replacement, stale cleanup, permissions, socket length, handshake timeout, and shutdown
- Linux and macOS cross-builds
- live TUI → `ps` → duplicate rejection → clean `q` smoke