### PR TITLE
feat(cli): add foreground runtime control

### DIFF
--- a/cmd/kranz/main.go
+++ b/cmd/kranz/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"text/tabwriter"
 	"time"
@@ -57,6 +58,36 @@ func execute(args []string, stdout, stderr io.Writer) int {
 			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, &kranzcli.Error{Code: "invalid_arguments", Message: "ps does not accept arguments", ExitCode: kranzcli.ExitUsage})
 		}
 		return runPS(invocation.Globals, stdout, stderr)
+	}
+	if invocation.Command() == "up" {
+		if invocation.Globals.Output != kranzcli.OutputText {
+			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, &kranzcli.Error{Code: "invalid_output", Message: "foreground up requires text output", ExitCode: kranzcli.ExitUsage})
+		}
+		if err := runUp(invocation.Globals, invocation.Args, stdout); err != nil {
+			var requested requestedExitError
+			if errors.As(err, &requested) {
+				return requested.code
+			}
+			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
+		}
+		return 0
+	}
+	if invocation.Command() == "status" {
+		if err := runStatus(invocation.Globals, invocation.Args, stdout); err != nil {
+			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
+		}
+		return 0
+	}
+	if invocation.Command() == "down" {
+		if err := runDown(invocation.Globals, invocation.Args); err != nil {
+			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
+		}
+		if invocation.Globals.Output == kranzcli.OutputJSON {
+			if err := kranzcli.WriteJSON(stdout, struct{}{}); err != nil {
+				return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
+			}
+		}
+		return 0
 	}
 	if invocation.Command() != "" {
 		err := &kranzcli.Error{
@@ -268,7 +299,12 @@ func runTUI(options kranzcli.GlobalOptions) (runErr error) {
 		Settings: userSettings, SettingsPath: settingsPath, ConfigPaths: cfgPaths,
 		DarkBackground: &darkBackground, App: client,
 	})
-	defer func() { runErr = errors.Join(runErr, model.Shutdown()) }()
+	var remoteDown atomic.Bool
+	defer func() {
+		if !remoteDown.Load() {
+			runErr = errors.Join(runErr, model.Shutdown())
+		}
+	}()
 
 	program := tea.NewProgram(model, tea.WithAltScreen(), tea.WithMouseCellMotion(), tea.WithReportFocus())
 	signals := make(chan os.Signal, 1)
@@ -279,6 +315,9 @@ func runTUI(options kranzcli.GlobalOptions) (runErr error) {
 	go func() {
 		select {
 		case <-signals:
+			program.Quit()
+		case <-supervisor.ShutdownRequested():
+			remoteDown.Store(true)
 			program.Quit()
 		case <-runDone:
 		}

--- a/cmd/kranz/main_test.go
+++ b/cmd/kranz/main_test.go
@@ -2,9 +2,19 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
+
+	kranzruntime "github.com/kranz-org/kranz/internal/runtime"
 )
 
 func TestVersionTextAndJSON(t *testing.T) {
@@ -31,6 +41,130 @@ func TestVersionTextAndJSON(t *testing.T) {
 	data := envelope["data"].(map[string]any)
 	if data["version"] != "1.2.3" || data["commit"] != "abc123" {
 		t.Fatalf("version envelope = %#v", envelope)
+	}
+}
+
+func TestForegroundHelperProcess(t *testing.T) {
+	if os.Getenv("KRANZ_TEST_FOREGROUND_HELPER") != "1" {
+		return
+	}
+	directory := os.Getenv("KRANZ_TEST_PROJECT_DIR")
+	os.Exit(execute([]string{"-C", directory, "up", "--no-start"}, os.Stdout, os.Stderr))
+}
+
+func TestForegroundRuntimeStatusAndRemoteDown(t *testing.T) {
+	directory := t.TempDir()
+	name := fmt.Sprintf("test-foreground-%d", os.Getpid())
+	configText := fmt.Sprintf("project: Test Foreground\nruntime:\n  name: %s\nservices:\n  sleeper:\n    command: sleep 60\n    env:\n      TOKEN: top-secret-value\n", name)
+	if err := os.WriteFile(filepath.Join(directory, "kranz.yaml"), []byte(configText), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	command := exec.Command(os.Args[0], "-test.run=^TestForegroundHelperProcess$")
+	command.Env = append(os.Environ(), "KRANZ_TEST_FOREGROUND_HELPER=1", "KRANZ_TEST_PROJECT_DIR="+directory)
+	command.Stdout = io.Discard
+	var childStderr bytes.Buffer
+	command.Stderr = &childStderr
+	if err := command.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if command.ProcessState == nil {
+			_ = command.Process.Kill()
+		}
+	})
+
+	registry, err := kranzruntime.DefaultRegistry()
+	if err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		_, err = registry.Resolve(ctx, name, "test")
+		cancel()
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("runtime did not appear: %v; stderr=%s", err, childStderr.String())
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := execute([]string{"-p", name, "status", "--output=json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("status exit=%d stderr=%s", code, stderr.String())
+	}
+	if !json.Valid(stdout.Bytes()) || strings.Contains(stdout.String(), "top-secret-value") || strings.Contains(stdout.String(), "TOKEN") {
+		t.Fatalf("unsafe status JSON: %s", stdout.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := execute([]string{"-p", name, "down"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("down exit=%d stderr=%s", code, stderr.String())
+	}
+	done := make(chan error, 1)
+	go func() { done <- command.Wait() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("foreground owner exit: %v; stderr=%s", err, childStderr.String())
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("foreground owner did not exit after remote down")
+	}
+}
+
+func TestForegroundSignalsPreserveSignalDeath(t *testing.T) {
+	for _, sig := range []syscall.Signal{syscall.SIGINT, syscall.SIGTERM} {
+		t.Run(sig.String(), func(t *testing.T) {
+			directory := t.TempDir()
+			name := fmt.Sprintf("test-signal-%d-%d", os.Getpid(), sig)
+			configText := fmt.Sprintf("project: Test Signal\nruntime:\n  name: %s\nservices:\n  sleeper:\n    command: sleep 60\n", name)
+			if err := os.WriteFile(filepath.Join(directory, "kranz.yaml"), []byte(configText), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			command := exec.Command(os.Args[0], "-test.run=^TestForegroundHelperProcess$")
+			command.Env = append(os.Environ(), "KRANZ_TEST_FOREGROUND_HELPER=1", "KRANZ_TEST_PROJECT_DIR="+directory)
+			command.Stdout, command.Stderr = io.Discard, io.Discard
+			if err := command.Start(); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				if command.ProcessState == nil {
+					_ = command.Process.Kill()
+				}
+			})
+			registry, err := kranzruntime.DefaultRegistry()
+			if err != nil {
+				t.Fatal(err)
+			}
+			deadline := time.Now().Add(5 * time.Second)
+			for {
+				ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+				_, err = registry.Resolve(ctx, name, "test")
+				cancel()
+				if err == nil {
+					break
+				}
+				if time.Now().After(deadline) {
+					t.Fatalf("runtime did not appear: %v", err)
+				}
+				time.Sleep(20 * time.Millisecond)
+			}
+			if err := command.Process.Signal(sig); err != nil {
+				t.Fatal(err)
+			}
+			err = command.Wait()
+			exitError, ok := err.(*exec.ExitError)
+			if !ok {
+				t.Fatalf("Wait = %T %v, want signal exit", err, err)
+			}
+			status, ok := exitError.Sys().(syscall.WaitStatus)
+			if !ok || !status.Signaled() || status.Signal() != sig {
+				t.Fatalf("wait status = %#v, want %s", exitError.Sys(), sig)
+			}
+		})
 	}
 }
 

--- a/cmd/kranz/main_test.go
+++ b/cmd/kranz/main_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -127,9 +128,12 @@ func TestForegroundSignalsPreserveSignalDeath(t *testing.T) {
 			command := exec.Command(os.Args[0], "-test.run=^TestForegroundHelperProcess$")
 			command.Env = append(os.Environ(), "KRANZ_TEST_FOREGROUND_HELPER=1", "KRANZ_TEST_PROJECT_DIR="+directory)
 			command.Stdout, command.Stderr = io.Discard, io.Discard
+			signal.Ignore(sig)
 			if err := command.Start(); err != nil {
+				signal.Reset(sig)
 				t.Fatal(err)
 			}
+			signal.Reset(sig)
 			t.Cleanup(func() {
 				if command.ProcessState == nil {
 					_ = command.Process.Kill()

--- a/cmd/kranz/runtime_commands.go
+++ b/cmd/kranz/runtime_commands.go
@@ -254,13 +254,10 @@ func terminateForegroundWithSignal(host *runtimeHost, closeHost func() error, si
 	if !ok {
 		return fmt.Errorf("unsupported signal %v", sig)
 	}
-	if err := forceDefaultSignal(unixSignal); err != nil {
-		return fmt.Errorf("restore default %s disposition: %w", sig, err)
+	if err := reraiseDefaultSignal(unixSignal); err != nil {
+		return fmt.Errorf("re-raise %s with default disposition: %w", sig, err)
 	}
-	if err := syscall.Kill(os.Getpid(), unixSignal); err != nil {
-		return err
-	}
-	return nil
+	return fmt.Errorf("re-raising %s with default disposition did not terminate the process", sig)
 }
 
 func resolveSession(options kranzcli.GlobalOptions, requireProject bool) (kranzruntime.SessionRecord, error) {

--- a/cmd/kranz/runtime_commands.go
+++ b/cmd/kranz/runtime_commands.go
@@ -1,0 +1,398 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"text/tabwriter"
+	"time"
+
+	"github.com/kranz-org/kranz/internal/app"
+	kranzcli "github.com/kranz-org/kranz/internal/cli"
+	"github.com/kranz-org/kranz/internal/config"
+	kranzruntime "github.com/kranz-org/kranz/internal/runtime"
+)
+
+type runtimeHost struct {
+	session       *kranzruntime.SessionHandle
+	supervisor    *kranzruntime.Supervisor
+	client        *kranzruntime.Client
+	serveErr      chan error
+	stopOwnership chan struct{}
+	ownershipDone chan struct{}
+	restoreDir    func() error
+	closed        bool
+}
+
+func startRuntime(options kranzcli.GlobalOptions, mode string) (*runtimeHost, *config.Config, error) {
+	originalDirectory, err := os.Getwd()
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := os.Chdir(options.Directory); err != nil {
+		return nil, nil, fmt.Errorf("change directory to %s: %w", options.Directory, err)
+	}
+	restore := func() error { return os.Chdir(originalDirectory) }
+	fail := func(err error) (*runtimeHost, *config.Config, error) { return nil, nil, errors.Join(err, restore()) }
+
+	cfgPaths := options.ConfigPaths
+	if len(cfgPaths) == 0 {
+		cfgPaths, err = config.DiscoverFiles(".")
+		if err != nil {
+			return fail(fmt.Errorf("discover configuration: %w", err))
+		}
+	}
+	cfg, err := config.LoadFiles(cfgPaths)
+	if err != nil {
+		return fail(fmt.Errorf("load configuration: %w", err))
+	}
+	name := cfg.RuntimeName()
+	if options.Project != "" {
+		if err := config.ValidateRuntimeName(options.Project); err != nil {
+			return fail(err)
+		}
+		name = options.Project
+	}
+	directory, err := os.Getwd()
+	if err != nil {
+		return fail(err)
+	}
+	registry, err := kranzruntime.DefaultRegistry()
+	if err != nil {
+		return fail(err)
+	}
+	session, err := registry.Acquire(name)
+	if err != nil {
+		return fail(err)
+	}
+	metadata, err := session.Prepare(cfg.Project, version, mode, directory)
+	if err != nil {
+		_ = session.Close()
+		return fail(err)
+	}
+	local := app.NewLocal(cfg, cfgPaths, app.Options{})
+	supervisor := kranzruntime.NewSupervisor(local)
+	if err := supervisor.Listen(metadata.Socket); err != nil {
+		_ = session.Close()
+		return fail(err)
+	}
+	if err := session.Publish(); err != nil {
+		_ = supervisor.Close()
+		_ = session.Close()
+		return fail(err)
+	}
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- supervisor.Serve() }()
+	client, err := kranzruntime.Dial(metadata.Socket, version)
+	if err != nil {
+		_ = supervisor.Close()
+		<-serveErr
+		_ = session.Close()
+		return fail(err)
+	}
+	host := &runtimeHost{session: session, supervisor: supervisor, client: client, serveErr: serveErr, stopOwnership: make(chan struct{}), ownershipDone: make(chan struct{}), restoreDir: restore}
+	go host.watchOwnership()
+	return host, cfg, nil
+}
+
+func (h *runtimeHost) watchOwnership() {
+	defer close(h.ownershipDone)
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		_ = h.session.UpdateOwnership(h.client.Services())
+		select {
+		case <-ticker.C:
+		case <-h.stopOwnership:
+			return
+		}
+	}
+}
+
+func (h *runtimeHost) Close() error {
+	if h == nil || h.closed {
+		return nil
+	}
+	h.closed = true
+	close(h.stopOwnership)
+	<-h.ownershipDone
+	clientErr := h.client.Close()
+	supervisorErr := h.supervisor.Close()
+	serveErr := <-h.serveErr
+	sessionErr := h.session.Close()
+	return errors.Join(clientErr, supervisorErr, serveErr, sessionErr, h.restoreDir())
+}
+
+func runUp(options kranzcli.GlobalOptions, args []string, stdout io.Writer) error {
+	noStart := false
+	selectors := make([]string, 0, len(args))
+	for _, arg := range args {
+		switch arg {
+		case "--no-start":
+			noStart = true
+		case "-d", "--detach":
+			return &kranzcli.Error{Code: "not_implemented", Message: "background mode is not implemented in this build", ExitCode: kranzcli.ExitUsage}
+		default:
+			if strings.HasPrefix(arg, "-") {
+				return &kranzcli.Error{Code: "unknown_option", Message: "unknown up option " + arg, ExitCode: kranzcli.ExitUsage}
+			}
+			selectors = append(selectors, arg)
+		}
+	}
+	if noStart && len(selectors) > 0 {
+		return &kranzcli.Error{Code: "invalid_arguments", Message: "--no-start cannot be combined with selectors", ExitCode: kranzcli.ExitUsage}
+	}
+	host, cfg, err := startRuntime(options, "foreground")
+	if err != nil {
+		return classifyRuntimeError(err)
+	}
+	closed := false
+	closeHost := func() error {
+		if closed {
+			return nil
+		}
+		closed = true
+		return host.Close()
+	}
+	defer func() { _ = closeHost() }()
+	signals := make(chan os.Signal, 2)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(signals)
+
+	if !noStart {
+		if len(selectors) == 0 {
+			for _, name := range cfg.ServiceOrder {
+				if !cfg.Services[name].Disabled {
+					selectors = append(selectors, name)
+				}
+			}
+		}
+		for _, name := range selectors {
+			if _, ok := cfg.Services[name]; !ok {
+				_ = host.client.Shutdown()
+				return &kranzcli.Error{Code: "service_not_found", Message: fmt.Sprintf("service %q was not found", name), ExitCode: kranzcli.ExitNotFound}
+			}
+		}
+		startCtx, cancelStart := context.WithCancel(context.Background())
+		startDone := make(chan error, 1)
+		go func() { startDone <- host.client.StartServicesContext(startCtx, selectors) }()
+		select {
+		case err := <-startDone:
+			cancelStart()
+			if err != nil {
+				_ = host.client.Shutdown()
+				return err
+			}
+		case sig := <-signals:
+			cancelStart()
+			<-startDone
+			return terminateForegroundWithSignal(host, closeHost, signals, sig)
+		}
+	}
+	effectiveName := cfg.RuntimeName()
+	if options.Project != "" {
+		effectiveName = options.Project
+	}
+	if _, err := fmt.Fprintf(stdout, "Kranz runtime %s is ready (%s). Press Ctrl+C to stop.\n", cfg.Project, effectiveName); err != nil {
+		_ = host.client.Shutdown()
+		return err
+	}
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	logOffsets := make(map[string]int)
+	for {
+		select {
+		case sig := <-signals:
+			return terminateForegroundWithSignal(host, closeHost, signals, sig)
+		case <-host.supervisor.ShutdownRequested():
+			return closeHost()
+		case <-ticker.C:
+			for _, service := range host.client.Services() {
+				entries := host.client.Logs(service.Name)
+				start := logOffsets[service.Name]
+				if start > len(entries) {
+					start = 0
+				}
+				for _, entry := range entries[start:] {
+					line := strings.TrimRight(entry.Raw, "\r\n")
+					if line == "" {
+						line = strings.TrimRight(entry.Text, "\r\n")
+					}
+					_, _ = fmt.Fprintf(stdout, "[%s] %s\n", service.Name, line)
+				}
+				logOffsets[service.Name] = len(entries)
+			}
+			if requested, code := host.client.ProjectExitRequested(); requested {
+				_ = host.client.Shutdown()
+				if err := closeHost(); err != nil {
+					return err
+				}
+				if code != 0 {
+					return requestedExitError{code: code}
+				}
+				return nil
+			}
+		}
+	}
+}
+
+func terminateForegroundWithSignal(host *runtimeHost, closeHost func() error, signals chan os.Signal, sig os.Signal) error {
+	shutdownErr := host.client.Shutdown()
+	closeErr := closeHost()
+	if err := errors.Join(shutdownErr, closeErr); err != nil {
+		return err
+	}
+	signal.Stop(signals)
+	signal.Reset(sig)
+	unixSignal, ok := sig.(syscall.Signal)
+	if !ok {
+		return fmt.Errorf("unsupported signal %v", sig)
+	}
+	if err := syscall.Kill(os.Getpid(), unixSignal); err != nil {
+		return err
+	}
+	return nil
+}
+
+func resolveSession(options kranzcli.GlobalOptions, requireProject bool) (kranzruntime.SessionRecord, error) {
+	reference := options.Project
+	if reference == "" {
+		if requireProject {
+			return kranzruntime.SessionRecord{}, &kranzcli.Error{Code: "missing_project", Message: "-p NAME_OR_ID is required", ExitCode: kranzcli.ExitUsage}
+		}
+		original, err := os.Getwd()
+		if err != nil {
+			return kranzruntime.SessionRecord{}, err
+		}
+		if err := os.Chdir(options.Directory); err != nil {
+			return kranzruntime.SessionRecord{}, err
+		}
+		defer func() { _ = os.Chdir(original) }() // best effort; command performs no work after resolution on failure
+		paths := options.ConfigPaths
+		if len(paths) == 0 {
+			paths, err = config.DiscoverFiles(".")
+			if err != nil {
+				return kranzruntime.SessionRecord{}, err
+			}
+		}
+		cfg, err := config.LoadFiles(paths)
+		if err != nil {
+			return kranzruntime.SessionRecord{}, err
+		}
+		reference = cfg.RuntimeName()
+	}
+	registry, err := kranzruntime.DefaultRegistry()
+	if err != nil {
+		return kranzruntime.SessionRecord{}, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	record, err := registry.Resolve(ctx, reference, version)
+	if err != nil {
+		return kranzruntime.SessionRecord{}, classifyRuntimeError(err)
+	}
+	return record, nil
+}
+
+func runStatus(options kranzcli.GlobalOptions, args []string, stdout io.Writer) error {
+	record, err := resolveSession(options, false)
+	if err != nil {
+		return err
+	}
+	client, err := kranzruntime.DialContext(context.Background(), record.Socket, version)
+	if err != nil {
+		return classifyRuntimeError(err)
+	}
+	defer func() { _ = client.Close() }()
+	services := client.Services()
+	if len(args) > 0 {
+		selected := make([]*app.ServiceSnapshot, 0, len(args))
+		for _, name := range args {
+			service, ok := client.Service(name)
+			if !ok {
+				return &kranzcli.Error{Code: "service_not_found", Message: fmt.Sprintf("service %q was not found", name), ExitCode: kranzcli.ExitNotFound}
+			}
+			selected = append(selected, service)
+		}
+		services = selected
+	}
+	if options.Output == kranzcli.OutputJSON {
+		type statusService struct {
+			Name          string `json:"name"`
+			State         string `json:"state"`
+			PID           int    `json:"pid"`
+			Ready         *bool  `json:"ready"`
+			Alive         *bool  `json:"alive"`
+			DetectedPorts []int  `json:"detected_ports"`
+		}
+		safe := make([]statusService, 0, len(services))
+		for _, service := range services {
+			var ready, alive *bool
+			if service.Health.Observed {
+				readyValue, aliveValue := service.Health.Ready, service.Health.Alive
+				ready, alive = &readyValue, &aliveValue
+			}
+			safe = append(safe, statusService{Name: service.Name, State: service.State.Status.String(), PID: service.State.PID, Ready: ready, Alive: alive, DetectedPorts: service.DetectedPorts})
+		}
+		return kranzcli.WriteJSON(stdout, struct {
+			Session  kranzruntime.SessionMetadata `json:"session"`
+			Services []statusService              `json:"services"`
+		}{record.SessionMetadata, safe})
+	}
+	w := tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "NAME\tSTATE\tPID\tREADY")
+	for _, service := range services {
+		ready := "-"
+		if service.Health.Observed {
+			ready = fmt.Sprint(service.Health.Ready)
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%d\t%s\n", service.Name, service.State.Status.String(), service.State.PID, ready)
+	}
+	return w.Flush()
+}
+
+func runDown(options kranzcli.GlobalOptions, args []string) error {
+	if len(args) > 0 {
+		return &kranzcli.Error{Code: "invalid_arguments", Message: "down does not accept arguments in this build", ExitCode: kranzcli.ExitUsage}
+	}
+	record, err := resolveSession(options, true)
+	if err != nil {
+		return err
+	}
+	client, err := kranzruntime.DialContext(context.Background(), record.Socket, version)
+	if err != nil {
+		return classifyRuntimeError(err)
+	}
+	return client.Shutdown()
+}
+
+func classifyRuntimeError(err error) error {
+	var conflict *kranzruntime.SessionConflictError
+	if errors.As(err, &conflict) {
+		return &kranzcli.Error{Code: "runtime_conflict", Message: conflict.Error(), Hint: "Use `kranz -p " + conflict.Name + " status` or `kranz -p " + conflict.Name + " down`.", ExitCode: kranzcli.ExitConflict}
+	}
+	var missing *kranzruntime.SessionNotFoundError
+	if errors.As(err, &missing) {
+		return &kranzcli.Error{Code: "runtime_not_found", Message: missing.Error(), ExitCode: kranzcli.ExitNotFound}
+	}
+	var ambiguous *kranzruntime.AmbiguousSessionError
+	if errors.As(err, &ambiguous) {
+		return &kranzcli.Error{Code: "ambiguous_runtime", Message: ambiguous.Error(), ExitCode: kranzcli.ExitConflict}
+	}
+	var mismatch *kranzruntime.VersionMismatchError
+	if errors.As(err, &mismatch) {
+		return &kranzcli.Error{Code: "protocol_mismatch", Message: mismatch.Error(), ExitCode: kranzcli.ExitUnavailable}
+	}
+	var networkError net.Error
+	if errors.As(err, &networkError) {
+		return &kranzcli.Error{Code: "runtime_unavailable", Message: "runtime is unavailable", ExitCode: kranzcli.ExitUnavailable, Cause: err}
+	}
+	return err
+}

--- a/cmd/kranz/runtime_commands.go
+++ b/cmd/kranz/runtime_commands.go
@@ -148,6 +148,9 @@ func runUp(options kranzcli.GlobalOptions, args []string, stdout io.Writer) erro
 	if noStart && len(selectors) > 0 {
 		return &kranzcli.Error{Code: "invalid_arguments", Message: "--no-start cannot be combined with selectors", ExitCode: kranzcli.ExitUsage}
 	}
+	signals := make(chan os.Signal, 2)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(signals)
 	host, cfg, err := startRuntime(options, "foreground")
 	if err != nil {
 		return classifyRuntimeError(err)
@@ -161,10 +164,6 @@ func runUp(options kranzcli.GlobalOptions, args []string, stdout io.Writer) erro
 		return host.Close()
 	}
 	defer func() { _ = closeHost() }()
-	signals := make(chan os.Signal, 2)
-	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
-	defer signal.Stop(signals)
-
 	if !noStart {
 		if len(selectors) == 0 {
 			for _, name := range cfg.ServiceOrder {
@@ -254,6 +253,9 @@ func terminateForegroundWithSignal(host *runtimeHost, closeHost func() error, si
 	unixSignal, ok := sig.(syscall.Signal)
 	if !ok {
 		return fmt.Errorf("unsupported signal %v", sig)
+	}
+	if err := forceDefaultSignal(unixSignal); err != nil {
+		return fmt.Errorf("restore default %s disposition: %w", sig, err)
 	}
 	if err := syscall.Kill(os.Getpid(), unixSignal); err != nil {
 		return err

--- a/cmd/kranz/signal_default_darwin.go
+++ b/cmd/kranz/signal_default_darwin.go
@@ -14,11 +14,11 @@ type userSignalAction struct {
 	flags   int32
 }
 
-func forceDefaultSignal(sig syscall.Signal) error {
+func reraiseDefaultSignal(sig syscall.Signal) error {
 	action := userSignalAction{}
 	_, _, errno := syscall.RawSyscall(syscall.SYS_SIGACTION, uintptr(sig), uintptr(unsafe.Pointer(&action)), 0)
 	if errno != 0 {
 		return errno
 	}
-	return nil
+	return syscall.Kill(syscall.Getpid(), sig)
 }

--- a/cmd/kranz/signal_default_darwin.go
+++ b/cmd/kranz/signal_default_darwin.go
@@ -1,0 +1,23 @@
+//go:build darwin
+
+package main
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+type userSignalAction struct {
+	handler uintptr
+	mask    uint32
+	flags   int32
+}
+
+func forceDefaultSignal(sig syscall.Signal) error {
+	action := userSignalAction{}
+	_, _, errno := syscall.RawSyscall(syscall.SYS_SIGACTION, uintptr(sig), uintptr(unsafe.Pointer(&action)), 0)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}

--- a/cmd/kranz/signal_default_darwin.go
+++ b/cmd/kranz/signal_default_darwin.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build darwin && !cgo
 
 package main
 
@@ -9,6 +9,7 @@ import (
 
 type userSignalAction struct {
 	handler uintptr
+	tramp   uintptr
 	mask    uint32
 	flags   int32
 }

--- a/cmd/kranz/signal_default_darwin_cgo.go
+++ b/cmd/kranz/signal_default_darwin_cgo.go
@@ -5,13 +5,15 @@ package main
 /*
 #include <errno.h>
 #include <signal.h>
+#include <unistd.h>
 
-static int kranz_signal_default(int sig) {
+static int kranz_signal_default_and_raise(int sig) {
 	struct sigaction action;
 	if (sigemptyset(&action.sa_mask) != 0) return errno;
 	action.sa_handler = SIG_DFL;
 	action.sa_flags = 0;
 	if (sigaction(sig, &action, NULL) != 0) return errno;
+	if (kill(getpid(), sig) != 0) return errno;
 	return 0;
 }
 */
@@ -19,8 +21,8 @@ import "C"
 
 import "syscall"
 
-func forceDefaultSignal(sig syscall.Signal) error {
-	if errno := C.kranz_signal_default(C.int(sig)); errno != 0 {
+func reraiseDefaultSignal(sig syscall.Signal) error {
+	if errno := C.kranz_signal_default_and_raise(C.int(sig)); errno != 0 {
 		return syscall.Errno(errno)
 	}
 	return nil

--- a/cmd/kranz/signal_default_darwin_cgo.go
+++ b/cmd/kranz/signal_default_darwin_cgo.go
@@ -1,0 +1,27 @@
+//go:build darwin && cgo
+
+package main
+
+/*
+#include <errno.h>
+#include <signal.h>
+
+static int kranz_signal_default(int sig) {
+	struct sigaction action;
+	if (sigemptyset(&action.sa_mask) != 0) return errno;
+	action.sa_handler = SIG_DFL;
+	action.sa_flags = 0;
+	if (sigaction(sig, &action, NULL) != 0) return errno;
+	return 0;
+}
+*/
+import "C"
+
+import "syscall"
+
+func forceDefaultSignal(sig syscall.Signal) error {
+	if errno := C.kranz_signal_default(C.int(sig)); errno != 0 {
+		return syscall.Errno(errno)
+	}
+	return nil
+}

--- a/cmd/kranz/signal_default_linux.go
+++ b/cmd/kranz/signal_default_linux.go
@@ -14,11 +14,11 @@ type kernelSignalAction struct {
 	mask     uint64
 }
 
-func forceDefaultSignal(sig syscall.Signal) error {
+func reraiseDefaultSignal(sig syscall.Signal) error {
 	action := kernelSignalAction{}
 	_, _, errno := syscall.RawSyscall6(syscall.SYS_RT_SIGACTION, uintptr(sig), uintptr(unsafe.Pointer(&action)), 0, 8, 0, 0)
 	if errno != 0 {
 		return errno
 	}
-	return nil
+	return syscall.Kill(syscall.Getpid(), sig)
 }

--- a/cmd/kranz/signal_default_linux.go
+++ b/cmd/kranz/signal_default_linux.go
@@ -1,0 +1,24 @@
+//go:build linux
+
+package main
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+type kernelSignalAction struct {
+	handler  uintptr
+	flags    uint64
+	restorer uintptr
+	mask     uint64
+}
+
+func forceDefaultSignal(sig syscall.Signal) error {
+	action := kernelSignalAction{}
+	_, _, errno := syscall.RawSyscall6(syscall.SYS_RT_SIGACTION, uintptr(sig), uintptr(unsafe.Pointer(&action)), 0, 8, 0, 0)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}

--- a/cmd/kranz/signal_default_other.go
+++ b/cmd/kranz/signal_default_other.go
@@ -2,6 +2,9 @@
 
 package main
 
-import "syscall"
+import (
+	"os"
+	"syscall"
+)
 
-func forceDefaultSignal(syscall.Signal) error { return nil }
+func reraiseDefaultSignal(sig syscall.Signal) error { return syscall.Kill(os.Getpid(), sig) }

--- a/cmd/kranz/signal_default_other.go
+++ b/cmd/kranz/signal_default_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin && !linux
+
+package main
+
+import "syscall"
+
+func forceDefaultSignal(syscall.Signal) error { return nil }

--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -1,11 +1,20 @@
 package config
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 )
 
 var runtimeSlugSeparators = regexp.MustCompile(`[^a-z0-9_.-]+`)
+var runtimeNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_.-]{0,62}$`)
+
+func ValidateRuntimeName(name string) error {
+	if !runtimeNamePattern.MatchString(name) {
+		return fmt.Errorf("runtime name must match [a-z0-9][a-z0-9_.-]{0,62}, got %q", name)
+	}
+	return nil
+}
 
 // RuntimeName returns the explicit runtime name or a stable slug derived from
 // the project title. Validate guarantees explicit names already use the

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -12,8 +12,10 @@ func Validate(cfg *Config) error {
 	if cfg.Project == "" {
 		return fmt.Errorf("field 'project' is required")
 	}
-	if cfg.Runtime.Name != "" && !regexp.MustCompile(`^[a-z0-9][a-z0-9_.-]{0,62}$`).MatchString(cfg.Runtime.Name) {
-		return fmt.Errorf("runtime.name must match [a-z0-9][a-z0-9_.-]{0,62}, got %q", cfg.Runtime.Name)
+	if cfg.Runtime.Name != "" {
+		if err := ValidateRuntimeName(cfg.Runtime.Name); err != nil {
+			return fmt.Errorf("runtime.name: %w", err)
+		}
 	}
 	switch cfg.UI.Background {
 	case "", UIBackgroundTerminal, UIBackgroundTheme:

--- a/internal/runtime/integration_test.go
+++ b/internal/runtime/integration_test.go
@@ -115,6 +115,25 @@ func TestSupervisorClientDriveARealServiceLifecycle(t *testing.T) {
 	}
 }
 
+func TestStartedServiceOutlivesCompletedRPCRequest(t *testing.T) {
+	cfg := &config.Config{Project: "RPC lifetime", Services: map[string]config.Service{
+		"worker": {Command: "sleep 60"},
+	}}
+	client, cleanup := startTestSupervisor(t, cfg, nil)
+	defer cleanup()
+	if err := client.StartServicesContext(context.Background(), []string{"worker"}); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	worker, ok := client.Service("worker")
+	if !ok || worker.State.Status != config.StatusRunning || worker.State.PID <= 0 {
+		t.Fatalf("service after completed start RPC = %+v, exists=%v", worker, ok)
+	}
+	if err := client.StopAll(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestSupervisorClientRunNonInteractiveAction(t *testing.T) {
 	cfg := &config.Config{
 		Project: "RPC Actions",

--- a/internal/runtime/registry.go
+++ b/internal/runtime/registry.go
@@ -102,6 +102,21 @@ func (e *SessionConflictError) Error() string {
 	return fmt.Sprintf("runtime %q is already active", e.Name)
 }
 
+type SessionNotFoundError struct{ Reference string }
+
+func (e *SessionNotFoundError) Error() string {
+	return fmt.Sprintf("runtime %q was not found", e.Reference)
+}
+
+type AmbiguousSessionError struct {
+	Reference string
+	Matches   []string
+}
+
+func (e *AmbiguousSessionError) Error() string {
+	return fmt.Sprintf("runtime reference %q is ambiguous (%s)", e.Reference, strings.Join(e.Matches, ", "))
+}
+
 type SessionHandle struct {
 	registry      *Registry
 	lock          *os.File
@@ -343,6 +358,36 @@ func (r *Registry) List(ctx context.Context, clientVersion string) ([]SessionRec
 	}
 	sort.Slice(records, func(i, j int) bool { return records[i].Name < records[j].Name })
 	return records, nil
+}
+
+// Resolve accepts an exact NAME, a full ID, or a unique ID prefix.
+func (r *Registry) Resolve(ctx context.Context, reference, clientVersion string) (SessionRecord, error) {
+	records, err := r.List(ctx, clientVersion)
+	if err != nil {
+		return SessionRecord{}, err
+	}
+	for _, record := range records {
+		if record.Name == reference || record.ID == reference {
+			return record, nil
+		}
+	}
+	matches := make([]SessionRecord, 0)
+	for _, record := range records {
+		if strings.HasPrefix(record.ID, reference) {
+			matches = append(matches, record)
+		}
+	}
+	if len(matches) == 1 {
+		return matches[0], nil
+	}
+	if len(matches) == 0 {
+		return SessionRecord{}, &SessionNotFoundError{Reference: reference}
+	}
+	names := make([]string, len(matches))
+	for i, match := range matches {
+		names[i] = match.ID[:8] + " (" + match.Name + ")"
+	}
+	return SessionRecord{}, &AmbiguousSessionError{Reference: reference, Matches: names}
 }
 
 func (r *Registry) isLocked(name string) (bool, error) {

--- a/internal/runtime/supervisor.go
+++ b/internal/runtime/supervisor.go
@@ -41,8 +41,14 @@ type Supervisor struct {
 
 	connWG sync.WaitGroup
 
-	closeOnce sync.Once
-	closed    chan struct{}
+	closeOnce                 sync.Once
+	closed                    chan struct{}
+	shutdownOnce              sync.Once
+	shutdownRequested         chan struct{}
+	applicationShutdownOnce   sync.Once
+	applicationShutdownDone   chan struct{}
+	applicationShutdownResult any
+	applicationShutdownErr    error
 }
 
 // NewSupervisor wraps local. local must not be driven by any other caller
@@ -51,12 +57,19 @@ type Supervisor struct {
 // services.
 func NewSupervisor(local *app.Local) *Supervisor {
 	return &Supervisor{
-		local:     local,
-		stopWatch: make(chan struct{}),
-		watchDone: make(chan struct{}),
-		closed:    make(chan struct{}),
+		local:                   local,
+		stopWatch:               make(chan struct{}),
+		watchDone:               make(chan struct{}),
+		closed:                  make(chan struct{}),
+		shutdownRequested:       make(chan struct{}),
+		applicationShutdownDone: make(chan struct{}),
 	}
 }
+
+// ShutdownRequested closes after a successful remote Shutdown RPC response
+// has been written. The process owner uses it to tear down the listener and
+// registry entry after the application layer has stopped its services.
+func (s *Supervisor) ShutdownRequested() <-chan struct{} { return s.shutdownRequested }
 
 // Serve binds socketPath, starts the background reload watcher, and accepts
 // connections until Close is called or the listener otherwise fails. It
@@ -302,7 +315,18 @@ func (s *Supervisor) dispatch(ctx context.Context, c *codec, msg envelope, lease
 		_ = c.send(envelope{Type: messageError, ID: msg.ID, Body: body})
 		return
 	}
-	result, err := entry(ctx, s.local, msg.Body)
+	var result any
+	var err error
+	if msg.Method == methodShutdown {
+		s.applicationShutdownOnce.Do(func() {
+			s.applicationShutdownResult, s.applicationShutdownErr = entry(context.Background(), s.local, msg.Body)
+			close(s.applicationShutdownDone)
+		})
+		<-s.applicationShutdownDone
+		result, err = s.applicationShutdownResult, s.applicationShutdownErr
+	} else {
+		result, err = entry(ctx, s.local, msg.Body)
+	}
 	if err != nil {
 		body, marshalErr := json.Marshal(encodeError(err))
 		if marshalErr != nil {
@@ -322,7 +346,9 @@ func (s *Supervisor) dispatch(ctx context.Context, c *codec, msg envelope, lease
 		_ = c.send(envelope{Type: messageError, ID: msg.ID, Body: body})
 		return
 	}
-	_ = c.send(envelope{Type: messageResponse, ID: msg.ID, Body: body})
+	if err := c.send(envelope{Type: messageResponse, ID: msg.ID, Body: body}); err == nil && msg.Method == methodShutdown {
+		s.shutdownOnce.Do(func() { close(s.shutdownRequested) })
+	}
 }
 
 func validateInteractiveLease(msg envelope, leases *connectionLeases) error {

--- a/internal/service/manager_start.go
+++ b/internal/service/manager_start.go
@@ -93,7 +93,16 @@ func (m *Manager) startService(ctx context.Context, name string, recovery bool) 
 		return fmt.Errorf("service %q has no start capability", name)
 	}
 
-	pid, err := pm.Start(ctx, start.Command, start.Dir, start.Env, start.Shell)
+	// ctx bounds the start operation (prerequisites and dependency gates), not
+	// the lifetime of the managed process. RPC handlers cancel their request
+	// context after sending the response; tying exec.CommandContext to it would
+	// kill every successfully started service as soon as `start` returned.
+	if err := ctx.Err(); err != nil {
+		svc.SetDesiredRunning(false)
+		svc.SetStatus(config.StatusStopped)
+		return err
+	}
+	pid, err := pm.Start(context.Background(), start.Command, start.Dir, start.Env, start.Shell)
 	if err != nil {
 		svc.SetDesiredRunning(false)
 		svc.SetStatus(config.StatusStopped)


### PR DESCRIPTION
## Summary
- add foreground `up`, runtime `status` (text/JSON), and graceful remote `down`
- preserve real SIGINT/SIGTERM termination semantics and close foreground/TUI owners after remote shutdown
- resolve sessions by NAME/full ID/unique prefix with classified CLI errors
- decouple managed process lifetime from the completed start RPC request context

## Security
- status JSON contains only explicit runtime/service status fields and never effective config or env
- ownership snapshots update while services transition

## Validation
- `make verify`
- `make lint`
- subprocess tests for remote down and WIFSIGNALED(SIGINT/SIGTERM)
- protocol regression proving a service remains running after start RPC returns
- live `up preview` → logs → status → ownership snapshot → remote down
- live TUI → remote down exits both commands 0