### PR TITLE
feat(cli): add background runtimes and attach

### DIFF
--- a/cmd/kranz/attach.go
+++ b/cmd/kranz/attach.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	kranzcli "github.com/kranz-org/kranz/internal/cli"
+	"github.com/kranz-org/kranz/internal/config"
+	kranzruntime "github.com/kranz-org/kranz/internal/runtime"
+	"github.com/kranz-org/kranz/internal/settings"
+	"github.com/kranz-org/kranz/internal/ui"
+)
+
+func runAttach(options kranzcli.GlobalOptions, args []string) (runErr error) {
+	if len(args) > 0 {
+		return &kranzcli.Error{Code: "invalid_arguments", Message: "attach does not accept arguments", ExitCode: kranzcli.ExitUsage}
+	}
+	record, err := resolveSession(options, true)
+	if err != nil {
+		return err
+	}
+	originalDirectory, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	if err := os.Chdir(record.Directory); err != nil {
+		return fmt.Errorf("open runtime directory %s: %w", record.Directory, err)
+	}
+	defer func() { runErr = errors.Join(runErr, os.Chdir(originalDirectory)) }()
+	client, err := kranzruntime.Dial(record.Socket, version)
+	if err != nil {
+		return classifyRuntimeError(err)
+	}
+	defer func() { runErr = errors.Join(runErr, client.Close()) }()
+	cfg := client.Config()
+	if cfg == nil {
+		return errors.New("runtime returned no effective configuration")
+	}
+	return runAttachedTUI(client, cfg)
+}
+
+func runAttachedTUI(client *kranzruntime.Client, cfg *config.Config) (runErr error) {
+	settingsPath, settingsPathErr := settings.DefaultPath()
+	if settingsPathErr != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Kranz settings warning: %v\n", settingsPathErr)
+	}
+	userSettings, settingsErr := settings.Load(settingsPath)
+	if settingsErr != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Kranz settings warning: %v\n", settingsErr)
+		userSettings = settings.Settings{}
+	}
+	darkBackground := lipgloss.HasDarkBackground()
+	model := ui.NewModelWithOptions(cfg, version, ui.ModelOptions{Settings: userSettings, SettingsPath: settingsPath, ConfigPaths: cfg.Paths, DarkBackground: &darkBackground, App: client, DetachOnExit: true})
+	defer func() { runErr = errors.Join(runErr, model.Shutdown()) }()
+	program := tea.NewProgram(model, tea.WithAltScreen(), tea.WithMouseCellMotion(), tea.WithReportFocus())
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
+	defer signal.Stop(signals)
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-signals:
+			program.Quit()
+		case <-client.Done():
+			program.Quit()
+		case <-done:
+		}
+	}()
+	if _, err := program.Run(); err != nil {
+		return &kranzcli.Error{Code: "tui", Message: "run attached TUI", ExitCode: kranzcli.ExitInternal, Cause: err}
+	}
+	if code := model.RequestedExitCode(); code != 0 {
+		return requestedExitError{code: code}
+	}
+	return nil
+}

--- a/cmd/kranz/background_process_other.go
+++ b/cmd/kranz/background_process_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin && !linux
+
+package main
+
+import "syscall"
+
+func backgroundProcessAttributes() *syscall.SysProcAttr { return &syscall.SysProcAttr{} }

--- a/cmd/kranz/background_process_unix.go
+++ b/cmd/kranz/background_process_unix.go
@@ -1,0 +1,7 @@
+//go:build darwin || linux
+
+package main
+
+import "syscall"
+
+func backgroundProcessAttributes() *syscall.SysProcAttr { return &syscall.SysProcAttr{Setsid: true} }

--- a/cmd/kranz/main.go
+++ b/cmd/kranz/main.go
@@ -89,6 +89,19 @@ func execute(args []string, stdout, stderr io.Writer) int {
 		}
 		return 0
 	}
+	if invocation.Command() == "attach" {
+		if invocation.Globals.Output != kranzcli.OutputText {
+			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, &kranzcli.Error{Code: "invalid_output", Message: "attach requires text output", ExitCode: kranzcli.ExitUsage})
+		}
+		if err := runAttach(invocation.Globals, invocation.Args); err != nil {
+			var requested requestedExitError
+			if errors.As(err, &requested) {
+				return requested.code
+			}
+			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
+		}
+		return 0
+	}
 	if invocation.Command() != "" {
 		err := &kranzcli.Error{
 			Code: "not_implemented", Message: fmt.Sprintf("command %q is not implemented yet", invocation.Command()),
@@ -219,13 +232,32 @@ func runTUI(options kranzcli.GlobalOptions) (runErr error) {
 	if err != nil {
 		return &kranzcli.Error{Code: "invalid_config", Message: "load configuration", ExitCode: kranzcli.ExitConfig, Cause: err}
 	}
-	directory, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("resolve runtime directory: %w", err)
-	}
 	registry, err := kranzruntime.DefaultRegistry()
 	if err != nil {
 		return fmt.Errorf("open runtime registry: %w", err)
+	}
+	lookupCtx, cancelLookup := context.WithTimeout(context.Background(), 2*time.Second)
+	record, lookupErr := registry.Resolve(lookupCtx, cfg.RuntimeName(), version)
+	cancelLookup()
+	if lookupErr == nil {
+		client, dialErr := kranzruntime.Dial(record.Socket, version)
+		if dialErr != nil {
+			return classifyRuntimeError(dialErr)
+		}
+		defer func() { runErr = errors.Join(runErr, client.Close()) }()
+		activeConfig := client.Config()
+		if activeConfig == nil {
+			return errors.New("runtime returned no effective configuration")
+		}
+		return runAttachedTUI(client, activeConfig)
+	}
+	var missingRuntime *kranzruntime.SessionNotFoundError
+	if !errors.As(lookupErr, &missingRuntime) {
+		return classifyRuntimeError(lookupErr)
+	}
+	directory, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolve runtime directory: %w", err)
 	}
 	session, err := registry.Acquire(cfg.RuntimeName())
 	if err != nil {

--- a/cmd/kranz/main_test.go
+++ b/cmd/kranz/main_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -15,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	kranzcli "github.com/kranz-org/kranz/internal/cli"
 	kranzruntime "github.com/kranz-org/kranz/internal/runtime"
 )
 
@@ -51,6 +54,78 @@ func TestForegroundHelperProcess(t *testing.T) {
 	}
 	directory := os.Getenv("KRANZ_TEST_PROJECT_DIR")
 	os.Exit(execute([]string{"-C", directory, "up", "--no-start"}, os.Stdout, os.Stderr))
+}
+
+func TestBackgroundHelperProcess(t *testing.T) {
+	if os.Getenv("KRANZ_TEST_BACKGROUND_HELPER") != "1" {
+		return
+	}
+	data, err := base64.StdEncoding.DecodeString(os.Getenv("KRANZ_TEST_BACKGROUND_ARGS"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var args []string
+	if err := json.Unmarshal(data, &args); err != nil {
+		t.Fatal(err)
+	}
+	os.Exit(execute(args, os.Stdout, os.Stderr))
+}
+
+func TestBackgroundRuntimeReadinessConflictAndDown(t *testing.T) {
+	directory := t.TempDir()
+	name := fmt.Sprintf("test-background-%d", os.Getpid())
+	configText := fmt.Sprintf("project: Test Background\nruntime:\n  name: %s\nservices:\n  sleeper:\n    command: sleep 60\n", name)
+	if err := os.WriteFile(filepath.Join(directory, "kranz.yaml"), []byte(configText), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	previousFactory := newBackgroundCommand
+	newBackgroundCommand = func(_ string, args ...string) *exec.Cmd {
+		data, _ := json.Marshal(args)
+		command := exec.Command(os.Args[0], "-test.run=^TestBackgroundHelperProcess$")
+		command.Env = append(os.Environ(), "KRANZ_TEST_BACKGROUND_HELPER=1", "KRANZ_TEST_BACKGROUND_ARGS="+base64.StdEncoding.EncodeToString(data))
+		return command
+	}
+	defer func() { newBackgroundCommand = previousFactory }()
+	var stdout, stderr bytes.Buffer
+	if code := execute([]string{"-C", directory, "up", "-d", "--no-start"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("up -d exit=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Started "+name) {
+		t.Fatalf("readiness output = %q", stdout.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := execute([]string{"-C", directory, "up", "-d", "--no-start"}, &stdout, &stderr); code != kranzcli.ExitConflict {
+		t.Fatalf("duplicate exit=%d stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := execute([]string{"-p", name, "status", "--output=json"}, &stdout, &stderr); code != 0 || !json.Valid(stdout.Bytes()) {
+		t.Fatalf("status exit=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := execute([]string{"-p", name, "down"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("down exit=%d stderr=%s", code, stderr.String())
+	}
+	registry, err := kranzruntime.DefaultRegistry()
+	if err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		_, err = registry.Resolve(ctx, name, "test")
+		cancel()
+		var missing *kranzruntime.SessionNotFoundError
+		if errors.As(err, &missing) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("background runtime remained after down: %v", err)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
 }
 
 func TestForegroundRuntimeStatusAndRemoteDown(t *testing.T) {

--- a/cmd/kranz/runtime_commands.go
+++ b/cmd/kranz/runtime_commands.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net"
 	"os"
+	"os/exec"
 	"os/signal"
 	"strings"
 	"syscall"
@@ -131,13 +133,14 @@ func (h *runtimeHost) Close() error {
 
 func runUp(options kranzcli.GlobalOptions, args []string, stdout io.Writer) error {
 	noStart := false
+	detached := false
 	selectors := make([]string, 0, len(args))
 	for _, arg := range args {
 		switch arg {
 		case "--no-start":
 			noStart = true
 		case "-d", "--detach":
-			return &kranzcli.Error{Code: "not_implemented", Message: "background mode is not implemented in this build", ExitCode: kranzcli.ExitUsage}
+			detached = true
 		default:
 			if strings.HasPrefix(arg, "-") {
 				return &kranzcli.Error{Code: "unknown_option", Message: "unknown up option " + arg, ExitCode: kranzcli.ExitUsage}
@@ -147,6 +150,13 @@ func runUp(options kranzcli.GlobalOptions, args []string, stdout io.Writer) erro
 	}
 	if noStart && len(selectors) > 0 {
 		return &kranzcli.Error{Code: "invalid_arguments", Message: "--no-start cannot be combined with selectors", ExitCode: kranzcli.ExitUsage}
+	}
+	if detached {
+		if os.Getenv("KRANZ_INTERNAL_BACKGROUND") == "1" {
+			_ = os.Unsetenv("KRANZ_INTERNAL_BACKGROUND")
+			return runBackgroundChild(options, selectors, noStart)
+		}
+		return spawnBackground(options, selectors, noStart, stdout)
 	}
 	signals := make(chan os.Signal, 2)
 	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
@@ -187,6 +197,10 @@ func runUp(options kranzcli.GlobalOptions, args []string, stdout io.Writer) erro
 			if err != nil {
 				_ = host.client.Shutdown()
 				return err
+			}
+			if err := host.session.UpdateOwnership(host.client.Services()); err != nil {
+				_ = host.client.Shutdown()
+				return fmt.Errorf("record runtime ownership: %w", err)
 			}
 		case sig := <-signals:
 			cancelStart()
@@ -240,6 +254,221 @@ func runUp(options kranzcli.GlobalOptions, args []string, stdout io.Writer) erro
 			}
 		}
 	}
+}
+
+type backgroundReady struct {
+	OK       bool   `json:"ok"`
+	ID       string `json:"id,omitempty"`
+	Name     string `json:"name,omitempty"`
+	PID      int    `json:"pid,omitempty"`
+	Error    string `json:"error,omitempty"`
+	Code     string `json:"code,omitempty"`
+	Hint     string `json:"hint,omitempty"`
+	ExitCode int    `json:"exit_code,omitempty"`
+}
+
+var newBackgroundCommand = func(executable string, args ...string) *exec.Cmd { return exec.Command(executable, args...) }
+
+func spawnBackground(options kranzcli.GlobalOptions, selectors []string, noStart bool, stdout io.Writer) error {
+	executable, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = reader.Close() }()
+	args := []string{"-C", options.Directory}
+	for _, path := range options.ConfigPaths {
+		args = append(args, "-f", path)
+	}
+	if options.Project != "" {
+		args = append(args, "-p", options.Project)
+	}
+	args = append(args, "up", "-d")
+	if noStart {
+		args = append(args, "--no-start")
+	} else {
+		args = append(args, selectors...)
+	}
+	command := newBackgroundCommand(executable, args...)
+	if command.Env == nil {
+		command.Env = os.Environ()
+	}
+	command.Env = append(command.Env, "KRANZ_INTERNAL_BACKGROUND=1")
+	command.ExtraFiles = []*os.File{writer}
+	command.SysProcAttr = backgroundProcessAttributes()
+	command.Stdout, command.Stderr = io.Discard, io.Discard
+	devNull, err := os.Open(os.DevNull)
+	if err != nil {
+		_ = writer.Close()
+		return err
+	}
+	defer func() { _ = devNull.Close() }()
+	command.Stdin = devNull
+	if err := command.Start(); err != nil {
+		_ = writer.Close()
+		return err
+	}
+	_ = writer.Close()
+	readyResult := make(chan struct {
+		ready backgroundReady
+		err   error
+	}, 1)
+	go func() {
+		var ready backgroundReady
+		decodeErr := json.NewDecoder(reader).Decode(&ready)
+		readyResult <- struct {
+			ready backgroundReady
+			err   error
+		}{ready, decodeErr}
+	}()
+	select {
+	case result := <-readyResult:
+		if result.err != nil {
+			waitErr := command.Wait()
+			return fmt.Errorf("background runtime exited before readiness: %w", errors.Join(result.err, waitErr))
+		}
+		if !result.ready.OK {
+			_ = command.Wait()
+			exitCode := result.ready.ExitCode
+			if exitCode == 0 {
+				exitCode = kranzcli.ExitInternal
+			}
+			code := result.ready.Code
+			if code == "" {
+				code = "background_start"
+			}
+			return &kranzcli.Error{Code: code, Message: result.ready.Error, Hint: result.ready.Hint, ExitCode: exitCode}
+		}
+		if err := command.Process.Release(); err != nil {
+			return err
+		}
+		_, err = fmt.Fprintf(stdout, "Started %s (%s), PID %d.\n", result.ready.Name, shortID(result.ready.ID), result.ready.PID)
+		return err
+	case <-time.After(60 * time.Second):
+		_ = command.Process.Signal(syscall.SIGTERM)
+		waitDone := make(chan error, 1)
+		go func() { waitDone <- command.Wait() }()
+		select {
+		case <-waitDone:
+		case <-time.After(10 * time.Second):
+			_ = command.Process.Kill()
+			<-waitDone
+		}
+		return &kranzcli.Error{Code: "background_timeout", Message: "background runtime did not become ready within 1m", ExitCode: kranzcli.ExitUnavailable}
+	}
+}
+
+func runBackgroundChild(options kranzcli.GlobalOptions, selectors []string, noStart bool) error {
+	readyFile := os.NewFile(3, "kranz-readiness")
+	if readyFile == nil {
+		return errors.New("background readiness descriptor is missing")
+	}
+	syscall.CloseOnExec(3)
+	defer func() { _ = readyFile.Close() }()
+	sendReady := func(ready backgroundReady) error { return json.NewEncoder(readyFile).Encode(ready) }
+	signals := make(chan os.Signal, 2)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(signals)
+	host, cfg, err := startRuntime(options, "background")
+	if err != nil {
+		classified := kranzcli.AsError(classifyRuntimeError(err))
+		_ = sendReady(backgroundReady{Error: classified.Error(), Code: classified.Code, Hint: classified.Hint, ExitCode: classified.ExitCode})
+		return err
+	}
+	closed := false
+	closeHost := func() error {
+		if closed {
+			return nil
+		}
+		closed = true
+		return host.Close()
+	}
+	defer func() { _ = closeHost() }()
+	if !noStart {
+		if len(selectors) == 0 {
+			for _, name := range cfg.ServiceOrder {
+				if !cfg.Services[name].Disabled {
+					selectors = append(selectors, name)
+				}
+			}
+		}
+		for _, name := range selectors {
+			if _, ok := cfg.Services[name]; !ok {
+				_ = host.client.Shutdown()
+				commandErr := &kranzcli.Error{Code: "service_not_found", Message: fmt.Sprintf("service %q was not found", name), ExitCode: kranzcli.ExitNotFound}
+				_ = sendReady(backgroundReady{Error: commandErr.Error(), Code: commandErr.Code, ExitCode: commandErr.ExitCode})
+				return commandErr
+			}
+		}
+		startCtx, cancelStart := context.WithCancel(context.Background())
+		startDone := make(chan error, 1)
+		go func() { startDone <- host.client.StartServicesContext(startCtx, selectors) }()
+		select {
+		case err = <-startDone:
+			cancelStart()
+		case <-signals:
+			cancelStart()
+			<-startDone
+			_ = host.client.Shutdown()
+			return closeHost()
+		}
+		if err != nil {
+			_ = host.client.Shutdown()
+			commandErr := kranzcli.AsError(err)
+			_ = sendReady(backgroundReady{Error: commandErr.Error(), Code: commandErr.Code, ExitCode: commandErr.ExitCode})
+			return err
+		}
+		if err := host.session.UpdateOwnership(host.client.Services()); err != nil {
+			_ = host.client.Shutdown()
+			commandErr := kranzcli.AsError(fmt.Errorf("record runtime ownership: %w", err))
+			_ = sendReady(backgroundReady{Error: commandErr.Error(), Code: commandErr.Code, ExitCode: commandErr.ExitCode})
+			return err
+		}
+	}
+	metadata := host.session.Metadata()
+	select {
+	case <-signals:
+		_ = host.client.Shutdown()
+		return closeHost()
+	default:
+	}
+	if err := sendReady(backgroundReady{OK: true, ID: metadata.ID, Name: metadata.Name, PID: metadata.PID}); err != nil {
+		_ = host.client.Shutdown()
+		return err
+	}
+	_ = readyFile.Close()
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-host.supervisor.ShutdownRequested():
+			return closeHost()
+		case <-signals:
+			_ = host.client.Shutdown()
+			return closeHost()
+		case <-ticker.C:
+			if requested, code := host.client.ProjectExitRequested(); requested {
+				_ = host.client.Shutdown()
+				if err := closeHost(); err != nil {
+					return err
+				}
+				if code != 0 {
+					return requestedExitError{code: code}
+				}
+				return nil
+			}
+		}
+	}
+}
+
+func shortID(id string) string {
+	if len(id) > 8 {
+		return id[:8]
+	}
+	return id
 }
 
 func terminateForegroundWithSignal(host *runtimeHost, closeHost func() error, signals chan os.Signal, sig os.Signal) error {

--- a/internal/runtime/client.go
+++ b/internal/runtime/client.go
@@ -39,6 +39,8 @@ type Client struct {
 	readErr   atomic.Value // error
 	closeOnce sync.Once
 	closeErr  error
+	done      chan struct{}
+	doneOnce  sync.Once
 }
 
 // Dial connects to a Supervisor listening on socketPath and performs the
@@ -64,6 +66,7 @@ func DialContext(ctx context.Context, socketPath, clientVersion string) (*Client
 		conn:    unixConn,
 		c:       newCodec(unixConn),
 		pending: make(map[uint64]chan envelope),
+		done:    make(chan struct{}),
 	}
 	deadline, hasDeadline := ctx.Deadline()
 	if !hasDeadline {
@@ -132,10 +135,14 @@ func (c *Client) Close() error {
 			c.closeErr = nil
 		}
 	})
+	c.doneOnce.Do(func() { close(c.done) })
 	return c.closeErr
 }
 
+func (c *Client) Done() <-chan struct{} { return c.done }
+
 func (c *Client) readLoop() {
+	defer c.doneOnce.Do(func() { close(c.done) })
 	for {
 		msg, err := c.c.receive()
 		if err != nil {

--- a/internal/runtime/registry.go
+++ b/internal/runtime/registry.go
@@ -126,6 +126,8 @@ type SessionHandle struct {
 	closed        bool
 }
 
+func (h *SessionHandle) Metadata() SessionMetadata { return h.meta }
+
 type OwnershipSnapshot struct {
 	Version   int            `json:"ownership_version"`
 	SessionID string         `json:"session_id"`

--- a/internal/runtime/registry_test.go
+++ b/internal/runtime/registry_test.go
@@ -203,7 +203,11 @@ func TestClientCloseIsIdempotentAfterPeerCloses(t *testing.T) {
 		t.Fatal(err)
 	}
 	<-done
-	time.Sleep(10 * time.Millisecond)
+	select {
+	case <-client.Done():
+	case <-time.After(time.Second):
+		t.Fatal("client Done did not close after peer disconnect")
+	}
 	if err := client.Close(); err != nil {
 		t.Fatalf("first Close: %v", err)
 	}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -270,6 +270,7 @@ type Model struct {
 
 	shutdownOnce sync.Once
 	shutdownErr  error
+	detachOnExit bool
 }
 
 // ModelOptions supplies user-level preferences and their persistence path.
@@ -284,6 +285,9 @@ type ModelOptions struct {
 	// is constructed from cfg and ConfigPaths with production defaults —
 	// the shape every existing caller and test relies on.
 	App app.API
+	// DetachOnExit makes q/Ctrl+C close only this delivery surface. The
+	// background runtime remains owned by its supervisor process.
+	DetachOnExit bool
 }
 
 // NewModel creates a model with default user settings and terminal detection.
@@ -314,6 +318,7 @@ func NewModelWithOptions(cfg *config.Config, version string, options ModelOption
 		version:             version,
 		workingDirectory:    workingDirectory,
 		app:                 application,
+		detachOnExit:        options.DetachOnExit,
 		services:            services,
 		allServices:         services,
 		portDetails:         make(map[int]*config.PortInfo),

--- a/internal/ui/model_lifecycle.go
+++ b/internal/ui/model_lifecycle.go
@@ -22,7 +22,9 @@ func (m *Model) Shutdown() error {
 		if m.operationCancel != nil {
 			m.operationCancel()
 		}
-		m.shutdownErr = m.app.Shutdown()
+		if !m.detachOnExit {
+			m.shutdownErr = m.app.Shutdown()
+		}
 	})
 	return m.shutdownErr
 }

--- a/internal/ui/model_lifecycle_test.go
+++ b/internal/ui/model_lifecycle_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +13,23 @@ import (
 	"github.com/kranz-org/kranz/internal/app"
 	"github.com/kranz-org/kranz/internal/config"
 )
+
+func TestDetachOnExitLeavesRuntimeUsable(t *testing.T) {
+	cfg := &config.Config{Project: "Attached", Services: map[string]config.Service{"worker": {Command: "sleep 60"}}}
+	local := app.NewLocal(cfg, nil, app.Options{})
+	model := NewModelWithOptions(cfg, "test", ModelOptions{App: local, DetachOnExit: true})
+	if err := model.Shutdown(); err != nil {
+		t.Fatal(err)
+	}
+	if err := local.StartServicesContext(context.Background(), []string{"worker"}); err != nil {
+		t.Fatalf("runtime was shut down by detach: %v", err)
+	}
+	defer func() { _ = local.Shutdown() }()
+	worker, ok := local.Service("worker")
+	if !ok || worker.State.Status != config.StatusRunning {
+		t.Fatalf("worker after detach = %+v", worker)
+	}
+}
 
 // Tests for service lifecycle actions driven from the dashboard.
 


### PR DESCRIPTION
## Summary
- add per-project `up -d` owners with a readiness pipe and detached process session
- add explicit `attach` and make bare `kranz` attach to the active runtime for the current project
- make attached TUI exit detach-only while remote `down` closes every attached client
- expose client disconnect notification for delivery surfaces

## Safety
- readiness FD is CLOEXEC before services start
- internal child marker is removed from the environment before service execution
- parent reports success only after service startup and synchronous ownership snapshot
- startup timeout requests graceful SIGTERM before bounded kill fallback

## Validation
- `make verify`
- `make lint`
- macOS/Linux CGO-disabled cross-build
- automated `up -d --no-start` → duplicate conflict → JSON status → down
- live background service → ownership fingerprint → down
- live explicit attach and bare attach; q leaves runtime active; down exits attached client