### PR TITLE
feat(cli): add runtime lifecycle controls

### DIFF
--- a/cmd/kranz/main.go
+++ b/cmd/kranz/main.go
@@ -78,6 +78,17 @@ func execute(args []string, stdout, stderr io.Writer) int {
 		}
 		return 0
 	}
+	if command := invocation.Command(); command == "start" || command == "stop" || command == "restart" || command == "reload" {
+		if err := runLifecycle(invocation.Globals, command, invocation.Args); err != nil {
+			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
+		}
+		if invocation.Globals.Output == kranzcli.OutputJSON {
+			if err := kranzcli.WriteJSON(stdout, struct{}{}); err != nil {
+				return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
+			}
+		}
+		return 0
+	}
 	if invocation.Command() == "down" {
 		if err := runDown(invocation.Globals, invocation.Args); err != nil {
 			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)

--- a/cmd/kranz/main_test.go
+++ b/cmd/kranz/main_test.go
@@ -74,7 +74,7 @@ func TestBackgroundHelperProcess(t *testing.T) {
 func TestBackgroundRuntimeReadinessConflictAndDown(t *testing.T) {
 	directory := t.TempDir()
 	name := fmt.Sprintf("test-background-%d", os.Getpid())
-	configText := fmt.Sprintf("project: Test Background\nruntime:\n  name: %s\nservices:\n  sleeper:\n    command: sleep 60\n", name)
+	configText := fmt.Sprintf("project: Test Background\nruntime:\n  name: %s\nservices:\n  sleeper:\n    command: sleep 60\n    tags: [workers]\n", name)
 	if err := os.WriteFile(filepath.Join(directory, "kranz.yaml"), []byte(configText), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -105,6 +105,20 @@ func TestBackgroundRuntimeReadinessConflictAndDown(t *testing.T) {
 	}
 	stdout.Reset()
 	stderr.Reset()
+	if code := execute([]string{"-p", name, "start", "workers"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("start tag exit=%d stderr=%s", code, stderr.String())
+	}
+	if code := execute([]string{"-p", name, "restart", "sleeper"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("restart exit=%d stderr=%s", code, stderr.String())
+	}
+	if code := execute([]string{"-p", name, "stop", "sleeper"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("stop exit=%d stderr=%s", code, stderr.String())
+	}
+	if code := execute([]string{"-p", name, "reload"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("reload exit=%d stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
 	if code := execute([]string{"-p", name, "down"}, &stdout, &stderr); code != 0 {
 		t.Fatalf("down exit=%d stderr=%s", code, stderr.String())
 	}
@@ -123,6 +137,59 @@ func TestBackgroundRuntimeReadinessConflictAndDown(t *testing.T) {
 		}
 		if time.Now().After(deadline) {
 			t.Fatalf("background runtime remained after down: %v", err)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestForceDownRecoversUnreachableBackgroundRuntime(t *testing.T) {
+	directory := t.TempDir()
+	name := fmt.Sprintf("test-force-down-%d", os.Getpid())
+	configText := fmt.Sprintf("project: Test Force Down\nruntime:\n  name: %s\nservices:\n  sleeper:\n    command: sleep 60\n", name)
+	if err := os.WriteFile(filepath.Join(directory, "kranz.yaml"), []byte(configText), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	previousFactory := newBackgroundCommand
+	newBackgroundCommand = func(_ string, args ...string) *exec.Cmd {
+		data, _ := json.Marshal(args)
+		command := exec.Command(os.Args[0], "-test.run=^TestBackgroundHelperProcess$")
+		command.Env = append(os.Environ(), "KRANZ_TEST_BACKGROUND_HELPER=1", "KRANZ_TEST_BACKGROUND_ARGS="+base64.StdEncoding.EncodeToString(data))
+		return command
+	}
+	defer func() { newBackgroundCommand = previousFactory }()
+	var stdout, stderr bytes.Buffer
+	if code := execute([]string{"-C", directory, "up", "-d"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("up -d exit=%d stderr=%s", code, stderr.String())
+	}
+	registry, err := kranzruntime.DefaultRegistry()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	record, err := registry.Resolve(ctx, name, "test")
+	cancel()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(record.Socket); err != nil {
+		t.Fatal(err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := execute([]string{"-p", name, "down", "--force"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("down --force exit=%d stderr=%s", code, stderr.String())
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		_, err = registry.Resolve(ctx, name, "test")
+		cancel()
+		var missing *kranzruntime.SessionNotFoundError
+		if errors.As(err, &missing) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("forced runtime remained registered: %v", err)
 		}
 		time.Sleep(20 * time.Millisecond)
 	}

--- a/cmd/kranz/runtime_commands.go
+++ b/cmd/kranz/runtime_commands.go
@@ -586,9 +586,16 @@ func runStatus(options kranzcli.GlobalOptions, args []string, stdout io.Writer) 
 	return w.Flush()
 }
 
-func runDown(options kranzcli.GlobalOptions, args []string) error {
-	if len(args) > 0 {
-		return &kranzcli.Error{Code: "invalid_arguments", Message: "down does not accept arguments in this build", ExitCode: kranzcli.ExitUsage}
+func runLifecycle(options kranzcli.GlobalOptions, command string, args []string) error {
+	if options.Project == "" {
+		return &kranzcli.Error{Code: "missing_project", Message: "-p NAME_OR_ID is required", ExitCode: kranzcli.ExitUsage}
+	}
+	if command == "reload" {
+		if len(args) != 0 {
+			return &kranzcli.Error{Code: "invalid_arguments", Message: "reload does not accept selectors", ExitCode: kranzcli.ExitUsage}
+		}
+	} else if len(args) == 0 {
+		return &kranzcli.Error{Code: "missing_selector", Message: command + " requires at least one service or tag selector", ExitCode: kranzcli.ExitUsage}
 	}
 	record, err := resolveSession(options, true)
 	if err != nil {
@@ -598,7 +605,88 @@ func runDown(options kranzcli.GlobalOptions, args []string) error {
 	if err != nil {
 		return classifyRuntimeError(err)
 	}
-	return client.Shutdown()
+	defer func() { _ = client.Close() }()
+	if command == "reload" {
+		_, err = client.Reload(true)
+		return err
+	}
+	names, err := resolveServiceSelectors(client.Config(), args)
+	if err != nil {
+		return err
+	}
+	switch command {
+	case "start":
+		return client.StartServicesContext(context.Background(), names)
+	case "stop":
+		return client.StopServices(names)
+	case "restart":
+		return client.RestartServices(names)
+	}
+	return nil
+}
+
+func resolveServiceSelectors(cfg *config.Config, selectors []string) ([]string, error) {
+	selected := make(map[string]bool)
+	for _, selector := range selectors {
+		if _, ok := cfg.Services[selector]; ok {
+			selected[selector] = true
+			continue
+		}
+		matched := false
+		for name, service := range cfg.Services {
+			for _, tag := range service.Tags {
+				if strings.EqualFold(tag, selector) {
+					selected[name] = true
+					matched = true
+					break
+				}
+			}
+		}
+		if !matched {
+			return nil, &kranzcli.Error{Code: "selector_not_found", Message: fmt.Sprintf("service or tag %q was not found", selector), ExitCode: kranzcli.ExitNotFound}
+		}
+	}
+	names := make([]string, 0, len(selected))
+	for _, name := range cfg.ServiceOrder {
+		if selected[name] {
+			names = append(names, name)
+		}
+	}
+	return names, nil
+}
+
+func runDown(options kranzcli.GlobalOptions, args []string) error {
+	force := false
+	for _, arg := range args {
+		if arg == "--force" {
+			force = true
+			continue
+		}
+		return &kranzcli.Error{Code: "unknown_option", Message: "unknown down option " + arg, ExitCode: kranzcli.ExitUsage}
+	}
+	record, err := resolveSession(options, true)
+	if err != nil {
+		return err
+	}
+	dialCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	client, dialErr := kranzruntime.DialContext(dialCtx, record.Socket, version)
+	cancel()
+	if dialErr == nil {
+		return client.Shutdown()
+	}
+	if !force {
+		return classifyRuntimeError(dialErr)
+	}
+	registry, err := kranzruntime.DefaultRegistry()
+	if err != nil {
+		return err
+	}
+	forceCtx, forceCancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer forceCancel()
+	if err := registry.ForceDown(forceCtx, record); err != nil {
+		return classifyRuntimeError(err)
+	}
+	return nil
 }
 
 func classifyRuntimeError(err error) error {
@@ -617,6 +705,10 @@ func classifyRuntimeError(err error) error {
 	var mismatch *kranzruntime.VersionMismatchError
 	if errors.As(err, &mismatch) {
 		return &kranzcli.Error{Code: "protocol_mismatch", Message: mismatch.Error(), ExitCode: kranzcli.ExitUnavailable}
+	}
+	var refused *kranzruntime.ForceDownError
+	if errors.As(err, &refused) {
+		return &kranzcli.Error{Code: "force_down_refused", Message: refused.Error(), ExitCode: kranzcli.ExitUnavailable}
 	}
 	var networkError net.Error
 	if errors.As(err, &networkError) {

--- a/internal/app/api.go
+++ b/internal/app/api.go
@@ -69,6 +69,9 @@ type API interface {
 	RestartAll() error
 	// RestartService restarts name and its transitive dependents.
 	RestartService(name string) error
+	// RestartServices restarts names and their active transitive dependents in
+	// one config generation.
+	RestartServices(names []string) error
 	// HasRunningServices reports whether any service is running, starting,
 	// stopping, or unhealthy.
 	HasRunningServices() bool

--- a/internal/app/local.go
+++ b/internal/app/local.go
@@ -254,6 +254,10 @@ func (l *Local) RestartService(name string) error {
 	return l.manager.RestartService(name)
 }
 
+func (l *Local) RestartServices(names []string) error {
+	return l.manager.RestartServices(names)
+}
+
 func (l *Local) HasRunningServices() bool {
 	return l.manager.HasRunningServices()
 }

--- a/internal/runtime/client.go
+++ b/internal/runtime/client.go
@@ -331,6 +331,11 @@ func (c *Client) RestartService(name string) error {
 	return err
 }
 
+func (c *Client) RestartServices(names []string) error {
+	_, err := call[namesRequest, emptyResponse](c, context.Background(), methodRestartServices, namesRequest{Names: names})
+	return err
+}
+
 func (c *Client) HasRunningServices() bool {
 	resp, _ := call[emptyRequest, boolResponse](c, context.Background(), methodHasRunningServices, emptyRequest{})
 	return resp.Value

--- a/internal/runtime/handlers.go
+++ b/internal/runtime/handlers.go
@@ -92,6 +92,9 @@ var handlers = map[string]handlerFunc{
 	methodRestartService: handler(func(_ context.Context, l *app.Local, req nameRequest) (emptyResponse, error) {
 		return emptyResponse{}, l.RestartService(req.Name)
 	}),
+	methodRestartServices: handler(func(_ context.Context, l *app.Local, req namesRequest) (emptyResponse, error) {
+		return emptyResponse{}, l.RestartServices(req.Names)
+	}),
 	methodHasRunningServices: handler(func(_ context.Context, l *app.Local, _ emptyRequest) (boolResponse, error) {
 		return boolResponse{Value: l.HasRunningServices()}, nil
 	}),

--- a/internal/runtime/messages.go
+++ b/internal/runtime/messages.go
@@ -33,6 +33,7 @@ const (
 	methodStopAll                         = "stopAll"
 	methodRestartAll                      = "restartAll"
 	methodRestartService                  = "restartService"
+	methodRestartServices                 = "restartServices"
 	methodHasRunningServices              = "hasRunningServices"
 	methodProjectExitRequested            = "projectExitRequested"
 	methodShutdown                        = "shutdown"

--- a/internal/runtime/process_identity_darwin.go
+++ b/internal/runtime/process_identity_darwin.go
@@ -4,6 +4,7 @@ package runtime
 
 import (
 	"fmt"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
@@ -15,4 +16,21 @@ func processIdentity(pid int) (int, string, error) {
 	}
 	started := info.Proc.P_starttime
 	return int(info.Eproc.Pgid), fmt.Sprintf("darwin-start:%d.%06d", started.Sec, started.Usec), nil
+}
+
+func processParent(pid int) (int, error) {
+	info, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	if err != nil {
+		return 0, err
+	}
+	return int(info.Eproc.Ppid), nil
+}
+
+func processStartedAt(pid int) (time.Time, error) {
+	info, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	if err != nil {
+		return time.Time{}, err
+	}
+	started := info.Proc.P_starttime
+	return time.Unix(started.Sec, int64(started.Usec)*1000).UTC(), nil
 }

--- a/internal/runtime/process_identity_linux.go
+++ b/internal/runtime/process_identity_linux.go
@@ -8,20 +8,29 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 )
 
-func processIdentity(pid int) (int, string, error) {
+func linuxProcessFields(pid int) ([]string, error) {
 	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
 	if err != nil {
-		return 0, "", err
+		return nil, err
 	}
 	end := strings.LastIndex(string(data), ") ")
 	if end < 0 {
-		return 0, "", fmt.Errorf("invalid proc stat for %d", pid)
+		return nil, fmt.Errorf("invalid proc stat for %d", pid)
 	}
 	fields := strings.Fields(string(data)[end+2:])
 	if len(fields) <= 19 {
-		return 0, "", fmt.Errorf("short proc stat for %d", pid)
+		return nil, fmt.Errorf("short proc stat for %d", pid)
+	}
+	return fields, nil
+}
+
+func processIdentity(pid int) (int, string, error) {
+	fields, err := linuxProcessFields(pid)
+	if err != nil {
+		return 0, "", err
 	}
 	start, err := strconv.ParseUint(fields[19], 10, 64)
 	if err != nil {
@@ -32,4 +41,40 @@ func processIdentity(pid int) (int, string, error) {
 		return 0, "", err
 	}
 	return pgid, fmt.Sprintf("linux-proc-start:%d", start), nil
+}
+
+func processParent(pid int) (int, error) {
+	fields, err := linuxProcessFields(pid)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(fields[1])
+}
+
+func processStartedAt(pid int) (time.Time, error) {
+	fields, err := linuxProcessFields(pid)
+	if err != nil {
+		return time.Time{}, err
+	}
+	ticks, err := strconv.ParseUint(fields[19], 10, 64)
+	if err != nil {
+		return time.Time{}, err
+	}
+	data, err := os.ReadFile("/proc/stat")
+	if err != nil {
+		return time.Time{}, err
+	}
+	var boot int64
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "btime ") {
+			boot, err = strconv.ParseInt(strings.TrimSpace(strings.TrimPrefix(line, "btime ")), 10, 64)
+			break
+		}
+	}
+	if err != nil || boot == 0 {
+		return time.Time{}, fmt.Errorf("read Linux boot time: %w", err)
+	}
+	// Linux exposes process start ticks in USER_HZ, whose userspace ABI value
+	// is 100 on the architectures supported by Kranz.
+	return time.Unix(boot+int64(ticks/100), int64(ticks%100)*10_000_000).UTC(), nil
 }

--- a/internal/runtime/process_identity_other.go
+++ b/internal/runtime/process_identity_other.go
@@ -2,8 +2,19 @@
 
 package runtime
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 func processIdentity(pid int) (int, string, error) {
 	return 0, "", fmt.Errorf("process identity is unsupported on this platform")
+}
+
+func processParent(pid int) (int, error) {
+	return 0, fmt.Errorf("process ancestry is unsupported on this platform")
+}
+
+func processStartedAt(pid int) (time.Time, error) {
+	return time.Time{}, fmt.Errorf("process start time is unsupported on this platform")
 }

--- a/internal/runtime/registry.go
+++ b/internal/runtime/registry.go
@@ -31,19 +31,20 @@ const (
 )
 
 type SessionMetadata struct {
-	MetadataVersion int       `json:"metadata_version"`
-	ID              string    `json:"id"`
-	Name            string    `json:"name"`
-	Project         string    `json:"project"`
-	PID             int       `json:"pid"`
-	ProcessStarted  time.Time `json:"process_started_at"`
-	KranzVersion    string    `json:"kranz_version"`
-	ProtocolMin     int       `json:"protocol_min"`
-	ProtocolMax     int       `json:"protocol_max"`
-	Socket          string    `json:"socket"`
-	Mode            string    `json:"mode"`
-	StartedAt       time.Time `json:"started_at"`
-	Directory       string    `json:"directory"`
+	MetadataVersion    int       `json:"metadata_version"`
+	ID                 string    `json:"id"`
+	Name               string    `json:"name"`
+	Project            string    `json:"project"`
+	PID                int       `json:"pid"`
+	ProcessStarted     time.Time `json:"process_started_at"`
+	ProcessFingerprint string    `json:"process_birth_fingerprint"`
+	KranzVersion       string    `json:"kranz_version"`
+	ProtocolMin        int       `json:"protocol_min"`
+	ProtocolMax        int       `json:"protocol_max"`
+	Socket             string    `json:"socket"`
+	Mode               string    `json:"mode"`
+	StartedAt          time.Time `json:"started_at"`
+	Directory          string    `json:"directory"`
 }
 
 type SessionRecord struct {
@@ -141,6 +142,10 @@ type OwnedProcess struct {
 	Fingerprint string `json:"birth_fingerprint"`
 }
 
+type ForceDownError struct{ Reason string }
+
+func (e *ForceDownError) Error() string { return "refusing forced shutdown: " + e.Reason }
+
 func (r *Registry) Acquire(name string) (*SessionHandle, error) {
 	return r.acquire(name, nil)
 }
@@ -224,10 +229,18 @@ func (h *SessionHandle) Prepare(project, version, mode, directory string) (Sessi
 		return SessionMetadata{}, fmt.Errorf("create session id: %w", err)
 	}
 	now := time.Now().UTC()
+	started, err := processStartedAt(os.Getpid())
+	if err != nil {
+		return SessionMetadata{}, fmt.Errorf("identify runtime process start: %w", err)
+	}
+	_, fingerprint, err := processIdentity(os.Getpid())
+	if err != nil {
+		return SessionMetadata{}, fmt.Errorf("identify runtime process: %w", err)
+	}
 	hash := sha256.Sum256([]byte(h.registry.root + "\x00" + hex.EncodeToString(idBytes)))
 	socket := filepath.Join(h.registry.socketRoot, "s-"+hex.EncodeToString(hash[:8])+".sock")
 	_ = os.Remove(socket)
-	h.meta = SessionMetadata{MetadataVersion: metadataVersion, ID: hex.EncodeToString(idBytes), Name: strings.TrimSuffix(filepath.Base(h.lock.Name()), ".lock"), Project: project, PID: os.Getpid(), ProcessStarted: now, KranzVersion: version, ProtocolMin: protocolVersion, ProtocolMax: protocolVersion, Socket: socket, Mode: mode, StartedAt: now, Directory: directory}
+	h.meta = SessionMetadata{MetadataVersion: metadataVersion, ID: hex.EncodeToString(idBytes), Name: strings.TrimSuffix(filepath.Base(h.lock.Name()), ".lock"), Project: project, PID: os.Getpid(), ProcessStarted: started, ProcessFingerprint: fingerprint, KranzVersion: version, ProtocolMin: protocolVersion, ProtocolMax: protocolVersion, Socket: socket, Mode: mode, StartedAt: now, Directory: directory}
 	return h.meta, nil
 }
 
@@ -390,6 +403,179 @@ func (r *Registry) Resolve(ctx context.Context, reference, clientVersion string)
 		names[i] = match.ID[:8] + " (" + match.Name + ")"
 	}
 	return SessionRecord{}, &AmbiguousSessionError{Reference: reference, Matches: names}
+}
+
+// ForceDown performs the recovery-only shutdown path for a session whose RPC
+// endpoint cannot be reached. Every signal target is proven again immediately
+// before use; a PID, metadata file, or ownership snapshot alone is never
+// accepted as evidence of ownership.
+func (r *Registry) ForceDown(ctx context.Context, record SessionRecord) error {
+	metadata, ownership, err := r.forceEvidence(record)
+	if err != nil {
+		return err
+	}
+	for _, process := range ownership.Processes {
+		if err := validateOwnedProcess(process, metadata.PID); err != nil {
+			return err
+		}
+	}
+	for _, process := range ownership.Processes {
+		if err := signalOwnedGroup(process, syscall.SIGTERM); err != nil && !processGone(err) {
+			return err
+		}
+	}
+	if err := signalSupervisor(metadata, syscall.SIGTERM); err != nil && !processGone(err) {
+		return err
+	}
+	if r.waitUnlocked(ctx, metadata.Name, 3*time.Second) {
+		return r.cleanupForced(metadata.Name)
+	}
+
+	// Only identities that still match the immutable evidence may receive
+	// SIGKILL. An identity mismatch is a hard refusal, never a reason to widen
+	// or substitute the target set.
+	for _, process := range ownership.Processes {
+		if err := validateOwnedProcess(process, metadata.PID); err != nil {
+			if processGone(err) {
+				continue
+			}
+			return err
+		}
+		if err := signalOwnedGroup(process, syscall.SIGKILL); err != nil && !processGone(err) {
+			return err
+		}
+	}
+	if err := validateSupervisor(metadata); err != nil {
+		if !processGone(err) {
+			return err
+		}
+	} else if err := syscall.Kill(metadata.PID, syscall.SIGKILL); err != nil && !processGone(err) {
+		return err
+	}
+	if !r.waitUnlocked(ctx, metadata.Name, 3*time.Second) {
+		return &ForceDownError{Reason: "runtime lock was not released after validated signals"}
+	}
+	return r.cleanupForced(metadata.Name)
+}
+
+func (r *Registry) forceEvidence(record SessionRecord) (SessionMetadata, OwnershipSnapshot, error) {
+	locked, err := r.isLocked(record.Name)
+	if err != nil {
+		return SessionMetadata{}, OwnershipSnapshot{}, err
+	}
+	if !locked {
+		return SessionMetadata{}, OwnershipSnapshot{}, &ForceDownError{Reason: "session lock is not held"}
+	}
+	data, err := os.ReadFile(r.metadataPath(record.Name))
+	if err != nil {
+		return SessionMetadata{}, OwnershipSnapshot{}, &ForceDownError{Reason: "immutable metadata is unavailable"}
+	}
+	var metadata SessionMetadata
+	if err := json.Unmarshal(data, &metadata); err != nil || metadata.MetadataVersion != metadataVersion || metadata.Name != record.Name || metadata.ID != record.ID {
+		return SessionMetadata{}, OwnershipSnapshot{}, &ForceDownError{Reason: "immutable metadata does not match the selected lock generation"}
+	}
+	if err := validateSupervisor(metadata); err != nil {
+		return SessionMetadata{}, OwnershipSnapshot{}, err
+	}
+	data, err = os.ReadFile(r.ownershipPath(record.Name))
+	if err != nil {
+		return SessionMetadata{}, OwnershipSnapshot{}, &ForceDownError{Reason: "ownership snapshot is unavailable"}
+	}
+	var ownership OwnershipSnapshot
+	if err := json.Unmarshal(data, &ownership); err != nil || ownership.Version != 1 || ownership.SessionID != metadata.ID {
+		return SessionMetadata{}, OwnershipSnapshot{}, &ForceDownError{Reason: "ownership snapshot does not match the selected session"}
+	}
+	return metadata, ownership, nil
+}
+
+func validateSupervisor(metadata SessionMetadata) error {
+	_, fingerprint, err := processIdentity(metadata.PID)
+	if err != nil {
+		return err
+	}
+	started, err := processStartedAt(metadata.PID)
+	if err != nil {
+		return err
+	}
+	if metadata.ProcessFingerprint == "" || fingerprint != metadata.ProcessFingerprint || !started.Equal(metadata.ProcessStarted) {
+		return &ForceDownError{Reason: "runtime process birth identity does not match metadata"}
+	}
+	return nil
+}
+
+func validateOwnedProcess(process OwnedProcess, supervisorPID int) error {
+	pgid, fingerprint, err := processIdentity(process.PID)
+	if err != nil {
+		return err
+	}
+	if process.PID <= 1 || process.PGID <= 1 || process.PGID != process.PID || pgid != process.PGID || fingerprint != process.Fingerprint {
+		return &ForceDownError{Reason: fmt.Sprintf("service %q process identity does not match ownership evidence", process.Service)}
+	}
+	pid := process.PID
+	for depth := 0; depth < 256 && pid > 1; depth++ {
+		parent, err := processParent(pid)
+		if err != nil {
+			return err
+		}
+		if parent == supervisorPID {
+			return nil
+		}
+		if parent <= 1 || parent == pid {
+			break
+		}
+		pid = parent
+	}
+	return &ForceDownError{Reason: fmt.Sprintf("service %q is outside the runtime process ancestry", process.Service)}
+}
+
+func signalOwnedGroup(process OwnedProcess, signal syscall.Signal) error {
+	// The full ancestry check is performed by the caller. Refresh the birth
+	// identity immediately before signalling to close the PID-reuse race.
+	pgid, fingerprint, err := processIdentity(process.PID)
+	if err != nil {
+		return err
+	}
+	if pgid != process.PGID || fingerprint != process.Fingerprint {
+		return &ForceDownError{Reason: fmt.Sprintf("service %q changed identity before signal", process.Service)}
+	}
+	return syscall.Kill(-process.PGID, signal)
+}
+
+func signalSupervisor(metadata SessionMetadata, signal syscall.Signal) error {
+	if err := validateSupervisor(metadata); err != nil {
+		return err
+	}
+	return syscall.Kill(metadata.PID, signal)
+}
+
+func processGone(err error) bool {
+	return errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ESRCH)
+}
+
+func (r *Registry) waitUnlocked(ctx context.Context, name string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		locked, err := r.isLocked(name)
+		if err == nil && !locked {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(25 * time.Millisecond):
+		}
+	}
+}
+
+func (r *Registry) cleanupForced(name string) error {
+	handle, err := r.Acquire(name)
+	if err != nil {
+		return err
+	}
+	return handle.Close()
 }
 
 func (r *Registry) isLocked(name string) (bool, error) {

--- a/internal/runtime/registry_test.go
+++ b/internal/runtime/registry_test.go
@@ -121,6 +121,35 @@ func TestRegistryListCleansStaleMetadataWithoutRemovingLock(t *testing.T) {
 	}
 }
 
+func TestForceDownRefusesMismatchedSupervisorBirthIdentity(t *testing.T) {
+	registry, err := NewRegistry(filepath.Join(t.TempDir(), "registry"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	handle, err := registry.Acquire("mismatch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	metadata, err := handle.Prepare("Mismatch", "dev", "background", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := handle.Publish(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = handle.Close() }()
+	metadata.ProcessFingerprint = "not-the-current-process"
+	if err := atomicJSON(registry.metadataPath(metadata.Name), metadata); err != nil {
+		t.Fatal(err)
+	}
+	record := SessionRecord{SessionMetadata: metadata, State: SessionUnreachable}
+	err = registry.ForceDown(context.Background(), record)
+	var refused *ForceDownError
+	if !errors.As(err, &refused) {
+		t.Fatalf("ForceDown error = %T %v, want ForceDownError", err, err)
+	}
+}
+
 func syscallUnlockAndClose(handle *SessionHandle) error {
 	if err := unix.Flock(int(handle.lock.Fd()), unix.LOCK_UN); err != nil {
 		return err

--- a/internal/service/manager_start.go
+++ b/internal/service/manager_start.go
@@ -372,22 +372,34 @@ func (m *Manager) StartByTags(tags []string) error {
 // StopAll stops every service in reverse dependency order.
 
 func (m *Manager) RestartService(name string) error {
+	return m.RestartServices([]string{name})
+}
+
+// RestartServices performs one stop/start plan while holding the reload lock,
+// so a watcher reload cannot split a multi-selector CLI request across config
+// generations.
+func (m *Manager) RestartServices(names []string) error {
 	// Hold reloadMu for the whole operation so a concurrent config reload
 	// cannot swap or remove services mid-restart out from under this plan.
 	m.reloadMu.Lock()
 	defer m.reloadMu.Unlock()
-	if _, ok := m.GetService(name); !ok {
-		return fmt.Errorf("service %q not found", name)
+	for _, name := range names {
+		if _, ok := m.GetService(name); !ok {
+			return fmt.Errorf("service %q not found", name)
+		}
 	}
 
 	order, err := m.topologicalSort()
 	if err != nil {
 		return err
 	}
-	affectedSet := map[string]bool{name: true}
-	for _, dependent := range m.findDependents(name) {
-		if svc, ok := m.GetService(dependent); ok && svc.Status() != config.StatusStopped {
-			affectedSet[dependent] = true
+	affectedSet := make(map[string]bool)
+	for _, name := range names {
+		affectedSet[name] = true
+		for _, dependent := range m.findDependents(name) {
+			if svc, ok := m.GetService(dependent); ok && svc.Status() != config.StatusStopped {
+				affectedSet[dependent] = true
+			}
 		}
 	}
 	var affected []string


### PR DESCRIPTION
## Summary
- add start, stop, restart, and reload commands over the runtime supervisor
- resolve exact service and tag selectors with non-empty destructive command semantics
- add recovery-only down --force with lock, process birth, ancestry, and owned process-group validation
- make multi-service restart atomic against config reloads

## Verification
- make verify
- make lint
- Linux and macOS CGO-disabled command test cross-builds
- live kranz-dev lifecycle smoke against examples/native
- subprocess recovery test with an intentionally unreachable Unix socket