### PR TITLE
Address action logs, and give a selector one meaning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,55 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-08-23
+
+### Added
+
+- `kranz logs OWNER/ACTION` reads an action's output after it has finished, so a
+  report or a migration can be read again without running it a second time.
+  Actions are addressed by the same name `kranz action run` uses.
+- Run addressing for action logs. Every execution is numbered and framed in the
+  buffer; `--run N` selects one, `--run -1` the latest, and `--runs N` the last
+  N. `--since` still narrows by time, and the three compose with `--tail`.
+- `--with-actions` folds an owner's actions into one timeline with the owner's
+  own output, labelled per line. An action group has no output of its own, so
+  its bare name reports what to name instead.
+- `kranz logs clear [SELECTOR ...]` discards buffered history for what it names,
+  or for the whole project with `--force`.
+- Display flags for reading one stream back: `--plain` prints the output as the
+  command printed it, `--no-timestamps` and `--no-labels` drop one column each,
+  and `--source stdout|stderr|kranz` narrows by origin before the tail applies.
+- `kranz status` accepts tags, which the other selector commands already did.
+
+### Changed
+
+- A bare action selector now shows its whole latest run. An action produces a
+  finite report, and capping it at the last lines cut off the part explaining
+  what the run did. Services keep the recent-lines default; `--tail` and `--all`
+  override both.
+- A selector has one meaning across the CLI: a name a service answers to means
+  that service, and a name no service answers to is tried as a tag. `plan` and
+  `ports` previously unioned the two, so they could cover different services
+  than `start` and `stop` did for the same word.
+- Log lines are labelled `[stream source]` rather than `[service/source]`,
+  because the stream address itself now contains a slash for an action.
+- JSON log events carry `stream`, `kind`, `owner`, `action`, and `run` in place
+  of `service`.
+- A project may no longer define an action group and a service with the same
+  name. Every action under such a group was ambiguous and unreachable, while the
+  configuration still validated cleanly; `kranz config check` now says so.
+
+### Fixed
+
+- `--tail N` returns N lines. A pipe hands Kranz whatever chunk it read, and a
+  chunk could hold many lines while counting as one, so the flag returned an
+  unpredictable number of lines and could cut in the middle of one. Captured
+  output is now stored one line per entry, which also corrects the log search
+  hit count in the interface, the `N lines omitted` cap on a failed lifecycle
+  hook, and the service prefix printed by a foreground `kranz up`, all of which
+  counted chunks.
+- `kranz action run --output json` returns one array element per output line.
+
 ## [0.8.0] - 2026-08-21
 
 ### Added
@@ -324,7 +373,8 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 - Explicit global-user and project-config save destinations in the live theme picker.
 - Native compatibility for common Process Compose configurations.
 
-[Unreleased]: https://github.com/kranz-org/kranz/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/kranz-org/kranz/compare/v0.8.1...HEAD
+[0.8.1]: https://github.com/kranz-org/kranz/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/kranz-org/kranz/compare/v0.7.2...v0.8.0
 [0.7.2]: https://github.com/kranz-org/kranz/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/kranz-org/kranz/compare/v0.7.0...v0.7.1

--- a/cmd/kranz/action_commands.go
+++ b/cmd/kranz/action_commands.go
@@ -214,14 +214,14 @@ func runActionRun(options kranzcli.GlobalOptions, args []string, stdout io.Write
 			Stdout   []string `json:"stdout"`
 			Stderr   []string `json:"stderr"`
 			Error    string   `json:"error"`
-		}{actionIDString(id), result.Status.String(), result.ExitCode, result.Duration.String(), emptyIfNil(result.Stdout), emptyIfNil(result.Stderr), result.Error}); err != nil {
+		}{actionIDString(id), result.Status.String(), result.ExitCode, result.Duration.String(), actionOutputLines(result.Stdout), actionOutputLines(result.Stderr), result.Error}); err != nil {
 			return err
 		}
 	} else {
-		for _, line := range result.Stdout {
+		for _, line := range actionOutputLines(result.Stdout) {
 			_, _ = fmt.Fprintln(stdout, line)
 		}
-		for _, line := range result.Stderr {
+		for _, line := range actionOutputLines(result.Stderr) {
 			_, _ = fmt.Fprintln(stdout, line)
 		}
 		_, _ = fmt.Fprintf(stdout, "%s %s in %s (exit %d)\n", actionIDString(id), result.Status, result.Duration.Round(1e6), result.ExitCode)
@@ -257,4 +257,17 @@ func rejectInteractiveAction(id config.ActionID, action config.Action) error {
 		Hint:     "Run it from the TUI with `kranz attach`.",
 		ExitCode: kranzcli.ExitUsage,
 	}
+}
+
+// actionOutputLines turns captured output into one entry per line. A pipe hands
+// Kranz whatever chunk it read, so a JSON consumer counting array elements and
+// a human counting printed lines would otherwise disagree.
+func actionOutputLines(chunks []string) []string {
+	lines := make([]string, 0, len(chunks))
+	for _, chunk := range chunks {
+		for _, line := range strings.Split(strings.TrimSuffix(chunk, "\n"), "\n") {
+			lines = append(lines, strings.TrimSuffix(line, "\r"))
+		}
+	}
+	return lines
 }

--- a/cmd/kranz/action_commands_test.go
+++ b/cmd/kranz/action_commands_test.go
@@ -110,3 +110,22 @@ func TestActionRunNeedsARuntime(t *testing.T) {
 		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
 	}
 }
+
+// `kranz action run --output=json` promises an array of output lines. A pipe
+// hands Kranz whatever chunk it read, so without splitting, a consumer counting
+// array elements and a human counting printed lines disagree.
+func TestActionOutputLinesAreOneLineEach(t *testing.T) {
+	lines := actionOutputLines([]string{"one\ntwo\n", "three\r\n", "four"})
+	want := []string{"one", "two", "three", "four"}
+	if len(lines) != len(want) {
+		t.Fatalf("lines = %q, want %q", lines, want)
+	}
+	for index := range lines {
+		if lines[index] != want[index] {
+			t.Fatalf("lines = %q, want %q", lines, want)
+		}
+	}
+	if empty := actionOutputLines(nil); empty == nil {
+		t.Error("nil output must still encode as an empty JSON array")
+	}
+}

--- a/cmd/kranz/inspect_commands.go
+++ b/cmd/kranz/inspect_commands.go
@@ -67,35 +67,15 @@ func loadProject(options kranzcli.GlobalOptions) (*config.Config, []string, erro
 // selectServices resolves positional selectors, which name either a service or
 // a tag. An empty selector means every configured service, which is safe here
 // because no inspection command changes anything.
+// selectServices resolves selectors for the commands that describe a project
+// without a runtime. It is the same rule the runtime commands use, so `kranz
+// plan api` and `kranz start api` can never disagree about what they cover; an
+// empty selection means the whole project.
 func selectServices(cfg *config.Config, selectors []string) ([]string, error) {
 	if len(selectors) == 0 {
 		return cfg.ServiceNames(), nil
 	}
-	seen := make(map[string]bool)
-	var selected []string
-	for _, selector := range selectors {
-		matched := false
-		for _, name := range cfg.ServiceNames() {
-			svc := cfg.Services[name]
-			if name != selector && !containsString(svc.Tags, selector) {
-				continue
-			}
-			matched = true
-			if !seen[name] {
-				seen[name] = true
-				selected = append(selected, name)
-			}
-		}
-		if !matched {
-			return nil, &kranzcli.Error{
-				Code:     "selector_not_found",
-				Message:  fmt.Sprintf("no service or tag matches %q", selector),
-				Hint:     "Run `kranz list services` or `kranz list tags` to see what this project defines.",
-				ExitCode: kranzcli.ExitNotFound,
-			}
-		}
-	}
-	return selected, nil
+	return resolveServiceSelectors(cfg, selectors)
 }
 
 func containsString(values []string, want string) bool {

--- a/cmd/kranz/inspect_commands_test.go
+++ b/cmd/kranz/inspect_commands_test.go
@@ -355,3 +355,64 @@ func TestDoctorStatesWhatItChecked(t *testing.T) {
 		t.Errorf("doctor does not state its verdict:\n%s", output)
 	}
 }
+
+// A selector must mean one thing everywhere. The CLI used to carry three rules:
+// plan and ports unioned a service name with the tag of the same name, the
+// lifecycle commands let the name win, and status understood no tags at all —
+// so `kranz plan api` and `kranz start api` could cover different services.
+func TestEverySelectorResolverAgreesOnWhatANameMeans(t *testing.T) {
+	cfg := &config.Config{
+		Services: map[string]config.Service{
+			"api":    {},
+			"worker": {Tags: []string{"api", "background"}},
+		},
+		ServiceOrder: []string{"api", "worker"},
+	}
+
+	// A name that a service answers to means that service, not everything
+	// tagged with the same word: `kranz stop api` must not stop the worker.
+	byName, err := resolveServiceSelectors(cfg, []string{"api"})
+	if err != nil {
+		t.Fatalf("resolve = %v", err)
+	}
+	if len(byName) != 1 || byName[0] != "api" {
+		t.Errorf("selector resolved to %v, want just the service", byName)
+	}
+	// The describing commands must answer identically.
+	planned, err := selectServices(cfg, []string{"api"})
+	if err != nil {
+		t.Fatalf("selectServices = %v", err)
+	}
+	if len(planned) != len(byName) || planned[0] != byName[0] {
+		t.Errorf("plan resolved %v but the lifecycle commands resolve %v", planned, byName)
+	}
+	// The log targets are the same rule with actions layered on top.
+	logged, err := resolveLogTargets(cfg, []string{"api"}, false)
+	if err != nil {
+		t.Fatalf("resolveLogTargets = %v", err)
+	}
+	if got := targetAddresses(logged); len(got) != 1 || got[0] != "api" {
+		t.Errorf("logs resolved %v but the lifecycle commands resolve %v", got, byName)
+	}
+
+	// A word no service answers to is tried as a tag, everywhere alike.
+	for name, resolve := range map[string]func() ([]string, error){
+		"lifecycle":  func() ([]string, error) { return resolveServiceSelectors(cfg, []string{"background"}) },
+		"describing": func() ([]string, error) { return selectServices(cfg, []string{"background"}) },
+	} {
+		got, err := resolve()
+		if err != nil {
+			t.Fatalf("%s resolver on a tag: %v", name, err)
+		}
+		if len(got) != 1 || got[0] != "worker" {
+			t.Errorf("%s resolver read the tag as %v, want the worker", name, got)
+		}
+	}
+
+	// And an empty selection still means the whole project for the commands
+	// that describe one.
+	all, err := selectServices(cfg, nil)
+	if err != nil || len(all) != 2 {
+		t.Errorf("empty selection = %v, %v", all, err)
+	}
+}

--- a/cmd/kranz/logs.go
+++ b/cmd/kranz/logs.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -18,24 +19,54 @@ import (
 	kranzruntime "github.com/kranz-org/kranz/internal/runtime"
 )
 
-// defaultLogTail bounds a bare `kranz logs`. Every service keeps a thousand
+// defaultLogTail bounds a bare `kranz logs`. Every stream keeps a thousand
 // lines, so a project with four of them answers an unqualified request with
 // thousands of lines the user has to scroll past to reach the recent ones they
 // were asking about. --all still returns everything.
 const defaultLogTail = 50
 
 type logOptions struct {
-	selectors []string
-	tail      int
-	tailSet   bool
-	all       bool
-	follow    bool
-	since     time.Duration
-	sinceSet  bool
+	selectors   []string
+	tail        int
+	tailSet     bool
+	all         bool
+	follow      bool
+	since       time.Duration
+	sinceSet    bool
+	withActions bool
+	run         int
+	runSet      bool
+	runs        int
+	runsSet     bool
+	noTimes     bool
+	noLabels    bool
+	sources     []string
+}
+
+// logTarget is one addressable log stream. A service owns the output of its own
+// command; an action owns the output of its executions. The address is what the
+// user typed and what the output labels lines with, so the two never drift.
+type logTarget struct {
+	address  string
+	service  string
+	action   config.ActionID
+	isAction bool
+}
+
+func serviceLogTarget(name string) logTarget {
+	return logTarget{address: name, service: name}
+}
+
+func actionLogTarget(id config.ActionID) logTarget {
+	return logTarget{address: actionIDString(id), action: id, isAction: true}
 }
 
 type cliLogEvent struct {
-	Service   string    `json:"service"`
+	Stream    string    `json:"stream"`
+	Kind      string    `json:"kind"`
+	Owner     string    `json:"owner"`
+	Action    string    `json:"action,omitempty"`
+	Run       uint32    `json:"run,omitempty"`
 	Source    string    `json:"source"`
 	Sequence  uint64    `json:"sequence"`
 	Timestamp time.Time `json:"timestamp"`
@@ -49,34 +80,38 @@ func runLogs(options kranzcli.GlobalOptions, args []string, stdout io.Writer) er
 	if err != nil {
 		return err
 	}
-	record, err := resolveSession(options)
+	client, closeClient, err := dialProjectRuntime(options)
 	if err != nil {
 		return err
 	}
-	client, err := kranzruntime.DialContext(context.Background(), record.Socket, version)
-	if err != nil {
-		return classifyRuntimeError(err)
-	}
-	defer func() { _ = client.Close() }()
-	names, err := resolveLogSelectors(client.Config(), parsed.selectors)
+	defer closeClient()
+	targets, err := resolveLogTargets(client.Config(), parsed.selectors, parsed.withActions)
 	if err != nil {
 		return err
 	}
-	allEvents := collectLogEvents(client, names)
-	cursors := make(map[string]uint64, len(names))
+	parsed = applyLogDefaults(parsed, targets)
+	if parsed.runSet || parsed.runsSet {
+		// A run addresses one execution, and only actions execute. Keeping a
+		// service's continuous stream in the result would answer a question
+		// about runs with lines that belong to no run at all.
+		targets, err = actionTargetsOnly(targets)
+		if err != nil {
+			return err
+		}
+	}
+	allEvents := collectLogEvents(client, targets, parsed)
+	cursors := make(map[string]uint64, len(targets))
 	for _, event := range allEvents {
-		cursors[event.Service] = max(cursors[event.Service], event.Sequence)
+		cursors[event.Stream] = max(cursors[event.Stream], event.Sequence)
 	}
 	// --since narrows the window and --tail caps what that window returns, so
 	// the two compose: "the last 50 lines, from the past five minutes".
-	events := allEvents
+	events := filterLogEventsBySource(allEvents, parsed.sources)
 	if parsed.sinceSet {
 		events = filterLogEventsSince(events, time.Now().Add(-parsed.since))
 	}
-	if parsed.tailSet && parsed.tail < len(events) {
-		events = events[len(events)-parsed.tail:]
-	}
-	if err := writeLogEvents(stdout, options.Output, events, parsed.follow); err != nil {
+	events = tailLogEvents(events, parsed)
+	if err := writeLogEvents(stdout, options.Output, events, parsed); err != nil {
 		return err
 	}
 	if !parsed.follow {
@@ -94,15 +129,92 @@ func runLogs(options kranzcli.GlobalOptions, args []string, stdout io.Writer) er
 		case <-client.Done():
 			return nil
 		case <-ticker.C:
-			fresh := collectLogEventsAfter(client, names, cursors)
-			if err := writeLogEvents(stdout, options.Output, fresh, true); err != nil {
-				return err
-			}
+			fresh := collectLogEventsAfter(client, targets, parsed, cursors)
+			// The cursor has to advance over every fresh line, including the
+			// ones --source hides: a hidden line is still a line this client
+			// has already seen, and filtering compacts the slice in place.
 			for _, event := range fresh {
-				cursors[event.Service] = max(cursors[event.Service], event.Sequence)
+				cursors[event.Stream] = max(cursors[event.Stream], event.Sequence)
+			}
+			if err := writeLogEvents(stdout, options.Output, filterLogEventsBySource(fresh, parsed.sources), parsed); err != nil {
+				return err
 			}
 		}
 	}
+}
+
+// runLogsClear discards buffered history. Clearing everything is the one shape
+// that cannot be narrowed after the fact, so it asks for --force the way `down`
+// does rather than prompting: the CLI is expected to work in scripts.
+func runLogsClear(options kranzcli.GlobalOptions, args []string, stdout io.Writer) error {
+	selectors := make([]string, 0, len(args))
+	force, withActions := false, false
+	for _, arg := range args {
+		switch {
+		case arg == "--force":
+			force = true
+		case arg == "--with-actions":
+			withActions = true
+		case strings.HasPrefix(arg, "-"):
+			return &kranzcli.Error{Code: "unknown_option", Message: fmt.Sprintf("unknown logs clear option %q", arg), Hint: "logs clear accepts --with-actions and --force.", ExitCode: kranzcli.ExitUsage}
+		default:
+			selectors = append(selectors, arg)
+		}
+	}
+	if len(selectors) == 0 && !force {
+		return &kranzcli.Error{
+			Code:     "confirmation_required",
+			Message:  "clearing every log buffer needs --force",
+			Hint:     "Name what to clear, as in `kranz logs clear api`, or repeat with --force.",
+			ExitCode: kranzcli.ExitUsage,
+		}
+	}
+	client, closeClient, err := dialProjectRuntime(options)
+	if err != nil {
+		return err
+	}
+	defer closeClient()
+	// An unqualified clear means the whole project, actions included: the
+	// buffers it leaves behind would be exactly the ones nobody can name.
+	targets, err := resolveLogTargets(client.Config(), selectors, withActions || len(selectors) == 0)
+	if err != nil {
+		return err
+	}
+	cleared := make([]string, 0, len(targets))
+	for _, target := range targets {
+		if target.isAction {
+			client.ClearActionLogs(target.action)
+		} else {
+			client.ClearLogs(target.service)
+		}
+		cleared = append(cleared, target.address)
+	}
+	if options.Output == kranzcli.OutputJSON {
+		return kranzcli.WriteJSON(stdout, struct {
+			Cleared []string `json:"cleared"`
+		}{cleared})
+	}
+	_, _ = fmt.Fprintf(stdout, "Cleared %s.\n", pluralizeStreams(cleared))
+	return nil
+}
+
+func pluralizeStreams(cleared []string) string {
+	if len(cleared) == 1 {
+		return "1 log stream: " + cleared[0]
+	}
+	return fmt.Sprintf("%d log streams: %s", len(cleared), strings.Join(cleared, ", "))
+}
+
+func dialProjectRuntime(options kranzcli.GlobalOptions) (*kranzruntime.Client, func(), error) {
+	record, err := resolveSession(options)
+	if err != nil {
+		return nil, nil, err
+	}
+	client, err := kranzruntime.DialContext(context.Background(), record.Socket, version)
+	if err != nil {
+		return nil, nil, classifyRuntimeError(err)
+	}
+	return client, func() { _ = client.Close() }, nil
 }
 
 func parseLogOptions(args []string) (logOptions, error) {
@@ -114,40 +226,74 @@ func parseLogOptions(args []string) (logOptions, error) {
 			options.follow = true
 		case arg == "--all":
 			options.all = true
-		case arg == "--tail":
-			if index+1 >= len(args) {
-				return logOptions{}, &kranzcli.Error{Code: "missing_option_value", Message: "--tail requires a value", ExitCode: kranzcli.ExitUsage}
+		case arg == "--with-actions":
+			options.withActions = true
+		case arg == "--source" || strings.HasPrefix(arg, "--source="):
+			value, consumed, err := logOptionValue(args, index, "--source")
+			if err != nil {
+				return logOptions{}, err
 			}
-			index++
-			value, err := strconv.Atoi(args[index])
-			if err != nil || value < 0 {
+			index += consumed
+			selected, err := parseLogSources(value)
+			if err != nil {
+				return logOptions{}, err
+			}
+			options.sources = append(options.sources, selected...)
+		case arg == "--no-timestamps":
+			options.noTimes = true
+		case arg == "--no-labels":
+			options.noLabels = true
+		case arg == "--plain":
+			// The command's own output, as the command printed it. Every
+			// column Kranz adds is there to tell interleaved streams apart,
+			// which is exactly what a single stream does not need.
+			options.noTimes, options.noLabels = true, true
+		case arg == "--tail" || strings.HasPrefix(arg, "--tail="):
+			value, consumed, err := logOptionValue(args, index, "--tail")
+			if err != nil {
+				return logOptions{}, err
+			}
+			index += consumed
+			count, convErr := strconv.Atoi(value)
+			if convErr != nil || count < 0 {
 				return logOptions{}, &kranzcli.Error{Code: "invalid_tail", Message: "--tail requires a non-negative integer", ExitCode: kranzcli.ExitUsage}
 			}
-			options.tail, options.tailSet = value, true
-		case strings.HasPrefix(arg, "--tail="):
-			value, err := strconv.Atoi(strings.TrimPrefix(arg, "--tail="))
-			if err != nil || value < 0 {
-				return logOptions{}, &kranzcli.Error{Code: "invalid_tail", Message: "--tail requires a non-negative integer", ExitCode: kranzcli.ExitUsage}
+			options.tail, options.tailSet = count, true
+		case arg == "--since" || strings.HasPrefix(arg, "--since="):
+			value, consumed, err := logOptionValue(args, index, "--since")
+			if err != nil {
+				return logOptions{}, err
 			}
-			options.tail, options.tailSet = value, true
-		case arg == "--since":
-			if index+1 >= len(args) {
-				return logOptions{}, &kranzcli.Error{Code: "missing_option_value", Message: "--since requires a value", ExitCode: kranzcli.ExitUsage}
-			}
-			index++
-			duration, err := time.ParseDuration(args[index])
-			if err != nil || duration < 0 {
+			index += consumed
+			duration, convErr := time.ParseDuration(value)
+			if convErr != nil || duration < 0 {
 				return logOptions{}, &kranzcli.Error{Code: "invalid_since", Message: "--since requires a non-negative duration such as 5m", ExitCode: kranzcli.ExitUsage}
 			}
 			options.since, options.sinceSet = duration, true
-		case strings.HasPrefix(arg, "--since="):
-			duration, err := time.ParseDuration(strings.TrimPrefix(arg, "--since="))
-			if err != nil || duration < 0 {
-				return logOptions{}, &kranzcli.Error{Code: "invalid_since", Message: "--since requires a non-negative duration such as 5m", ExitCode: kranzcli.ExitUsage}
+		case arg == "--run" || strings.HasPrefix(arg, "--run="):
+			value, consumed, err := logOptionValue(args, index, "--run")
+			if err != nil {
+				return logOptions{}, err
 			}
-			options.since, options.sinceSet = duration, true
+			index += consumed
+			number, convErr := strconv.Atoi(value)
+			if convErr != nil || number == 0 {
+				return logOptions{}, &kranzcli.Error{Code: "invalid_run", Message: "--run requires a run number, or a negative offset such as -1 for the latest", ExitCode: kranzcli.ExitUsage}
+			}
+			options.run, options.runSet = number, true
+		case arg == "--runs" || strings.HasPrefix(arg, "--runs="):
+			value, consumed, err := logOptionValue(args, index, "--runs")
+			if err != nil {
+				return logOptions{}, err
+			}
+			index += consumed
+			count, convErr := strconv.Atoi(value)
+			if convErr != nil || count < 1 {
+				return logOptions{}, &kranzcli.Error{Code: "invalid_runs", Message: "--runs requires a positive count", ExitCode: kranzcli.ExitUsage}
+			}
+			options.runs, options.runsSet = count, true
 		case strings.HasPrefix(arg, "-"):
-			return logOptions{}, &kranzcli.Error{Code: "unknown_option", Message: fmt.Sprintf("unknown logs option %q", arg), Hint: "logs accepts --tail N, --since D, --all, and --follow.", ExitCode: kranzcli.ExitUsage}
+			return logOptions{}, &kranzcli.Error{Code: "unknown_option", Message: fmt.Sprintf("unknown logs option %q", arg), Hint: "logs accepts --tail N, --since D, --run N, --runs N, --source S, --all, --with-actions, --plain, --no-timestamps, --no-labels, and --follow.", ExitCode: kranzcli.ExitUsage}
 		default:
 			options.selectors = append(options.selectors, arg)
 		}
@@ -155,55 +301,326 @@ func parseLogOptions(args []string) (logOptions, error) {
 	if options.all && options.tailSet {
 		return logOptions{}, &kranzcli.Error{Code: "invalid_arguments", Message: "--all and --tail contradict each other", ExitCode: kranzcli.ExitUsage}
 	}
-	// An unqualified request means "the recent lines", not "everything ever
-	// captured". Narrowing by time is already a deliberate limit, so --since
-	// does not additionally get the default cap.
-	if !options.tailSet && !options.all && !options.sinceSet {
-		options.tail, options.tailSet = defaultLogTail, true
+	if options.runSet && options.runsSet {
+		return logOptions{}, &kranzcli.Error{Code: "invalid_arguments", Message: "--run and --runs contradict each other", ExitCode: kranzcli.ExitUsage}
 	}
 	return options, nil
 }
 
-func resolveLogSelectors(cfg *config.Config, selectors []string) ([]string, error) {
-	if len(selectors) != 0 {
-		return resolveServiceSelectors(cfg, selectors)
+// knownLogSources are the origins Kranz records for a line: the two process
+// streams, and Kranz itself for the lifecycle notes it writes into the buffer.
+var knownLogSources = []string{"stdout", "stderr", "kranz"}
+
+// parseLogSources accepts one source or a comma-separated list, so both
+// `--source stdout --source stderr` and `--source stdout,stderr` work.
+func parseLogSources(value string) ([]string, error) {
+	selected := make([]string, 0, 2)
+	for _, part := range strings.Split(value, ",") {
+		part = strings.ToLower(strings.TrimSpace(part))
+		if part == "" {
+			continue
+		}
+		if !slices.Contains(knownLogSources, part) {
+			return nil, &kranzcli.Error{
+				Code:     "invalid_source",
+				Message:  fmt.Sprintf("unknown log source %q", part),
+				Hint:     "Sources are " + strings.Join(knownLogSources, ", ") + ".",
+				ExitCode: kranzcli.ExitUsage,
+			}
+		}
+		selected = append(selected, part)
 	}
-	return append([]string(nil), cfg.ServiceOrder...), nil
+	if len(selected) == 0 {
+		return nil, &kranzcli.Error{Code: "invalid_source", Message: "--source requires a source name", Hint: "Sources are " + strings.Join(knownLogSources, ", ") + ".", ExitCode: kranzcli.ExitUsage}
+	}
+	return selected, nil
 }
 
-func collectLogEvents(client *kranzruntime.Client, names []string) []cliLogEvent {
-	events := make([]cliLogEvent, 0)
-	for _, name := range names {
-		for _, entry := range client.Logs(name) {
-			parsed := kranzlog.ParseLine(entry.Raw)
-			source := entry.Source
-			if source == "" {
-				source = "unknown"
+// filterLogEventsBySource keeps only the origins asked for. It runs before the
+// tail so that `--source stderr --tail 20` means twenty error lines, not
+// whatever errors survive in the last twenty lines of everything.
+func filterLogEventsBySource(events []cliLogEvent, sources []string) []cliLogEvent {
+	if len(sources) == 0 {
+		return events
+	}
+	filtered := events[:0]
+	for _, event := range events {
+		if slices.Contains(sources, event.Source) {
+			filtered = append(filtered, event)
+		}
+	}
+	return filtered
+}
+
+// applyLogDefaults decides what an unqualified request means, which depends on
+// what it selected. A service streams without end, so "recent" is the useful
+// answer. An action produces a finite, self-contained run, and capping that at
+// the last 50 lines cuts off its head — the part explaining what the run did.
+func applyLogDefaults(options logOptions, targets []logTarget) logOptions {
+	if options.tailSet || options.all || options.sinceSet || options.runSet || options.runsSet {
+		return options
+	}
+	if allActionTargets(targets) {
+		options.run, options.runSet = -1, true
+		return options
+	}
+	options.tail, options.tailSet = defaultLogTail, true
+	return options
+}
+
+func allActionTargets(targets []logTarget) bool {
+	for _, target := range targets {
+		if !target.isAction {
+			return false
+		}
+	}
+	return len(targets) != 0
+}
+
+// logOptionValue reads a value written either as `--flag value` or `--flag=value`
+// and reports how many extra arguments it consumed.
+func logOptionValue(args []string, index int, name string) (string, int, error) {
+	arg := args[index]
+	if strings.HasPrefix(arg, name+"=") {
+		return strings.TrimPrefix(arg, name+"="), 0, nil
+	}
+	if index+1 >= len(args) {
+		return "", 0, &kranzcli.Error{Code: "missing_option_value", Message: fmt.Sprintf("%s requires a value", name), ExitCode: kranzcli.ExitUsage}
+	}
+	return args[index+1], 1, nil
+}
+
+// resolveLogTargets turns selectors into streams. A name without a slash
+// addresses a service or a tag; a name with one addresses an action, which
+// resolveActionID already disambiguates between service and group owners.
+func resolveLogTargets(cfg *config.Config, selectors []string, withActions bool) ([]logTarget, error) {
+	if len(selectors) == 0 {
+		targets := make([]logTarget, 0, len(cfg.ServiceOrder))
+		for _, name := range cfg.ServiceOrder {
+			targets = append(targets, serviceLogTarget(name))
+		}
+		if withActions {
+			for _, id := range cfg.ActionIDs() {
+				targets = append(targets, actionLogTarget(id))
 			}
-			events = append(events, cliLogEvent{
-				Service:   name,
-				Source:    source,
-				Sequence:  entry.Sequence,
-				Timestamp: entry.Timestamp,
-				Level:     logLevelName(parsed.Level),
-				// The line terminator is how the line arrived, not part of
-				// what it says, so it does not belong in a JSON field a
-				// consumer will compare or print.
-				Text: trimLineEnding(parsed.Text),
-				Raw:  trimLineEnding(entry.Raw),
-			})
+		}
+		return targets, nil
+	}
+	seen := make(map[string]bool)
+	targets := make([]logTarget, 0, len(selectors))
+	add := func(target logTarget) {
+		if seen[target.address] {
+			return
+		}
+		seen[target.address] = true
+		targets = append(targets, target)
+	}
+	for _, selector := range selectors {
+		resolved, err := resolveOneLogSelector(cfg, selector, withActions)
+		if err != nil {
+			return nil, err
+		}
+		for _, target := range resolved {
+			add(target)
+		}
+	}
+	return targets, nil
+}
+
+func resolveOneLogSelector(cfg *config.Config, selector string, withActions bool) ([]logTarget, error) {
+	if strings.Contains(selector, "/") {
+		id, _, err := resolveActionID(cfg, selector)
+		if err != nil {
+			return nil, err
+		}
+		return []logTarget{actionLogTarget(id)}, nil
+	}
+	if _, ok := cfg.Services[selector]; ok {
+		targets := []logTarget{serviceLogTarget(selector)}
+		if withActions {
+			targets = append(targets, ownedActionTargets(cfg, config.ActionOwnerService, selector)...)
+		}
+		return targets, nil
+	}
+	var tagged []logTarget
+	for _, name := range cfg.ServiceOrder {
+		for _, tag := range cfg.Services[name].Tags {
+			if strings.EqualFold(tag, selector) {
+				tagged = append(tagged, serviceLogTarget(name))
+				if withActions {
+					tagged = append(tagged, ownedActionTargets(cfg, config.ActionOwnerService, name)...)
+				}
+				break
+			}
+		}
+	}
+	if len(tagged) != 0 {
+		return tagged, nil
+	}
+	if _, ok := cfg.ActionGroups[selector]; ok {
+		// A group has no command of its own, so its name addresses no stream.
+		// Saying which two ways forward exist beats a bare "not found" for a
+		// name the project really does define.
+		if !withActions {
+			return nil, &kranzcli.Error{
+				Code:     "group_has_no_stream",
+				Message:  fmt.Sprintf("%q is an action group and has no log stream of its own", selector),
+				Hint:     groupSelectorHint(cfg, selector),
+				ExitCode: kranzcli.ExitNotFound,
+			}
+		}
+		return ownedActionTargets(cfg, config.ActionOwnerGroup, selector), nil
+	}
+	return nil, &kranzcli.Error{
+		Code:     "selector_not_found",
+		Message:  fmt.Sprintf("service or tag %q was not found", selector),
+		Hint:     "Run `kranz list services` for services, or `kranz action list` for actions, which are named OWNER/ACTION.",
+		ExitCode: kranzcli.ExitNotFound,
+	}
+}
+
+func groupSelectorHint(cfg *config.Config, group string) string {
+	for _, id := range cfg.ActionIDs() {
+		if id.OwnerKind == config.ActionOwnerGroup && id.Owner == group {
+			return fmt.Sprintf("Name an action, as in `kranz logs %s`, or pass --with-actions to read every action in the group.", actionIDString(id))
+		}
+	}
+	return "Pass --with-actions to read every action in the group."
+}
+
+func ownedActionTargets(cfg *config.Config, kind config.ActionOwnerKind, owner string) []logTarget {
+	var targets []logTarget
+	for _, id := range cfg.ActionIDs() {
+		if id.OwnerKind == kind && id.Owner == owner {
+			targets = append(targets, actionLogTarget(id))
+		}
+	}
+	return targets
+}
+
+func actionTargetsOnly(targets []logTarget) ([]logTarget, error) {
+	filtered := make([]logTarget, 0, len(targets))
+	for _, target := range targets {
+		if target.isAction {
+			filtered = append(filtered, target)
+		}
+	}
+	if len(filtered) == 0 {
+		return nil, &kranzcli.Error{
+			Code:     "no_action_streams",
+			Message:  "--run and --runs address action executions, and no action was selected",
+			Hint:     "Name an action, as in `kranz logs api/migrate --run -1`.",
+			ExitCode: kranzcli.ExitUsage,
+		}
+	}
+	return filtered, nil
+}
+
+func collectLogEvents(client *kranzruntime.Client, targets []logTarget, options logOptions) []cliLogEvent {
+	events := make([]cliLogEvent, 0)
+	for _, target := range targets {
+		entries := target.entries(client)
+		if options.runSet || options.runsSet {
+			entries = filterLogEntriesByRun(entries, options)
+		}
+		for _, entry := range entries {
+			events = append(events, target.events(entry)...)
 		}
 	}
 	sort.SliceStable(events, func(i, j int) bool {
 		if events[i].Timestamp.Equal(events[j].Timestamp) {
-			if events[i].Service == events[j].Service {
+			if events[i].Stream == events[j].Stream {
 				return events[i].Sequence < events[j].Sequence
 			}
-			return events[i].Service < events[j].Service
+			return events[i].Stream < events[j].Stream
 		}
 		return events[i].Timestamp.Before(events[j].Timestamp)
 	})
 	return events
+}
+
+func (t logTarget) entries(client *kranzruntime.Client) []config.LogEntry {
+	if t.isAction {
+		return client.ActionLogs(t.action)
+	}
+	return client.Logs(t.service)
+}
+
+// events turns one captured entry into one event per line of text. A pipe hands
+// Kranz whatever chunk it read, so a single entry can hold fourteen lines; if
+// that entry stayed one event, --tail 50 would print an unpredictable number of
+// lines and cut in the middle of one.
+func (t logTarget) events(entry config.LogEntry) []cliLogEvent {
+	source := entry.Source
+	if source == "" {
+		source = "unknown"
+	}
+	lines := strings.Split(trimLineEnding(entry.Raw), "\n")
+	events := make([]cliLogEvent, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSuffix(line, "\r")
+		parsed := kranzlog.ParseLine(line)
+		event := cliLogEvent{
+			Stream:    t.address,
+			Kind:      "service",
+			Owner:     t.service,
+			Source:    source,
+			Sequence:  entry.Sequence,
+			Timestamp: entry.Timestamp,
+			Level:     logLevelName(parsed.Level),
+			Run:       entry.Run,
+			// The line terminator is how the line arrived, not part of what it
+			// says, so it does not belong in a JSON field a consumer will
+			// compare or print.
+			Text: trimLineEnding(parsed.Text),
+			Raw:  line,
+		}
+		if t.isAction {
+			event.Kind = "action"
+			event.Owner = t.action.Owner
+			event.Action = t.action.Name
+		}
+		events = append(events, event)
+	}
+	return events
+}
+
+// filterLogEntriesByRun narrows one stream to the executions asked for. Run
+// numbers are resolved against the newest run still buffered, so --run -1 keeps
+// meaning "the latest" no matter how many runs have aged out.
+func filterLogEntriesByRun(entries []config.LogEntry, options logOptions) []config.LogEntry {
+	var latest uint32
+	for _, entry := range entries {
+		latest = max(latest, entry.Run)
+	}
+	if latest == 0 {
+		return nil
+	}
+	var lowest, highest uint32
+	switch {
+	case options.runSet && options.run > 0:
+		lowest, highest = uint32(options.run), uint32(options.run)
+	case options.runSet:
+		offset := uint32(-options.run) - 1
+		if offset >= latest {
+			return nil
+		}
+		lowest, highest = latest-offset, latest-offset
+	default:
+		highest = latest
+		if uint32(options.runs) >= latest {
+			lowest = 1
+		} else {
+			lowest = latest - uint32(options.runs) + 1
+		}
+	}
+	filtered := make([]config.LogEntry, 0, len(entries))
+	for _, entry := range entries {
+		if entry.Run >= lowest && entry.Run <= highest {
+			filtered = append(filtered, entry)
+		}
+	}
+	return filtered
 }
 
 const logTimestampLayout = "2006-01-02T15:04:05.000Z07:00"
@@ -223,15 +640,24 @@ func logLevelName(level config.LogLevel) string {
 	}
 }
 
-func collectLogEventsAfter(client *kranzruntime.Client, names []string, cursors map[string]uint64) []cliLogEvent {
-	all := collectLogEvents(client, names)
+func collectLogEventsAfter(client *kranzruntime.Client, targets []logTarget, options logOptions, cursors map[string]uint64) []cliLogEvent {
+	all := collectLogEvents(client, targets, options)
 	fresh := all[:0]
 	for _, event := range all {
-		if event.Sequence > cursors[event.Service] {
+		if event.Sequence > cursors[event.Stream] {
 			fresh = append(fresh, event)
 		}
 	}
 	return fresh
+}
+
+// tailLogEvents keeps the last --tail events. Each event is exactly one printed
+// line, so the flag means the number of lines the user will actually see.
+func tailLogEvents(events []cliLogEvent, options logOptions) []cliLogEvent {
+	if !options.tailSet || options.tail >= len(events) {
+		return events
+	}
+	return events[len(events)-options.tail:]
 }
 
 func filterLogEventsSince(events []cliLogEvent, cutoff time.Time) []cliLogEvent {
@@ -244,9 +670,36 @@ func filterLogEventsSince(events []cliLogEvent, cutoff time.Time) []cliLogEvent 
 	return filtered
 }
 
-func writeLogEvents(stdout io.Writer, format kranzcli.OutputFormat, events []cliLogEvent, stream bool) error {
+// logEventLabel addresses the line the way the user would ask for it. The
+// address already contains a slash for an action, so the source is separated by
+// a space rather than a second slash that would read as another name segment.
+func logEventLabel(event cliLogEvent) string {
+	if event.Run > 0 {
+		return fmt.Sprintf("%s#%d %s", event.Stream, event.Run, event.Source)
+	}
+	return event.Stream + " " + event.Source
+}
+
+// logEventPrefix builds the columns Kranz adds in front of a line. Both are
+// there to tell interleaved streams apart, and both can be switched off for the
+// common case of reading one stream back as the command printed it.
+func logEventPrefix(event cliLogEvent, options logOptions) string {
+	var prefix strings.Builder
+	if !options.noTimes {
+		// A fixed-width timestamp keeps the address column aligned; RFC3339Nano
+		// drops trailing zeros and leaves the output ragged.
+		prefix.WriteString(event.Timestamp.Local().Format(logTimestampLayout))
+		prefix.WriteString(" ")
+	}
+	if !options.noLabels {
+		prefix.WriteString("[" + logEventLabel(event) + "] ")
+	}
+	return prefix.String()
+}
+
+func writeLogEvents(stdout io.Writer, format kranzcli.OutputFormat, events []cliLogEvent, options logOptions) error {
 	if format == kranzcli.OutputJSON {
-		if stream {
+		if options.follow {
 			for _, event := range events {
 				if err := kranzcli.WriteJSON(stdout, event); err != nil {
 					return err
@@ -257,14 +710,8 @@ func writeLogEvents(stdout io.Writer, format kranzcli.OutputFormat, events []cli
 		return kranzcli.WriteJSON(stdout, events)
 	}
 	for _, event := range events {
-		// A fixed-width timestamp keeps the service column aligned; RFC3339Nano
-		// drops trailing zeros and leaves the output ragged.
-		prefix := fmt.Sprintf("%s [%s/%s] ", event.Timestamp.Local().Format(logTimestampLayout), event.Service, event.Source)
-		lines := strings.Split(event.Raw, "\n")
-		for _, line := range lines {
-			if _, err := fmt.Fprintln(stdout, prefix+strings.TrimSuffix(line, "\r")); err != nil {
-				return err
-			}
+		if _, err := fmt.Fprintln(stdout, logEventPrefix(event, options)+event.Raw); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/cmd/kranz/logs_test.go
+++ b/cmd/kranz/logs_test.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
+	kranzcli "github.com/kranz-org/kranz/internal/cli"
 	"github.com/kranz-org/kranz/internal/config"
 )
 
@@ -93,8 +98,29 @@ func TestLogOptionsCapAnUnqualifiedRequest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse = %v", err)
 	}
+	options = applyLogDefaults(options, []logTarget{serviceLogTarget("api")})
 	if !options.tailSet || options.tail != defaultLogTail {
 		t.Errorf("bare logs tail = %d (set %t), want %d", options.tail, options.tailSet, defaultLogTail)
+	}
+}
+
+// An action run is finite and self-contained, so capping it at the last lines
+// cuts off its head: the part that says what the run was doing. A bare action
+// selector therefore means the whole latest run, not the last 50 lines of it.
+func TestLogDefaultsGiveAnActionItsWholeLatestRun(t *testing.T) {
+	action := actionLogTarget(config.ActionID{OwnerKind: config.ActionOwnerGroup, Owner: "analytics", Name: "stats"})
+	options := applyLogDefaults(logOptions{}, []logTarget{action})
+	if options.tailSet {
+		t.Errorf("an action run was capped at %d lines", options.tail)
+	}
+	if !options.runSet || options.run != -1 {
+		t.Errorf("run = %d (set %t), want the latest", options.run, options.runSet)
+	}
+	// A selection that still contains an endless stream keeps the line cap:
+	// "everything the service ever printed" is not what was asked for.
+	mixed := applyLogDefaults(logOptions{}, []logTarget{serviceLogTarget("api"), action})
+	if !mixed.tailSet || mixed.runSet {
+		t.Errorf("mixed selection defaults = %+v", mixed)
 	}
 }
 
@@ -106,7 +132,7 @@ func TestLogOptionsDoNotCapAnExplicitWindow(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v: %v", args, err)
 		}
-		if options.tailSet && options.tail == defaultLogTail {
+		if applied := applyLogDefaults(options, []logTarget{serviceLogTarget("api")}); applied.tailSet && applied.tail == defaultLogTail {
 			t.Errorf("%v was capped at the default tail", args)
 		}
 	}
@@ -115,5 +141,375 @@ func TestLogOptionsDoNotCapAnExplicitWindow(t *testing.T) {
 func TestLogOptionsRejectAllWithTail(t *testing.T) {
 	if _, err := parseLogOptions([]string{"--all", "--tail", "5"}); err == nil {
 		t.Error("--all --tail was accepted")
+	}
+}
+
+// logTargetConfig mirrors the shape this project actually uses: a service that
+// owns actions, and an action group that owns actions but no command.
+func logTargetConfig() *config.Config {
+	return &config.Config{
+		Services: map[string]config.Service{
+			"api":  {Tags: []string{"backend"}, Actions: map[string]config.Action{"migrate": {}}, ActionOrder: []string{"migrate"}},
+			"docs": {Tags: []string{"frontend"}},
+		},
+		ServiceOrder: []string{"api", "docs"},
+		ActionGroups: map[string]config.ActionGroup{
+			"analytics": {Actions: map[string]config.Action{"stats": {}}, ActionOrder: []string{"stats"}},
+		},
+		ActionGroupOrder: []string{"analytics"},
+	}
+}
+
+func targetAddresses(targets []logTarget) []string {
+	addresses := make([]string, 0, len(targets))
+	for _, target := range targets {
+		addresses = append(addresses, target.address)
+	}
+	return addresses
+}
+
+// The reason this work exists: an action is addressed OWNER/ACTION exactly the
+// way `kranz action run` addresses it.
+func TestResolveLogTargetsAddressesActionsByOwnerAndName(t *testing.T) {
+	targets, err := resolveLogTargets(logTargetConfig(), []string{"analytics/stats"}, false)
+	if err != nil {
+		t.Fatalf("resolve = %v", err)
+	}
+	if got := targetAddresses(targets); len(got) != 1 || got[0] != "analytics/stats" {
+		t.Fatalf("targets = %v", got)
+	}
+	if !targets[0].isAction || targets[0].action.OwnerKind != config.ActionOwnerGroup {
+		t.Errorf("target = %+v, want a group action", targets[0])
+	}
+}
+
+// A service name means the service's own command. Its actions are separate
+// streams that only --with-actions folds in.
+func TestResolveLogTargetsSeparatesServiceFromItsActions(t *testing.T) {
+	cfg := logTargetConfig()
+	plain, err := resolveLogTargets(cfg, []string{"api"}, false)
+	if err != nil {
+		t.Fatalf("resolve = %v", err)
+	}
+	if got := targetAddresses(plain); len(got) != 1 || got[0] != "api" {
+		t.Fatalf("without --with-actions = %v", got)
+	}
+	merged, err := resolveLogTargets(cfg, []string{"api"}, true)
+	if err != nil {
+		t.Fatalf("resolve = %v", err)
+	}
+	if got := targetAddresses(merged); len(got) != 2 || got[0] != "api" || got[1] != "api/migrate" {
+		t.Fatalf("with --with-actions = %v", got)
+	}
+}
+
+// A group has no command, so its bare name addresses nothing. The answer has to
+// say which two ways forward exist rather than claim the name is unknown.
+func TestResolveLogTargetsExplainsAGroupHasNoStreamOfItsOwn(t *testing.T) {
+	_, err := resolveLogTargets(logTargetConfig(), []string{"analytics"}, false)
+	if err == nil {
+		t.Fatal("a bare group name was accepted")
+	}
+	cliErr, ok := err.(*kranzcli.Error)
+	if !ok || cliErr.Code != "group_has_no_stream" {
+		t.Fatalf("err = %#v", err)
+	}
+	if !strings.Contains(cliErr.Hint, "analytics/stats") || !strings.Contains(cliErr.Hint, "--with-actions") {
+		t.Errorf("hint does not offer both ways forward: %s", cliErr.Hint)
+	}
+	expanded, err := resolveLogTargets(logTargetConfig(), []string{"analytics"}, true)
+	if err != nil {
+		t.Fatalf("resolve with --with-actions = %v", err)
+	}
+	if got := targetAddresses(expanded); len(got) != 1 || got[0] != "analytics/stats" {
+		t.Fatalf("expanded = %v", got)
+	}
+}
+
+func TestResolveLogTargetsResolvesTagsAndRejectsUnknownNames(t *testing.T) {
+	tagged, err := resolveLogTargets(logTargetConfig(), []string{"backend"}, false)
+	if err != nil {
+		t.Fatalf("resolve = %v", err)
+	}
+	if got := targetAddresses(tagged); len(got) != 1 || got[0] != "api" {
+		t.Fatalf("tag targets = %v", got)
+	}
+	if _, err := resolveLogTargets(logTargetConfig(), []string{"nope"}, false); err == nil {
+		t.Error("an unknown selector was accepted")
+	}
+}
+
+// Selectors that overlap must not print the same line twice.
+func TestResolveLogTargetsDeduplicatesOverlappingSelectors(t *testing.T) {
+	targets, err := resolveLogTargets(logTargetConfig(), []string{"api", "backend", "api/migrate"}, true)
+	if err != nil {
+		t.Fatalf("resolve = %v", err)
+	}
+	if got := targetAddresses(targets); len(got) != 2 {
+		t.Fatalf("targets = %v", got)
+	}
+}
+
+func TestLogOptionsParseRunSelection(t *testing.T) {
+	options, err := parseLogOptions([]string{"analytics/stats", "--run=-1"})
+	if err != nil {
+		t.Fatalf("parse = %v", err)
+	}
+	if !options.runSet || options.run != -1 {
+		t.Errorf("run = %d set=%t", options.run, options.runSet)
+	}
+	// Naming a run is already a deliberate limit, so the default tail must not
+	// silently trim the run the user asked to see in full.
+	if options.tailSet {
+		t.Errorf("run selection still received the default tail of %d", options.tail)
+	}
+	if _, err := parseLogOptions([]string{"--run", "2", "--runs", "3"}); err == nil {
+		t.Error("--run and --runs were accepted together")
+	}
+	for _, args := range [][]string{{"--run"}, {"--run", "0"}, {"--run", "x"}, {"--runs", "0"}, {"--runs", "-2"}} {
+		if _, err := parseLogOptions(args); err == nil {
+			t.Errorf("%v was accepted", args)
+		}
+	}
+}
+
+func runEntries(runs ...uint32) []config.LogEntry {
+	entries := make([]config.LogEntry, 0, len(runs))
+	for index, run := range runs {
+		entries = append(entries, config.LogEntry{Sequence: uint64(index + 1), Run: run, Raw: fmt.Sprintf("line %d", index+1)})
+	}
+	return entries
+}
+
+func entryRuns(entries []config.LogEntry) []uint32 {
+	runs := make([]uint32, 0, len(entries))
+	for _, entry := range entries {
+		runs = append(runs, entry.Run)
+	}
+	return runs
+}
+
+// A negative --run counts back from the newest run still buffered, so -1 keeps
+// meaning "the latest" however many runs have aged out.
+func TestFilterLogEntriesByRunAddressesAbsoluteAndRelativeRuns(t *testing.T) {
+	entries := runEntries(1, 1, 2, 3, 3)
+	for _, testCase := range []struct {
+		name    string
+		options logOptions
+		want    []uint32
+	}{
+		{"absolute", logOptions{run: 2, runSet: true}, []uint32{2}},
+		{"latest", logOptions{run: -1, runSet: true}, []uint32{3, 3}},
+		{"previous", logOptions{run: -2, runSet: true}, []uint32{2}},
+		{"last two", logOptions{runs: 2, runsSet: true}, []uint32{2, 3, 3}},
+		{"more runs than exist", logOptions{runs: 9, runsSet: true}, []uint32{1, 1, 2, 3, 3}},
+		{"beyond the buffer", logOptions{run: -9, runSet: true}, nil},
+		{"never ran", logOptions{run: -1, runSet: true}, nil},
+	} {
+		input := entries
+		if testCase.name == "never ran" {
+			input = runEntries(0, 0)
+		}
+		got := entryRuns(filterLogEntriesByRun(input, testCase.options))
+		if len(got) != len(testCase.want) {
+			t.Errorf("%s: runs = %v, want %v", testCase.name, got, testCase.want)
+			continue
+		}
+		for index := range got {
+			if got[index] != testCase.want[index] {
+				t.Errorf("%s: runs = %v, want %v", testCase.name, got, testCase.want)
+				break
+			}
+		}
+	}
+}
+
+// --run addresses an execution, and services do not execute; asking for one
+// against services alone is a mistake worth naming rather than an empty answer.
+func TestActionTargetsOnlyRejectsAServiceOnlySelection(t *testing.T) {
+	if _, err := actionTargetsOnly([]logTarget{serviceLogTarget("api")}); err == nil {
+		t.Error("a service-only selection was accepted for --run")
+	}
+	kept, err := actionTargetsOnly([]logTarget{
+		serviceLogTarget("api"),
+		actionLogTarget(config.ActionID{OwnerKind: config.ActionOwnerService, Owner: "api", Name: "migrate"}),
+	})
+	if err != nil {
+		t.Fatalf("mixed selection = %v", err)
+	}
+	if got := targetAddresses(kept); len(got) != 1 || got[0] != "api/migrate" {
+		t.Fatalf("kept = %v", got)
+	}
+}
+
+// The address already contains a slash for an action, so the source is split
+// off by a space instead of a second slash that would read as another name.
+func TestLogEventLabelKeepsTheAddressReadableBack(t *testing.T) {
+	for _, testCase := range []struct {
+		event cliLogEvent
+		want  string
+	}{
+		{cliLogEvent{Stream: "docs", Source: "stdout"}, "docs stdout"},
+		{cliLogEvent{Stream: "analytics/stats", Run: 3, Source: "stderr"}, "analytics/stats#3 stderr"},
+	} {
+		if got := logEventLabel(testCase.event); got != testCase.want {
+			t.Errorf("logEventLabel = %q, want %q", got, testCase.want)
+		}
+	}
+}
+
+// A pipe hands Kranz whatever chunk it read, so one captured entry can hold
+// many lines. Counting those as one event would make --tail print an
+// unpredictable number of lines and cut in the middle of one.
+func TestLogTargetEventsSplitACapturedChunkIntoLines(t *testing.T) {
+	target := serviceLogTarget("api")
+	events := target.events(config.LogEntry{Sequence: 7, Source: "stdout", Raw: "first\r\nsecond\nthird\n"})
+	if len(events) != 3 {
+		t.Fatalf("events = %d, want 3", len(events))
+	}
+	for index, want := range []string{"first", "second", "third"} {
+		if events[index].Raw != want {
+			t.Errorf("line %d = %q, want %q", index, events[index].Raw, want)
+		}
+		// The lines came from one captured entry and stay addressable as one:
+		// the follow cursor advances per entry, not per printed line.
+		if events[index].Sequence != 7 {
+			t.Errorf("line %d lost its cursor: %d", index, events[index].Sequence)
+		}
+	}
+}
+
+// Both added columns exist to tell interleaved streams apart, which is exactly
+// what reading a single stream back does not need.
+func TestLogEventPrefixCanBeSwitchedOff(t *testing.T) {
+	event := cliLogEvent{Stream: "analytics/stats", Run: 2, Source: "stdout", Timestamp: time.Date(2026, 8, 23, 9, 0, 0, 0, time.UTC)}
+	full := logEventPrefix(event, logOptions{})
+	if !strings.Contains(full, "analytics/stats#2 stdout") || !strings.Contains(full, "2026-08-23") {
+		t.Fatalf("default prefix = %q", full)
+	}
+	if got := logEventPrefix(event, logOptions{noTimes: true}); got != "[analytics/stats#2 stdout] " {
+		t.Errorf("--no-timestamps prefix = %q", got)
+	}
+	if got := logEventPrefix(event, logOptions{noLabels: true}); strings.Contains(got, "[") {
+		t.Errorf("--no-labels prefix = %q", got)
+	}
+	if got := logEventPrefix(event, logOptions{noTimes: true, noLabels: true}); got != "" {
+		t.Errorf("--plain prefix = %q, want nothing", got)
+	}
+}
+
+func TestLogOptionsParseDisplayFlags(t *testing.T) {
+	plain, err := parseLogOptions([]string{"--plain"})
+	if err != nil || !plain.noTimes || !plain.noLabels {
+		t.Fatalf("--plain = %+v, %v", plain, err)
+	}
+	separate, err := parseLogOptions([]string{"--no-timestamps", "--no-labels"})
+	if err != nil || !separate.noTimes || !separate.noLabels {
+		t.Fatalf("separate flags = %+v, %v", separate, err)
+	}
+}
+
+// The contract --tail states: N is the number of lines the user sees. It broke
+// once because a captured entry could hold many lines while counting as one, so
+// this walks the whole chain — capture, split, tail, print — and counts the
+// lines that actually come out.
+func TestTailPrintsExactlyTheRequestedNumberOfLines(t *testing.T) {
+	target := serviceLogTarget("api")
+	// Chunks as a pipe really delivers them: one read can carry many lines.
+	entries := []config.LogEntry{
+		{Sequence: 1, Source: "stdout", Raw: "one\ntwo\nthree\nfour\n"},
+		{Sequence: 2, Source: "stdout", Raw: "five\n"},
+		{Sequence: 3, Source: "stderr", Raw: "six\nseven\n"},
+	}
+	var events []cliLogEvent
+	for _, entry := range entries {
+		events = append(events, target.events(entry)...)
+	}
+	if len(events) != 7 {
+		t.Fatalf("chunks expanded to %d events, want 7 lines", len(events))
+	}
+	for _, tail := range []int{1, 3, 7, 50} {
+		var out bytes.Buffer
+		options := logOptions{tail: tail, tailSet: true}
+		if err := writeLogEvents(&out, kranzcli.OutputText, tailLogEvents(events, options), options); err != nil {
+			t.Fatal(err)
+		}
+		printed := strings.Count(out.String(), "\n")
+		want := min(tail, len(events))
+		if printed != want {
+			t.Errorf("--tail %d printed %d lines, want %d:\n%s", tail, printed, want, out.String())
+		}
+	}
+	// The tail is the *last* lines, not any N of them.
+	var out bytes.Buffer
+	options := logOptions{tail: 2, tailSet: true, noTimes: true, noLabels: true}
+	if err := writeLogEvents(&out, kranzcli.OutputText, tailLogEvents(events, options), options); err != nil {
+		t.Fatal(err)
+	}
+	if out.String() != "six\nseven\n" {
+		t.Errorf("tail kept the wrong lines: %q", out.String())
+	}
+}
+
+// Every event is one line, so a JSON consumer counting records and a human
+// counting lines must arrive at the same number.
+func TestTextAndJSONAgreeOnHowManyLinesThereAre(t *testing.T) {
+	target := actionLogTarget(config.ActionID{OwnerKind: config.ActionOwnerGroup, Owner: "analytics", Name: "stats"})
+	events := target.events(config.LogEntry{Sequence: 1, Run: 2, Source: "stdout", Raw: "alpha\nbeta\ngamma\n"})
+	var text, encoded bytes.Buffer
+	if err := writeLogEvents(&text, kranzcli.OutputText, events, logOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeLogEvents(&encoded, kranzcli.OutputJSON, events, logOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	var envelope struct {
+		Data []cliLogEvent `json:"data"`
+	}
+	if err := json.Unmarshal(encoded.Bytes(), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	if lines := strings.Count(text.String(), "\n"); lines != len(envelope.Data) {
+		t.Errorf("text printed %d lines but JSON carried %d records", lines, len(envelope.Data))
+	}
+	for _, record := range envelope.Data {
+		if strings.Contains(record.Raw, "\n") {
+			t.Errorf("a JSON record holds more than one line: %q", record.Raw)
+		}
+	}
+}
+
+func TestLogSourceParsingAcceptsListsAndRejectsUnknownNames(t *testing.T) {
+	options, err := parseLogOptions([]string{"--source", "stdout,stderr", "--source=kranz"})
+	if err != nil {
+		t.Fatalf("parse = %v", err)
+	}
+	if len(options.sources) != 3 {
+		t.Fatalf("sources = %v", options.sources)
+	}
+	for _, args := range [][]string{{"--source"}, {"--source", "stdin"}, {"--source", ""}, {"--source", "stdout,nope"}} {
+		if _, err := parseLogOptions(args); err == nil {
+			t.Errorf("%v was accepted", args)
+		}
+	}
+}
+
+// --source narrows before the tail, so `--source stderr --tail 2` means two
+// error lines, not the errors that survive in the last two lines of everything.
+func TestSourceFilterNarrowsBeforeTheTail(t *testing.T) {
+	target := serviceLogTarget("api")
+	events := target.events(config.LogEntry{Sequence: 1, Source: "stderr", Raw: "boom\nbang\n"})
+	events = append(events, target.events(config.LogEntry{Sequence: 2, Source: "stdout", Raw: "fine\nalso fine\nstill fine\n"})...)
+
+	options := logOptions{sources: []string{"stderr"}, tail: 2, tailSet: true, noTimes: true, noLabels: true}
+	var out bytes.Buffer
+	if err := writeLogEvents(&out, kranzcli.OutputText, tailLogEvents(filterLogEventsBySource(events, options.sources), options), options); err != nil {
+		t.Fatal(err)
+	}
+	if out.String() != "boom\nbang\n" {
+		t.Errorf("--source stderr --tail 2 printed %q", out.String())
+	}
+	if got := filterLogEventsBySource(events, nil); len(got) != 5 {
+		t.Errorf("no --source dropped lines: %d of 5 kept", len(got))
 	}
 }

--- a/cmd/kranz/main.go
+++ b/cmd/kranz/main.go
@@ -126,8 +126,13 @@ func execute(args []string, stdout, stderr io.Writer) int {
 			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
 		}
 		return 0
-	case "logs":
+	case "logs show":
 		if err := runLogs(invocation.Globals, invocation.Args, stdout); err != nil {
+			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
+		}
+		return 0
+	case "logs clear":
+		if err := runLogsClear(invocation.Globals, invocation.Args, stdout); err != nil {
 			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
 		}
 		return 0

--- a/cmd/kranz/main_test.go
+++ b/cmd/kranz/main_test.go
@@ -327,7 +327,7 @@ func TestLogsSnapshotFollowAndClientInterrupt(t *testing.T) {
 	if code := execute([]string{"-p", name, "logs", "emitter"}, &stdout, &stderr); code != 0 {
 		t.Fatalf("logs exit=%d stderr=%s", code, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "[emitter/stdout]") || !strings.Contains(stdout.String(), "[emitter/stderr]") {
+	if !strings.Contains(stdout.String(), "[emitter stdout]") || !strings.Contains(stdout.String(), "[emitter stderr]") {
 		t.Fatalf("text logs lost identity:\n%s", stdout.String())
 	}
 	stdout.Reset()
@@ -354,7 +354,7 @@ func TestLogsSnapshotFollowAndClientInterrupt(t *testing.T) {
 	if err := follow.Wait(); err != nil {
 		t.Fatalf("follow interrupted with %v; stderr=%s", err, followErr.String())
 	}
-	if !strings.Contains(followOut.String(), "[emitter/") {
+	if !strings.Contains(followOut.String(), "[emitter ") {
 		t.Fatalf("follow did not stream new events: %s", followOut.String())
 	}
 	stdout.Reset()

--- a/cmd/kranz/runtime_commands.go
+++ b/cmd/kranz/runtime_commands.go
@@ -604,8 +604,15 @@ func runStatus(options kranzcli.GlobalOptions, args []string, stdout io.Writer) 
 	defer func() { _ = client.Close() }()
 	services := client.Services()
 	if len(args) > 0 {
-		selected := make([]*app.ServiceSnapshot, 0, len(args))
-		for _, name := range args {
+		// status answers questions about the same words the lifecycle commands
+		// act on. Resolving them differently would make `kranz status web` and
+		// `kranz restart web` disagree about what "web" means.
+		names, err := resolveServiceSelectors(client.Config(), args)
+		if err != nil {
+			return err
+		}
+		selected := make([]*app.ServiceSnapshot, 0, len(names))
+		for _, name := range names {
 			service, ok := client.Service(name)
 			if !ok {
 				return &kranzcli.Error{Code: "service_not_found", Message: fmt.Sprintf("service %q was not found", name), ExitCode: kranzcli.ExitNotFound}
@@ -848,6 +855,10 @@ func reportReload(stdout io.Writer, options kranzcli.GlobalOptions, name string,
 	return nil
 }
 
+// resolveServiceSelectors is the one meaning a selector has anywhere in the
+// CLI. A name addresses that service; a name no service answers to is tried as
+// a tag. Name wins deliberately: `kranz stop api` must stop the service called
+// api, not everything that happens to carry api as a tag.
 func resolveServiceSelectors(cfg *config.Config, selectors []string) ([]string, error) {
 	selected := make(map[string]bool)
 	for _, selector := range selectors {
@@ -866,7 +877,12 @@ func resolveServiceSelectors(cfg *config.Config, selectors []string) ([]string, 
 			}
 		}
 		if !matched {
-			return nil, &kranzcli.Error{Code: "selector_not_found", Message: fmt.Sprintf("service or tag %q was not found", selector), ExitCode: kranzcli.ExitNotFound}
+			return nil, &kranzcli.Error{
+				Code:     "selector_not_found",
+				Message:  fmt.Sprintf("service or tag %q was not found", selector),
+				Hint:     "Run `kranz list services` for services and `kranz list tags` for tags.",
+				ExitCode: kranzcli.ExitNotFound,
+			}
 		}
 	}
 	names := make([]string, 0, len(selected))

--- a/docs/guide/cli-workflow.md
+++ b/docs/guide/cli-workflow.md
@@ -86,6 +86,72 @@ $ kranz logs --since 5m
 Logs survive the service. A worker that crashed two minutes ago still answers
 `kranz logs worker`, which is when you actually need it.
 
+Actions keep their own history under the same name `kranz action run` uses, so
+an action that has already finished can be read again without running it twice:
+
+```console
+$ kranz logs api/migrate
+$ kranz logs analytics/stats --run -1    # the latest execution
+$ kranz logs analytics/stats --runs 3    # the last three
+```
+
+A bare service name means "recent lines", because a service streams without
+end. A bare action name means its whole latest run: an action produces a
+finite, self-contained report, and capping that at the last lines would cut off
+the part explaining what the run did. `--tail` and `--all` still override both.
+
+The timestamp and label columns exist to tell interleaved streams apart, which
+is exactly what reading one stream back does not need:
+
+```console
+$ kranz logs analytics/stats --plain            # the output as the command printed it
+$ kranz logs analytics/stats --no-timestamps    # keep the labels, drop the clock
+$ kranz logs api --with-actions --no-labels
+```
+
+`--source` narrows to where a line came from — `stdout`, `stderr`, or `kranz`
+for the lifecycle notes Kranz writes into the buffer itself. It narrows before
+`--tail`, so `--source stderr --tail 20` means twenty error lines rather than
+whichever errors survive in the last twenty lines of everything:
+
+```console
+$ kranz logs api --source stderr --tail 20
+$ kranz logs analytics/stats --source stdout --plain > report.txt
+```
+
+## What a selector means
+
+One rule everywhere. A name a service answers to means that service; a name no
+service answers to is tried as a tag. `kranz plan api`, `kranz status api` and
+`kranz stop api` therefore always cover the same services.
+
+Actions extend the rule rather than change it: `OWNER/ACTION` addresses one
+action, using the same name `kranz action run` uses. Because of that, a service
+and an action group may not share a name — the actions under the second one
+would be unreachable — and `kranz config check` rejects a project that tries.
+
+A service name means the service's own command; a group name has no command of
+its own and so no stream. `--with-actions` folds an owner's actions into one
+timeline, labelled so every line says where it came from:
+
+```console
+$ kranz logs api --with-actions
+2026-08-21T09:12:04.118+03:00 [api stdout] listening on :3000
+2026-08-21T09:12:31.902+03:00 [api/migrate#2 stdout] applied 3 migrations
+```
+
+Lifecycle hooks are not addressed separately: their output is part of the life
+of the service they act on, and `kranz logs api` already carries it.
+
+Buffers live in the runtime and are gone after `kranz down`. To reclaim one
+sooner:
+
+```console
+$ kranz logs clear api
+$ kranz logs clear analytics/stats
+$ kranz logs clear --force          # every stream in the project
+```
+
 ## Open the interface on a running project
 
 ```console

--- a/internal/app/api.go
+++ b/internal/app/api.go
@@ -109,6 +109,11 @@ type API interface {
 
 	// Logs returns the current buffered log entries for a service.
 	Logs(name string) []config.LogEntry
+	// ActionLogs returns the buffered log entries of one action. Lifecycle
+	// actions have none: their output belongs to the service they act on.
+	ActionLogs(id config.ActionID) []config.LogEntry
+	// ClearActionLogs discards one action's buffered logs.
+	ClearActionLogs(id config.ActionID)
 	// ClearLogs discards a service's buffered logs and resets its unread
 	// count.
 	ClearLogs(name string)

--- a/internal/app/local.go
+++ b/internal/app/local.go
@@ -299,6 +299,12 @@ func (l *Local) Logs(name string) []config.LogEntry {
 	return svc.LogEntries()
 }
 
+func (l *Local) ActionLogs(id config.ActionID) []config.LogEntry {
+	return l.manager.ActionLogs(id)
+}
+
+func (l *Local) ClearActionLogs(id config.ActionID) { l.manager.ClearActionLogs(id) }
+
 func (l *Local) ClearLogs(name string) {
 	svc, ok := l.manager.GetService(name)
 	if !ok {

--- a/internal/cli/tree.go
+++ b/internal/cli/tree.go
@@ -60,7 +60,10 @@ func DefaultTree() *Command {
 		{Name: "reload", Summary: "reload runtime configuration"},
 		{Name: "down", Summary: "stop a project runtime", Usage: "kranz down [--force]"},
 		{Name: "attach", Summary: "open the TUI for an active runtime"},
-		{Name: "logs", Summary: "show service logs", Usage: "kranz logs [SELECTOR ...] [--tail N | --all] [--since D] [--follow]"},
+		{Name: "logs", Summary: "show and clear logs", Default: "show", Children: []*Command{
+			{Name: "show", Summary: "show service and action logs", Usage: "kranz logs [SELECTOR ...] [--tail N | --all] [--since D]\n  [--run N | --runs N] [--source S] [--with-actions]\n  [--plain | --no-timestamps | --no-labels] [--follow]"},
+			{Name: "clear", Summary: "discard buffered logs", Usage: "kranz logs clear [SELECTOR ...] [--with-actions] [--force]"},
+		}},
 		{Name: "action", Summary: "inspect and run actions", Default: "list", Children: []*Command{
 			{Name: "list", Summary: "list actions", Usage: "kranz action list [OWNER]"},
 			{Name: "info", Summary: "show action details", Usage: "kranz action info OWNER/ACTION"},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1428,3 +1428,33 @@ services:
 		t.Fatalf("merged before_start = %#v, want the override sequence only", prerequisites)
 	}
 }
+
+// An action is addressed OWNER/ACTION. When a service and an action group share
+// a name, every action in that group becomes ambiguous and the CLI has no way
+// to say which owner was meant — the project would load cleanly and then be
+// partly unreachable.
+func TestValidateRejectsAnActionGroupNamedAfterAService(t *testing.T) {
+	cfg := &Config{
+		Project:      "Collision",
+		Services:     map[string]Service{"api": {Command: "sleep 60"}},
+		ServiceOrder: []string{"api"},
+		ActionGroups: map[string]ActionGroup{
+			"api": {Actions: map[string]Action{"migrate": {Command: "true"}}, ActionOrder: []string{"migrate"}},
+		},
+		ActionGroupOrder: []string{"api"},
+	}
+	err := Validate(cfg)
+	if err == nil {
+		t.Fatal("a service and an action group were allowed to share a name")
+	}
+	if !strings.Contains(err.Error(), "collides") || !strings.Contains(err.Error(), "api") {
+		t.Errorf("error does not name the collision: %v", err)
+	}
+	// A group whose name is free stays valid.
+	delete(cfg.ActionGroups, "api")
+	cfg.ActionGroups["analytics"] = ActionGroup{Actions: map[string]Action{"stats": {Command: "true"}}, ActionOrder: []string{"stats"}}
+	cfg.ActionGroupOrder = []string{"analytics"}
+	if err := Validate(cfg); err != nil {
+		t.Errorf("a distinctly named group was rejected: %v", err)
+	}
+}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -518,9 +518,13 @@ type LogEntry struct {
 	Sequence  uint64    `json:"sequence"`
 	Timestamp time.Time `json:"timestamp"`
 	Source    string    `json:"source"`
-	Level     LogLevel  `json:"level"`
-	Text      string    `json:"text"`
-	Raw       string    `json:"raw"`
+	// Run numbers the execution that produced the line. Services stream
+	// continuously and leave it zero; actions number every invocation so a
+	// single run stays addressable after later ones append to the same buffer.
+	Run   uint32   `json:"run,omitempty"`
+	Level LogLevel `json:"level"`
+	Text  string   `json:"text"`
+	Raw   string   `json:"raw"`
 }
 
 // Notification is one entry in the in-memory notification center.

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -115,6 +115,13 @@ func Validate(cfg *Config) error {
 		if len(group.Actions) == 0 {
 			return fmt.Errorf("action group %q must contain at least one action", name)
 		}
+		// An action is addressed OWNER/ACTION. Sharing a name with a service
+		// would make every action in this group ambiguous, and the CLI has no
+		// way to say which owner was meant: the group would load cleanly and
+		// then be unreachable.
+		if _, taken := cfg.Services[name]; taken {
+			return fmt.Errorf("action group %q collides with the service of the same name: rename one so its actions stay addressable", name)
+		}
 		if err := validateActions(fmt.Sprintf("action group %q", name), group.Actions); err != nil {
 			return err
 		}

--- a/internal/runtime/client.go
+++ b/internal/runtime/client.go
@@ -386,6 +386,15 @@ func (c *Client) Logs(name string) []config.LogEntry {
 	return resp.Entries
 }
 
+func (c *Client) ActionLogs(id config.ActionID) []config.LogEntry {
+	resp, _ := call[actionIDRequest, logsResponse](c, context.Background(), methodActionLogs, actionIDRequest{ID: id})
+	return resp.Entries
+}
+
+func (c *Client) ClearActionLogs(id config.ActionID) {
+	_, _ = call[actionIDRequest, emptyResponse](c, context.Background(), methodClearActionLogs, actionIDRequest{ID: id})
+}
+
 func (c *Client) ClearLogs(name string) {
 	_, _ = call[nameRequest, emptyResponse](c, context.Background(), methodClearLogs, nameRequest{Name: name})
 }

--- a/internal/runtime/handlers.go
+++ b/internal/runtime/handlers.go
@@ -126,6 +126,13 @@ var handlers = map[string]handlerFunc{
 		}
 		return l.CompleteInteractiveAction(req.ID, req.Lease, execErr, req.ExitCode, req.PID)
 	}),
+	methodActionLogs: handler(func(_ context.Context, l *app.Local, req actionIDRequest) (logsResponse, error) {
+		return logsResponse{Entries: l.ActionLogs(req.ID)}, nil
+	}),
+	methodClearActionLogs: handler(func(_ context.Context, l *app.Local, req actionIDRequest) (emptyResponse, error) {
+		l.ClearActionLogs(req.ID)
+		return emptyResponse{}, nil
+	}),
 	methodLogs: handler(func(_ context.Context, l *app.Local, req nameRequest) (logsResponse, error) {
 		return logsResponse{Entries: l.Logs(req.Name)}, nil
 	}),

--- a/internal/runtime/messages.go
+++ b/internal/runtime/messages.go
@@ -42,6 +42,8 @@ const (
 	methodCancelAction                    = "cancelAction"
 	methodAcquireInteractiveAction        = "acquireInteractiveAction"
 	methodCompleteInteractiveAction       = "completeInteractiveAction"
+	methodActionLogs                      = "actionLogs"
+	methodClearActionLogs                 = "clearActionLogs"
 	methodLogs                            = "logs"
 	methodClearLogs                       = "clearLogs"
 	methodMarkLogsRead                    = "markLogsRead"

--- a/internal/service/action.go
+++ b/internal/service/action.go
@@ -119,6 +119,8 @@ type ActionRunner struct {
 	states       map[config.ActionID]ActionResult
 	active       map[actionOwner]*activeAction
 	logBufSize   int
+	logsMu       sync.RWMutex
+	logs         map[config.ActionID]*logStream
 	shuttingDown bool
 	leaseSeq     atomic.Uint64
 }
@@ -132,6 +134,7 @@ func NewActionRunner(cfg *config.Config, logBufSize int) *ActionRunner {
 		cfg:        cfg,
 		states:     make(map[config.ActionID]ActionResult),
 		active:     make(map[actionOwner]*activeAction),
+		logs:       make(map[config.ActionID]*logStream),
 		logBufSize: logBufSize,
 	}
 }
@@ -202,7 +205,17 @@ func (r *ActionRunner) RunDefinition(ctx context.Context, id config.ActionID, ac
 	r.states[id] = ActionResult{ID: id, Status: ActionRunning, ExitCode: -1, StartedAt: started}
 	r.mu.Unlock()
 
-	result, runErr := r.execute(runCtx, id, action, started)
+	stream := r.logStreamFor(id)
+	var run uint32
+	if stream != nil {
+		run = stream.BeginRun()
+		stream.Append(started, "kranz", fmt.Sprintf("[Kranz] %s/%s #%d started", id.Owner, id.Name, run))
+	}
+	result, runErr := r.execute(runCtx, id, action, started, stream)
+	if stream != nil {
+		stream.Append(time.Now(), "kranz", fmt.Sprintf("[Kranz] %s/%s #%d %s · exit %d · %s",
+			id.Owner, id.Name, run, result.Status, result.ExitCode, result.Duration.Round(time.Millisecond)))
+	}
 	cancel()
 	r.mu.Lock()
 	delete(r.active, owner)
@@ -212,7 +225,7 @@ func (r *ActionRunner) RunDefinition(ctx context.Context, id config.ActionID, ac
 	return result, runErr
 }
 
-func (r *ActionRunner) execute(ctx context.Context, id config.ActionID, action config.Action, started time.Time) (ActionResult, error) {
+func (r *ActionRunner) execute(ctx context.Context, id config.ActionID, action config.Action, started time.Time, stream *logStream) (ActionResult, error) {
 	result := ActionResult{ID: id, Status: ActionFailed, ExitCode: -1, StartedAt: started}
 	if err := ctx.Err(); err != nil {
 		return finishActionResult(result, ActionCancelled, nil, err)
@@ -226,6 +239,10 @@ func (r *ActionRunner) execute(ctx context.Context, id config.ActionID, action c
 	}
 	result.PID = pid
 	r.setActionPID(id, pid)
+	// The pump copies output into the addressable stream while the action runs,
+	// so `kranz logs owner/action --follow` sees lines as they land instead of
+	// only at exit. Its final sweep runs on every return path.
+	defer startOutputPump(stream, process)()
 
 	waitCh := make(chan error, 1)
 	go func() { waitCh <- process.Wait() }()
@@ -430,3 +447,96 @@ func (m *Manager) ActionStates() []ActionResult {
 func (m *Manager) CancelAction(id config.ActionID) bool {
 	return m.actions.Cancel(id)
 }
+
+// actionLogPumpInterval paces copying a running action's output into its
+// addressable stream. It matches the detached log follower's cadence: fast
+// enough that --follow feels live, slow enough to stay off the hot path.
+const actionLogPumpInterval = 100 * time.Millisecond
+
+// logStreamFor returns the addressable log stream for an action, creating it on
+// first use. Lifecycle actions get none: their output already belongs to the
+// service they act on, and `kranz logs api` is where it is read.
+func (r *ActionRunner) logStreamFor(id config.ActionID) *logStream {
+	if id.OwnerKind == config.ActionOwnerLifecycle {
+		return nil
+	}
+	r.logsMu.Lock()
+	defer r.logsMu.Unlock()
+	stream, exists := r.logs[id]
+	if !exists {
+		stream = newLogStream(r.logBufSize)
+		r.logs[id] = stream
+	}
+	return stream
+}
+
+// ActionLogEntries returns the buffered history of one action.
+func (r *ActionRunner) ActionLogEntries(id config.ActionID) []config.LogEntry {
+	r.logsMu.RLock()
+	stream := r.logs[id]
+	r.logsMu.RUnlock()
+	if stream == nil {
+		return nil
+	}
+	return stream.Entries()
+}
+
+// ClearActionLogs discards one action's buffered history.
+func (r *ActionRunner) ClearActionLogs(id config.ActionID) {
+	r.logsMu.RLock()
+	stream := r.logs[id]
+	r.logsMu.RUnlock()
+	if stream != nil {
+		stream.Clear()
+	}
+}
+
+// startOutputPump copies a process's captured output into stream until the
+// returned stop function is called, which sweeps whatever arrived last. It
+// reads by offset rather than draining, so the ActionResult snapshot the caller
+// builds from the same buffers stays complete.
+func startOutputPump(stream *logStream, process *ProcessManager) func() {
+	if stream == nil || process == nil {
+		return func() {}
+	}
+	stdoutOffset, stderrOffset := 0, 0
+	sweep := func() {
+		lines := process.Stdout().Lines()
+		for ; stdoutOffset < len(lines); stdoutOffset++ {
+			stream.Append(time.Now(), "stdout", lines[stdoutOffset])
+		}
+		lines = process.Stderr().Lines()
+		for ; stderrOffset < len(lines); stderrOffset++ {
+			stream.Append(time.Now(), "stderr", lines[stderrOffset])
+		}
+	}
+	done, finished := make(chan struct{}), make(chan struct{})
+	go func() {
+		defer close(finished)
+		ticker := time.NewTicker(actionLogPumpInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				sweep()
+			}
+		}
+	}()
+	// The offsets are owned by the pump goroutine; the final sweep runs only
+	// after it has exited, so the two never advance them concurrently.
+	return func() {
+		close(done)
+		<-finished
+		sweep()
+	}
+}
+
+// ActionLogs returns the buffered history of one action.
+func (m *Manager) ActionLogs(id config.ActionID) []config.LogEntry {
+	return m.actions.ActionLogEntries(id)
+}
+
+// ClearActionLogs discards one action's buffered history.
+func (m *Manager) ClearActionLogs(id config.ActionID) { m.actions.ClearActionLogs(id) }

--- a/internal/service/action_test.go
+++ b/internal/service/action_test.go
@@ -286,3 +286,79 @@ func waitForActionStatus(t *testing.T, runner *ActionRunner, id config.ActionID,
 	state, exists := runner.State(id)
 	t.Fatalf("action state = %#v, %v; want %s", state, exists, status)
 }
+
+// The whole point of the action log stream: output survives the run that
+// produced it, so it can be read again without running the action a second
+// time. Each run is numbered and framed so a later one stays distinguishable.
+func TestActionRunnerRetainsNumberedRunsInItsLogStream(t *testing.T) {
+	directory := t.TempDir()
+	id := serviceActionID("app", "report")
+	runner := newTestActionRunner(directory, map[string]config.Action{
+		"report": {Command: `printf 'counted\n'; printf 'noticed\n' >&2`, Dir: directory, Shell: "/bin/sh"},
+	})
+
+	for range 2 {
+		if _, err := runner.Run(context.Background(), id); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	entries := runner.ActionLogEntries(id)
+	if len(entries) == 0 {
+		t.Fatal("the finished action left no log stream behind")
+	}
+	byRun := map[uint32][]config.LogEntry{}
+	for _, entry := range entries {
+		byRun[entry.Run] = append(byRun[entry.Run], entry)
+	}
+	if len(byRun) != 2 {
+		t.Fatalf("runs = %d, want 2", len(byRun))
+	}
+	for run := uint32(1); run <= 2; run++ {
+		text := ""
+		sources := map[string]bool{}
+		for _, entry := range byRun[run] {
+			text += entry.Raw + "\n"
+			sources[entry.Source] = true
+		}
+		if !strings.Contains(text, "counted") || !strings.Contains(text, "noticed") {
+			t.Errorf("run %d lost process output: %s", run, text)
+		}
+		if !sources["stdout"] || !sources["stderr"] {
+			t.Errorf("run %d lost stream identity: %v", run, sources)
+		}
+		if !strings.Contains(text, "#"+string(rune('0'+run))+" started") {
+			t.Errorf("run %d is not framed: %s", run, text)
+		}
+	}
+
+	runner.ClearActionLogs(id)
+	if remaining := runner.ActionLogEntries(id); len(remaining) != 0 {
+		t.Errorf("cleared stream still holds %d entries", len(remaining))
+	}
+	// Clearing reclaims the buffer without reusing run numbers: an address must
+	// never come to mean a different execution than it did before.
+	if _, err := runner.Run(context.Background(), id); err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range runner.ActionLogEntries(id) {
+		if entry.Run != 3 {
+			t.Fatalf("run numbering restarted at %d after a clear", entry.Run)
+		}
+	}
+}
+
+// A lifecycle hook's output belongs to the service it acts on, which already
+// records it. Giving it a second, unaddressable stream would only duplicate it.
+func TestActionRunnerKeepsNoStreamForLifecycleActions(t *testing.T) {
+	directory := t.TempDir()
+	runner := newTestActionRunner(directory, nil)
+	id := config.ActionID{OwnerKind: config.ActionOwnerLifecycle, Owner: "app", Name: "prestart"}
+	action := config.Action{Command: `printf 'hooked\n'`, Dir: directory, Shell: "/bin/sh"}
+	if _, err := runner.RunDefinition(context.Background(), id, action); err != nil {
+		t.Fatal(err)
+	}
+	if entries := runner.ActionLogEntries(id); len(entries) != 0 {
+		t.Errorf("lifecycle action opened its own stream: %v", entries)
+	}
+}

--- a/internal/service/logstream.go
+++ b/internal/service/logstream.go
@@ -1,0 +1,169 @@
+package service
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kranz-org/kranz/internal/config"
+	"github.com/kranz-org/kranz/pkg/ringbuffer"
+)
+
+// logStream is one addressable log history: the bounded line buffer plus the
+// metadata rings written in lockstep with it. Services and actions both keep
+// one, so `kranz logs api` and `kranz logs analytics/stats` read the same
+// structure through the same filters rather than two parallel implementations.
+type logStream struct {
+	buffer *ringbuffer.RingBuffer
+
+	mu        sync.RWMutex
+	times     []time.Time
+	sources   []string
+	sequences []uint64
+	// runs records which execution produced each line. A service produces one
+	// continuous stream and leaves this zero; an action restarts the numbering
+	// story on every invocation, which is what --run addresses.
+	runs       []uint32
+	write      int
+	count      int
+	nextSeq    uint64
+	currentRun uint32
+}
+
+func newLogStream(size int) *logStream {
+	if size <= 0 {
+		size = defaultLogBufferSize
+	}
+	return &logStream{
+		buffer:    ringbuffer.New(size),
+		times:     make([]time.Time, size),
+		sources:   make([]string, size),
+		sequences: make([]uint64, size),
+		runs:      make([]uint32, size),
+	}
+}
+
+// BeginRun opens a new numbered execution and returns its number. Numbering is
+// monotonic for the life of the stream, so a run number stays a stable address
+// even after older runs age out of the buffer.
+func (s *logStream) BeginRun() uint32 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.currentRun++
+	return s.currentRun
+}
+
+// LastRun returns the most recent run number, or zero when nothing has run.
+func (s *logStream) LastRun() uint32 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.currentRun
+}
+
+// Append records text with the time Kranz received it, one entry per line. A
+// pipe read is not line-aligned, so what arrives here can be fourteen lines in
+// one string; storing that as a single entry is what made every consumer that
+// counts entries — a tail, a search hit count, an "N lines omitted" cap —
+// report a number the user could not reproduce by counting what they saw.
+func (s *logStream) Append(timestamp time.Time, source, text string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if source == "" {
+		source = "unknown"
+	}
+	for _, line := range splitCapturedLines(text) {
+		s.appendLineLocked(timestamp, source, line)
+	}
+}
+
+func (s *logStream) appendLineLocked(timestamp time.Time, source, line string) {
+	s.nextSeq++
+	s.buffer.Write(line)
+	s.times[s.write] = timestamp
+	s.sources[s.write] = source
+	s.sequences[s.write] = s.nextSeq
+	s.runs[s.write] = s.currentRun
+	s.write = (s.write + 1) % len(s.times)
+	if s.count < len(s.times) {
+		s.count++
+	}
+}
+
+// splitCapturedLines breaks captured text into stored lines. A trailing
+// newline ends the last line rather than starting an empty one; a blank line in
+// the middle is real output and is kept.
+func splitCapturedLines(text string) []string {
+	if !strings.Contains(text, "\n") {
+		return []string{text}
+	}
+	lines := strings.Split(strings.TrimSuffix(text, "\n"), "\n")
+	for index, line := range lines {
+		lines[index] = strings.TrimSuffix(line, "\r")
+	}
+	return lines
+}
+
+// Entries returns an aligned snapshot of log text and its capture metadata.
+func (s *logStream) Entries() []config.LogEntry {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	lines := s.buffer.Lines()
+	count := min(len(lines), s.count)
+	entries := make([]config.LogEntry, 0, count)
+	// The metadata rings are written in lockstep with the text buffer, so one
+	// index walked back from the write cursor addresses all of them. Rebuilding
+	// a separate ordered copy per field invites the fields to disagree.
+	for index := range count {
+		metadataIndex := (s.write - count + index + len(s.times)) % len(s.times)
+		entries = append(entries, config.LogEntry{
+			Sequence:  s.sequences[metadataIndex],
+			Timestamp: s.times[metadataIndex],
+			Source:    s.sources[metadataIndex],
+			Run:       s.runs[metadataIndex],
+			Raw:       lines[len(lines)-count+index],
+		})
+	}
+	return entries
+}
+
+// Lines returns the buffered text without its metadata.
+func (s *logStream) Lines() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.buffer.Lines()
+}
+
+// Clear atomically discards both log text and its metadata. The run counter
+// survives: clearing is about reclaiming the buffer, and reusing run numbers
+// afterwards would make an address point at two different executions.
+func (s *logStream) Clear() {
+	s.mu.Lock()
+	s.buffer.Clear()
+	clear(s.times)
+	clear(s.sources)
+	clear(s.sequences)
+	clear(s.runs)
+	s.write = 0
+	s.count = 0
+	s.mu.Unlock()
+}
+
+// CopyFrom preserves a logical stream across a hot reload.
+func (s *logStream) CopyFrom(previous *logStream) {
+	previous.mu.RLock()
+	defer previous.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.buffer = previous.buffer
+	s.times = append(s.times[:0], previous.times...)
+	s.sources = append(s.sources[:0], previous.sources...)
+	s.sequences = append(s.sequences[:0], previous.sequences...)
+	s.runs = append(s.runs[:0], previous.runs...)
+	s.write = previous.write
+	s.count = previous.count
+	s.nextSeq = previous.nextSeq
+	s.currentRun = previous.currentRun
+}
+
+// defaultLogBufferSize bounds one stream's history when no size is configured.
+const defaultLogBufferSize = 1000

--- a/internal/service/manager_dependencies.go
+++ b/internal/service/manager_dependencies.go
@@ -93,7 +93,7 @@ func (m *Manager) waitForDependencyCondition(ctx context.Context, name string, c
 				return fmt.Errorf("dependency %s completed with exit code %d", name, state.ExitCode)
 			}
 		case config.DependencyLogReady:
-			for _, line := range svc.Logs.Lines() {
+			for _, line := range svc.LogLines() {
 				if readyPattern.MatchString(line) {
 					return nil
 				}

--- a/internal/service/manager_stop.go
+++ b/internal/service/manager_stop.go
@@ -104,9 +104,14 @@ func (m *Manager) appendLifecycleResult(svc *Service, operation string, result A
 	// successful lifecycle operation only needs its concise boundary; keep
 	// command output for failures where it is diagnostic.
 	if result.Status != ActionSucceeded {
-		lines := append([]string(nil), result.Stdout...)
-		for _, line := range result.Stderr {
-			lines = append(lines, "[stderr] "+line)
+		var lines []string
+		for _, chunk := range result.Stdout {
+			lines = append(lines, splitCapturedLines(chunk)...)
+		}
+		for _, chunk := range result.Stderr {
+			for _, line := range splitCapturedLines(chunk) {
+				lines = append(lines, "[stderr] "+line)
+			}
 		}
 		const maxLifecycleFailureLines = 40
 		if omitted := len(lines) - maxLifecycleFailureLines; omitted > 0 {

--- a/internal/service/manager_test.go
+++ b/internal/service/manager_test.go
@@ -194,7 +194,7 @@ func TestLifecycleResultHidesSuccessfulProgressButKeepsFailureOutput(t *testing.
 		Status: ActionSucceeded, ExitCode: 0,
 		Stdout: []string{"created"}, Stderr: []string{"Container api Running"},
 	})
-	logs := strings.Join(service.Logs.Lines(), "\n")
+	logs := strings.Join(service.LogLines(), "\n")
 	if strings.Contains(logs, "created") || strings.Contains(logs, "Container api Running") {
 		t.Fatalf("successful lifecycle progress leaked into service logs:\n%s", logs)
 	}
@@ -205,7 +205,7 @@ func TestLifecycleResultHidesSuccessfulProgressButKeepsFailureOutput(t *testing.
 	manager.appendLifecycleResult(service, "stop", ActionResult{
 		Status: ActionFailed, ExitCode: 1, Stderr: []string{"permission denied"},
 	})
-	logs = strings.Join(service.Logs.Lines(), "\n")
+	logs = strings.Join(service.LogLines(), "\n")
 	if !strings.Contains(logs, "[stderr] permission denied") {
 		t.Fatalf("failed lifecycle diagnostics missing:\n%s", logs)
 	}
@@ -345,11 +345,11 @@ func TestDetachedLogFollowerStreamsAndStopsSeparately(t *testing.T) {
 	}
 	service, _ := manager.GetService("stack")
 	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) && !strings.Contains(strings.Join(service.Logs.Lines(), ""), "remote log") {
+	for time.Now().Before(deadline) && !strings.Contains(strings.Join(service.LogLines(), ""), "remote log") {
 		time.Sleep(10 * time.Millisecond)
 	}
-	if !strings.Contains(strings.Join(service.Logs.Lines(), ""), "remote log") {
-		t.Fatalf("detached logs were not streamed: %v", service.Logs.Lines())
+	if !strings.Contains(strings.Join(service.LogLines(), ""), "remote log") {
+		t.Fatalf("detached logs were not streamed: %v", service.LogLines())
 	}
 	if err := manager.StopService("stack"); err != nil {
 		t.Fatal(err)
@@ -579,7 +579,7 @@ func TestStartAndStopAppendLifecycleBoundaries(t *testing.T) {
 	}
 
 	api, _ := manager.GetService("api")
-	logs := strings.Join(api.Logs.Lines(), "\n")
+	logs := strings.Join(api.LogLines(), "\n")
 	for _, expected := range []string{
 		"[Kranz] Starting",
 		"[Kranz] Started · PID ",

--- a/internal/service/port_discovery_test.go
+++ b/internal/service/port_discovery_test.go
@@ -378,13 +378,13 @@ func TestDiscoveryFailureIsNonFatalAndRecoveryReplacesSnapshots(t *testing.T) {
 		{},
 	}}
 	manager.SetListenerScanner(scanner)
-	logsBefore := len(svc.Logs.Lines())
+	logsBefore := len(svc.LogLines())
 
 	manager.refreshDetectedPorts(context.Background())
 	if svc.Status() != config.StatusRunning || len(svc.DetectedPorts()) != 0 {
 		t.Fatalf("scanner failure affected service: status=%s ports=%v", svc.Status(), svc.DetectedPorts())
 	}
-	if logsAfter := len(svc.Logs.Lines()); logsAfter != logsBefore {
+	if logsAfter := len(svc.LogLines()); logsAfter != logsBefore {
 		t.Fatalf("scanner failure added service log spam: before=%d after=%d", logsBefore, logsAfter)
 	}
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -18,14 +18,7 @@ type Service struct {
 	State   config.ServiceState
 	stateMu sync.RWMutex
 
-	Logs            *ringbuffer.RingBuffer
-	logMu           sync.RWMutex
-	logTimes        []time.Time
-	logSources      []string
-	logSequences    []uint64
-	logTimeWrite    int
-	logTimeCount    int
-	nextLogSequence uint64
+	stream *logStream
 
 	// HealthHistory is bounded separately from process output.
 	HealthHistory *ringbuffer.RingBuffer
@@ -113,7 +106,7 @@ func (s *Service) updateDetectedPorts(generation uint64, ports []int) bool {
 // NewService creates a stopped runtime service from configuration.
 func NewService(name string, cfg config.Service, logBufSize int) *Service {
 	if logBufSize <= 0 {
-		logBufSize = 1000
+		logBufSize = defaultLogBufferSize
 	}
 	status := config.StatusStopped
 	if cfg.IsDetached() {
@@ -122,10 +115,7 @@ func NewService(name string, cfg config.Service, logBufSize int) *Service {
 	return &Service{
 		Name:          name,
 		Config:        cfg,
-		Logs:          ringbuffer.New(logBufSize),
-		logTimes:      make([]time.Time, logBufSize),
-		logSources:    make([]string, logBufSize),
-		logSequences:  make([]uint64, logBufSize),
+		stream:        newLogStream(logBufSize),
 		HealthHistory: ringbuffer.New(50),
 		State: config.ServiceState{
 			Status: status,
@@ -299,71 +289,21 @@ func (s *Service) AppendLogAt(timestamp time.Time, line string) {
 
 // AppendLogAtSource records a source-aware line with a stable sequence cursor.
 func (s *Service) AppendLogAtSource(timestamp time.Time, source, line string) {
-	s.logMu.Lock()
-	if source == "" {
-		source = "unknown"
-	}
-	s.nextLogSequence++
-	s.Logs.Write(line)
-	s.logTimes[s.logTimeWrite] = timestamp
-	s.logSources[s.logTimeWrite] = source
-	s.logSequences[s.logTimeWrite] = s.nextLogSequence
-	s.logTimeWrite = (s.logTimeWrite + 1) % len(s.logTimes)
-	if s.logTimeCount < len(s.logTimes) {
-		s.logTimeCount++
-	}
-	s.logMu.Unlock()
+	s.stream.Append(timestamp, source, line)
 	s.IncrementNewLogCount()
 }
 
 // LogEntries returns an aligned snapshot of log text and capture timestamps.
-func (s *Service) LogEntries() []config.LogEntry {
-	s.logMu.RLock()
-	defer s.logMu.RUnlock()
-	lines := s.Logs.Lines()
-	count := min(len(lines), s.logTimeCount)
-	entries := make([]config.LogEntry, 0, count)
-	// The metadata rings are written in lockstep with the text buffer, so one
-	// index walked back from the write cursor addresses all of them. Rebuilding
-	// a separate ordered copy per field invites the fields to disagree.
-	for index := range count {
-		metadataIndex := (s.logTimeWrite - count + index + len(s.logTimes)) % len(s.logTimes)
-		entries = append(entries, config.LogEntry{
-			Sequence:  s.logSequences[metadataIndex],
-			Timestamp: s.logTimes[metadataIndex],
-			Source:    s.logSources[metadataIndex],
-			Raw:       lines[len(lines)-count+index],
-		})
-	}
-	return entries
-}
+func (s *Service) LogEntries() []config.LogEntry { return s.stream.Entries() }
+
+// LogLines returns the buffered log text without its capture metadata.
+func (s *Service) LogLines() []string { return s.stream.Lines() }
 
 // CopyLogHistoryFrom preserves the logical service buffer across a hot reload.
-func (s *Service) CopyLogHistoryFrom(previous *Service) {
-	previous.logMu.RLock()
-	defer previous.logMu.RUnlock()
-	s.logMu.Lock()
-	defer s.logMu.Unlock()
-	s.Logs = previous.Logs
-	s.logTimes = append(s.logTimes[:0], previous.logTimes...)
-	s.logSources = append(s.logSources[:0], previous.logSources...)
-	s.logSequences = append(s.logSequences[:0], previous.logSequences...)
-	s.logTimeWrite = previous.logTimeWrite
-	s.logTimeCount = previous.logTimeCount
-	s.nextLogSequence = previous.nextLogSequence
-}
+func (s *Service) CopyLogHistoryFrom(previous *Service) { s.stream.CopyFrom(previous.stream) }
 
-// ClearLogs atomically clears both log text and its timestamp metadata.
-func (s *Service) ClearLogs() {
-	s.logMu.Lock()
-	s.Logs.Clear()
-	clear(s.logTimes)
-	clear(s.logSources)
-	clear(s.logSequences)
-	s.logTimeWrite = 0
-	s.logTimeCount = 0
-	s.logMu.Unlock()
-}
+// ClearLogs discards this service's buffered logs and their metadata.
+func (s *Service) ClearLogs() { s.stream.Clear() }
 
 // SetState replaces the complete mutable state.
 func (s *Service) SetState(state config.ServiceState) {

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -51,7 +52,7 @@ func TestLogEntriesKeepTimestampsAlignedAcrossOverflowAndClear(t *testing.T) {
 	}
 
 	svc.ClearLogs()
-	if len(svc.LogEntries()) != 0 || svc.Logs.Len() != 0 {
+	if len(svc.LogEntries()) != 0 || len(svc.LogLines()) != 0 {
 		t.Fatal("ClearLogs left text or timestamp metadata")
 	}
 }
@@ -75,6 +76,55 @@ func TestLogEntriesPreserveSourceSequenceAndHotReloadHistory(t *testing.T) {
 	}{{"stdout", 1, "one"}, {"stderr", 2, "two"}, {"stdout", 3, "three"}} {
 		if entries[index].Source != want.source || entries[index].Sequence != want.sequence || entries[index].Raw != want.raw {
 			t.Fatalf("entry %d = %+v, want %+v", index, entries[index], want)
+		}
+	}
+}
+
+// A pipe read is not line-aligned, so one captured chunk can carry many lines.
+// Storing it as a single entry is what made every consumer that counts entries
+// report a number the user could not reproduce by counting what they saw.
+func TestAppendLogStoresOneEntryPerLine(t *testing.T) {
+	svc := NewService("api", config.Service{}, 100)
+	svc.AppendLogAtSource(time.Now(), "stdout", "first\nsecond\n\nfourth\n")
+
+	entries := svc.LogEntries()
+	if len(entries) != 4 {
+		t.Fatalf("entries = %d, want 4", len(entries))
+	}
+	for index, want := range []string{"first", "second", "", "fourth"} {
+		if entries[index].Raw != want {
+			t.Errorf("entry %d = %q, want %q", index, entries[index].Raw, want)
+		}
+		if strings.Contains(entries[index].Raw, "\n") {
+			t.Errorf("entry %d still holds more than one line", index)
+		}
+		// Every line is separately addressable, which is what a follow cursor
+		// and a search hit index both rely on.
+		if index > 0 && entries[index].Sequence <= entries[index-1].Sequence {
+			t.Errorf("entry %d did not advance the cursor", index)
+		}
+	}
+}
+
+func TestSplitCapturedLinesKeepsBlanksAndDropsTheTerminator(t *testing.T) {
+	for input, want := range map[string][]string{
+		"solo":               {"solo"},
+		"one\ntwo\n":         {"one", "two"},
+		"one\ntwo":           {"one", "two"},
+		"trailing blank\n\n": {"trailing blank", ""},
+		"crlf\r\n":           {"crlf"},
+		"":                   {""},
+	} {
+		got := splitCapturedLines(input)
+		if len(got) != len(want) {
+			t.Errorf("splitCapturedLines(%q) = %q, want %q", input, got, want)
+			continue
+		}
+		for index := range got {
+			if got[index] != want[index] {
+				t.Errorf("splitCapturedLines(%q) = %q, want %q", input, got, want)
+				break
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Why

`kranz logs analytics/stats` answered `service or tag "analytics/stats" was not found`. An action's output existed only as the `ActionResult` of its last run, so a report or a migration could not be read back without running it a second time.

Fixing that surfaced two further defects, both of the same kind: a value the CLI promised meant something else inside.

## What changed

**Actions have addressable log streams.** Same `OWNER/ACTION` name `kranz action run` uses. The bounded buffer and its metadata rings move out of `Service` into one `logStream` type both share, so `--tail`, `--since` and `--follow` work on either without a second code path. Runs are numbered and framed; `--run N`, `--run -1` and `--runs N` address them. Lifecycle hooks keep no stream of their own — their output belongs to the service they act on, which already records it.

**`--tail N` returns N lines.** A pipe hands Kranz whatever chunk it read, and storing that chunk as one entry made the flag return an unpredictable number of lines and cut in the middle of one. Output is now stored one line per entry, which also corrects the log search hit count in the TUI, the `N lines omitted` cap on a failed lifecycle hook, the service prefix in a foreground `kranz up`, and the `action run --output json` array — all of which counted chunks.

**A selector means one thing.** `plan` and `ports` unioned a service name with the tag of the same name, the lifecycle commands let the name win, and `status` understood no tags at all — so `kranz plan api` and `kranz start api` could cover different services. They now share one resolver, and `status` accepts tags.

**A service and an action group may no longer share a name.** Every action under such a group was ambiguous and unreachable while the configuration still validated cleanly.

Also new: `kranz logs clear`, `--with-actions`, and `--plain` / `--no-timestamps` / `--no-labels` / `--source` for reading one stream back as the command printed it.

## Breaking

- Log lines are labelled `[stream source]` rather than `[service/source]`; the address itself now contains the slash.
- JSON log events carry `stream`, `kind`, `owner`, `action`, `run` in place of `service`.

## Verification

`make verify` clean, coverage 84.7% in `internal/service`. Each commit was built and tested as its own snapshot. Exercised end to end against this repository's own `kranz.yaml`: the action report reads back in full, `--tail N` prints exactly N lines, `--source stdout --plain` gives the command's own output, and the collision config is now rejected.

New tests cover every claim above, including one that requires all three selector resolvers to agree.