### PR TITLE
chore: bump golangci-lint to v2.12.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BIN_DIR := bin
 GO := go
 GORELEASER_VERSION ?= v2.17.0
 GORELEASER := $(GO) run github.com/goreleaser/goreleaser/v2@$(GORELEASER_VERSION)
-GOLANGCI_LINT_VERSION ?= v2.8.0
+GOLANGCI_LINT_VERSION ?= v2.12.2
 GOLANGCI_LINT := $(GO) run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)


### PR DESCRIPTION
`make lint` fails on any machine running Go 1.27:

```
pkg/ringbuffer/buffer.go:4:8: could not import sync (... export data version 4
is greater than maximum supported version 2) (typecheck)
```

golangci-lint v2.8.0 pins an `x/tools` that cannot read export data produced by a Go 1.27 toolchain. CI never saw it because `setup-go` builds with the Go declared in `go.mod` (1.25), so the failure only hit local machines — including `make tag`, which lints before creating a release tag and therefore could not create one at all.

v2.12.2 is the newest release that still declares `go 1.25.0`, so it builds under the toolchain CI pins with `GOTOOLCHAIN: local`, and its `x/tools` reads Go 1.27 export data. Verified locally on Go 1.27: `0 issues`.

v2.13.x would require raising the project's minimum Go to 1.26. That is a separate decision about who can build Kranz from source and is not taken here.