### PR TITLE
feat(cli): complete command help and shell options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,10 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Install fish
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install --yes fish
+
       - name: Check formatting
         run: test -z "$(gofmt -l .)"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 
 ## [Unreleased]
 
+### Fixed
+
+- `kranz logs -f` no longer looks like a `--follow` shorthand. The global parser
+  claims `-f` as `--config` wherever it appears, so the alias could never reach
+  the logs command; `--follow` is the spelling.
+
 ## [0.8.1] - 2026-08-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
   in the usage line. A flag whose value carries meaning now says what it means:
   `--run N` explains that a negative N counts back from the newest buffered run,
   so `--run -2` is the run before the latest.
+- The CLI reference documents `--run`, `--runs`, `--source`, `--with-actions`,
+  the display flags, and `kranz logs clear`, which it had omitted.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,16 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
   so `--run -2` is the run before the latest.
 - The CLI reference documents `--run`, `--runs`, `--source`, `--with-actions`,
   the display flags, and `kranz logs clear`, which it had omitted.
+- Shell completion covers each command's own options, not just the command
+  names: `kranz logs --<TAB>` offers the log flags and `kranz logs clear --<TAB>`
+  offers only the two that command takes. An option with a fixed set completes
+  its values, and one that takes a path completes filenames.
 
 ### Fixed
 
+- The generated bash completion no longer uses `mapfile`, which the bash 3.2
+  that macOS ships does not have; sourcing it there answered every keystroke
+  with "command not found".
 - `kranz logs -f` no longer looks like a `--follow` shorthand. The global parser
   claims `-f` as `--config` wherever it appears, so the alias could never reach
   the logs command; `--follow` is the spelling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 
 ## [Unreleased]
 
+### Added
+
+- `--help` documents the options each command parses, not just their spellings
+  in the usage line. A flag whose value carries meaning now says what it means:
+  `--run N` explains that a negative N counts back from the newest buffered run,
+  so `--run -2` is the run before the latest.
+
 ### Fixed
 
 - `kranz logs -f` no longer looks like a `--follow` shorthand. The global parser

--- a/cmd/kranz/help_options_test.go
+++ b/cmd/kranz/help_options_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -12,14 +13,14 @@ import (
 
 // optionValues supplies a plausible value per metavariable, so an option that
 // takes one is exercised the way a user would spell it rather than failing for
-// a missing argument.
+// a missing argument. An option that names its own values needs no entry here:
+// those are tried directly, which is also what proves a shell completing them
+// writes a command the CLI accepts.
 var optionValues = map[string]string{
 	"N":       "1",
-	"D":       "5m",
-	"S":       "stdout",
 	"NAME":    "sample",
 	"COMMAND": "true",
-	"FORMAT":  "text",
+	"D":       "5m",
 }
 
 // usageFailures are the codes that mean the CLI did not recognize what it was
@@ -43,7 +44,7 @@ func TestEveryDocumentedOptionIsAcceptedByItsCommand(t *testing.T) {
 	walk = func(command *kranzcli.Command, path []string) {
 		for _, option := range command.Options {
 			for _, spelling := range optionSpellings(option, directory) {
-				t.Run(strings.Join(append(path, spelling[0]), " "), func(t *testing.T) {
+				t.Run(strings.Join(append(append([]string(nil), path...), spelling...), " "), func(t *testing.T) {
 					args := append([]string{"-C", directory, "--output=json"}, path...)
 					var stdout, stderr bytes.Buffer
 					if code := execute(append(args, spelling...), &stdout, &stderr); code == 0 {
@@ -74,26 +75,86 @@ func TestEveryDocumentedOptionIsAcceptedByItsCommand(t *testing.T) {
 // optionSpellings expands one documented option into the argument lists a user
 // could type: every spelling it lists, each with a value when it takes one.
 func optionSpellings(option kranzcli.Option, directory string) [][]string {
-	var flags []string
-	value := ""
-	for _, field := range strings.Fields(strings.ReplaceAll(option.Flags, ",", " ")) {
-		if strings.HasPrefix(field, "-") {
-			flags = append(flags, field)
-			continue
-		}
-		if field == "PATH" {
+	values := option.Values
+	if len(values) == 0 {
+		value := ""
+		if metavariable := option.Metavariable(); metavariable == "PATH" {
 			value = filepath.Join(directory, "written.yaml")
-			continue
+		} else if metavariable != "" {
+			value = optionValues[metavariable]
 		}
-		value = optionValues[field]
+		if value != "" {
+			values = []string{value}
+		}
 	}
-	spellings := make([][]string, 0, len(flags))
-	for _, flag := range flags {
-		if value == "" {
+	var spellings [][]string
+	for _, flag := range option.Spellings() {
+		if len(values) == 0 {
 			spellings = append(spellings, []string{flag})
 			continue
 		}
-		spellings = append(spellings, []string{flag, value})
+		for _, value := range values {
+			spellings = append(spellings, []string{flag, value})
+		}
 	}
 	return spellings
+}
+
+// actsOnARuntime names the commands that change something when they run. The
+// value check below drives real invocations against a real configuration, so it
+// stays away from these; their flags are still covered by the parse check
+// above, which runs where no configuration exists.
+var actsOnARuntime = map[string]bool{
+	"init": true, "up": true, "start": true, "stop": true,
+	"restart": true, "reload": true, "down": true, "attach": true,
+}
+
+// A shell completes an option's value from the same table help reads, so a
+// value listed there has to be one the command accepts. Completing `--format`
+// to a word the parser then rejects is worse than completing nothing: the shell
+// wrote the error.
+func TestCompletionValuesAreAcceptedByTheirCommand(t *testing.T) {
+	directory := t.TempDir()
+	configuration := "version: 1\nproject: sample\nservices:\n  api:\n    command: sleep 60\n"
+	if err := os.WriteFile(filepath.Join(directory, "kranz.yaml"), []byte(configuration), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	check := func(t *testing.T, path []string, option kranzcli.Option) {
+		t.Helper()
+		for _, spelling := range option.Spellings() {
+			for _, value := range option.Values {
+				name := strings.Join(append(append([]string(nil), path...), spelling, value), " ")
+				t.Run(name, func(t *testing.T) {
+					// The value is checked in text mode: --output json is a
+					// machine contract that answers before a format-specific
+					// renderer ever runs.
+					args := append([]string{"-C", directory}, path...)
+					var stdout, stderr bytes.Buffer
+					if code := execute(append(args, spelling, value), &stdout, &stderr); code == kranzcli.ExitUsage {
+						t.Errorf("completion offers %s %s, which `kranz %s` rejects: %s",
+							spelling, value, kranzcli.PathString(path), strings.TrimSpace(stderr.String()))
+					}
+				})
+			}
+		}
+	}
+
+	var walk func(command *kranzcli.Command, path []string)
+	walk = func(command *kranzcli.Command, path []string) {
+		if len(path) == 0 || !actsOnARuntime[path[0]] {
+			for _, option := range command.Options {
+				check(t, path, option)
+			}
+		}
+		for _, child := range command.Children {
+			walk(child, append(append([]string(nil), path...), child.Name))
+		}
+	}
+	walk(kranzcli.DefaultTree(), nil)
+	// A global option belongs to no command, so it is checked through one that
+	// only reads.
+	for _, option := range kranzcli.GlobalFlags() {
+		check(t, []string{"list"}, option)
+	}
 }

--- a/cmd/kranz/help_options_test.go
+++ b/cmd/kranz/help_options_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	kranzcli "github.com/kranz-org/kranz/internal/cli"
+)
+
+// optionValues supplies a plausible value per metavariable, so an option that
+// takes one is exercised the way a user would spell it rather than failing for
+// a missing argument.
+var optionValues = map[string]string{
+	"N":       "1",
+	"D":       "5m",
+	"S":       "stdout",
+	"NAME":    "sample",
+	"COMMAND": "true",
+	"FORMAT":  "text",
+}
+
+// usageFailures are the codes that mean the CLI did not recognize what it was
+// handed. Anything else — no configuration here, no runtime running — means the
+// option was accepted and the command simply had nothing to work with.
+var usageFailures = map[string]bool{
+	"unknown_option":       true,
+	"invalid_arguments":    true,
+	"missing_option_value": true,
+	"unknown_command":      true,
+	"unknown_subcommand":   true,
+}
+
+// Help that lists an option the command cannot parse is worse than help that
+// omits it: the user spells what they were told to and gets an error. This is
+// not hypothetical — `logs` documented a -f shorthand for --follow that the
+// global parser claimed as --config before logs ever saw it.
+func TestEveryDocumentedOptionIsAcceptedByItsCommand(t *testing.T) {
+	directory := t.TempDir()
+	var walk func(command *kranzcli.Command, path []string)
+	walk = func(command *kranzcli.Command, path []string) {
+		for _, option := range command.Options {
+			for _, spelling := range optionSpellings(option, directory) {
+				t.Run(strings.Join(append(path, spelling[0]), " "), func(t *testing.T) {
+					args := append([]string{"-C", directory, "--output=json"}, path...)
+					var stdout, stderr bytes.Buffer
+					if code := execute(append(args, spelling...), &stdout, &stderr); code == 0 {
+						return
+					}
+					var envelope struct {
+						Error struct {
+							Code string `json:"code"`
+						} `json:"error"`
+					}
+					if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+						t.Fatalf("error output is not JSON: %s%s", stdout.String(), stderr.String())
+					}
+					if usageFailures[envelope.Error.Code] {
+						t.Errorf("help documents %s for `kranz %s`, but the command rejects it: %s",
+							option.Flags, kranzcli.PathString(path), stdout.String())
+					}
+				})
+			}
+		}
+		for _, child := range command.Children {
+			walk(child, append(append([]string(nil), path...), child.Name))
+		}
+	}
+	walk(kranzcli.DefaultTree(), nil)
+}
+
+// optionSpellings expands one documented option into the argument lists a user
+// could type: every spelling it lists, each with a value when it takes one.
+func optionSpellings(option kranzcli.Option, directory string) [][]string {
+	var flags []string
+	value := ""
+	for _, field := range strings.Fields(strings.ReplaceAll(option.Flags, ",", " ")) {
+		if strings.HasPrefix(field, "-") {
+			flags = append(flags, field)
+			continue
+		}
+		if field == "PATH" {
+			value = filepath.Join(directory, "written.yaml")
+			continue
+		}
+		value = optionValues[field]
+	}
+	spellings := make([][]string, 0, len(flags))
+	for _, flag := range flags {
+		if value == "" {
+			spellings = append(spellings, []string{flag})
+			continue
+		}
+		spellings = append(spellings, []string{flag, value})
+	}
+	return spellings
+}

--- a/cmd/kranz/logs.go
+++ b/cmd/kranz/logs.go
@@ -222,7 +222,10 @@ func parseLogOptions(args []string) (logOptions, error) {
 	for index := 0; index < len(args); index++ {
 		arg := args[index]
 		switch {
-		case arg == "--follow" || arg == "-f":
+		// -f is not a follow shorthand here: the global parser claims it as
+		// --config wherever it appears, so accepting it below would document a
+		// spelling that never reaches this switch.
+		case arg == "--follow":
 			options.follow = true
 		case arg == "--all":
 			options.all = true

--- a/docs/guide/cli-workflow.md
+++ b/docs/guide/cli-workflow.md
@@ -92,8 +92,14 @@ an action that has already finished can be read again without running it twice:
 ```console
 $ kranz logs api/migrate
 $ kranz logs analytics/stats --run -1    # the latest execution
+$ kranz logs analytics/stats --run -2    # the one before it
+$ kranz logs analytics/stats --run 7     # run number 7
 $ kranz logs analytics/stats --runs 3    # the last three
 ```
+
+A positive `--run` is the run number Kranz assigned; a negative one counts back
+from the newest run still buffered, which is what keeps `-1` meaning "the
+latest" as older runs age out of the buffer.
 
 A bare service name means "recent lines", because a service streams without
 end. A bare action name means its whole latest run: an action produces a

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -96,3 +96,6 @@ kranz completion bash > /usr/share/bash-completion/completions/kranz
 kranz completion zsh  > "${fpath[1]}/_kranz"
 kranz completion fish > ~/.config/fish/completions/kranz.fish
 ```
+
+Completion covers commands, subcommands, and each command's own options,
+including the values of options that take a fixed set.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -225,6 +225,14 @@ kranz completion fish > ~/.config/fish/completions/kranz.fish
 
 The Linux packages install these already.
 
+The scripts are generated from the same command tree as `--help`, so they offer
+what the binary actually has: commands, the subcommands of a group, and the
+options of whichever command is being typed. `kranz logs --<TAB>` offers the log
+flags, `kranz logs clear --<TAB>` offers only the two `clear` takes, and an
+option with a fixed set of values completes those too — `--source` to a stream
+name, `--format` to a graph format. A flag that takes a path completes
+filenames.
+
 ## Machine-readable output
 
 `--output json` wraps every successful non-interactive result in a versioned

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -167,6 +167,11 @@ kranz logs --tail 200
 kranz logs --all                   # everything still buffered
 kranz logs --since 5m
 kranz logs api --follow
+kranz logs api --with-actions      # the service and the actions it has run
+kranz logs api --source stderr     # stdout, stderr, or kranz; comma-separated
+kranz logs api --plain             # no time column, no label column
+kranz logs clear api               # discard one buffer
+kranz logs clear --force           # discard every buffer in the project
 ```
 
 A bare `kranz logs` returns the last fifty lines, because every service keeps a
@@ -175,6 +180,27 @@ thousand and a few services make that thousands. `--all` returns everything.
 from the past five minutes. A stopped service keeps its buffer, so logs still
 answer for a service that has already died. `--follow` resumes from a cursor
 rather than reprinting, and stops on `Ctrl+C`.
+
+`--plain` is `--no-timestamps` and `--no-labels` together: both columns exist to
+tell interleaved streams apart, which reading one stream back does not need.
+`logs clear` narrows the same way `logs` does, and an unqualified clear needs
+`--force`, because it is the one shape that cannot be narrowed afterwards.
+
+An action keeps one buffer per execution, so its logs are addressed by run:
+
+```bash
+kranz logs analytics/stats                # the latest run, whole
+kranz logs analytics/stats --run 7        # run number 7
+kranz logs analytics/stats --run -1       # the latest run
+kranz logs analytics/stats --run -2       # the run before it
+kranz logs analytics/stats --runs 3       # the last three runs
+```
+
+A positive `--run` is the absolute run number Kranz assigned. A negative one is
+an offset from the newest run still buffered, so `-1` keeps meaning "the latest"
+however many older runs have aged out, and `-2` is the one before it. Asking for
+a run that has already been evicted prints nothing rather than failing: the run
+is gone, not misnamed.
 
 ### Actions
 

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -48,28 +48,213 @@ func availableNames(command *Command) []string {
 	return names
 }
 
-const globalFlags = "-f --config -C --directory -p --project --output -h --help -v --version"
+// availableChildren returns the runnable direct children themselves, in the
+// same order availableNames lists them.
+func availableChildren(command *Command) []*Command {
+	children := make([]*Command, 0, len(command.Children))
+	for _, child := range command.Children {
+		if child.IsPlanned() {
+			continue
+		}
+		children = append(children, child)
+	}
+	sort.Slice(children, func(i, j int) bool { return children[i].Name < children[j].Name })
+	return children
+}
+
+// completionOptions returns the options a shell should offer for a token the
+// user has typed. A group that runs a default subcommand bare accepts that
+// subcommand's flags under its own name, and `kranz logs --tail 5` is how those
+// flags are actually typed, so the group offers them too.
+func completionOptions(command *Command) []Option {
+	options := append([]Option(nil), command.Options...)
+	if command.Default != "" {
+		if child := command.Child(command.Default); child != nil && !child.IsPlanned() {
+			options = append(options, child.Options...)
+		}
+	}
+	return options
+}
+
+// needsOwnOptions reports whether naming a subcommand changes which flags are
+// legal. A group's default subcommand does not: its flags are already offered
+// under the group's own name, and repeating them makes a shell list every flag
+// twice.
+func needsOwnOptions(group, subcommand *Command) bool {
+	if len(subcommand.Options) == 0 {
+		return false
+	}
+	inherited := strings.Join(completionSpellings(completionOptions(group)), " ")
+	return strings.Join(completionSpellings(subcommand.Options), " ") != inherited
+}
+
+// completionSpellings flattens the options of a command into the flat list of
+// words a shell completes against.
+func completionSpellings(options []Option) []string {
+	var spellings []string
+	for _, option := range options {
+		spellings = append(spellings, option.Spellings()...)
+	}
+	return spellings
+}
+
+// valueHint says how a shell should complete the argument of an option: from a
+// fixed set, from the filesystem, or not at all. Guessing wrong is worse than
+// silence — offering filenames after `--tail` hides that it wants a number.
+type valueHint int
+
+const (
+	hintNone valueHint = iota
+	hintValues
+	hintPath
+	hintDirectory
+	hintFree
+)
+
+func optionHint(option Option) valueHint {
+	switch {
+	case len(option.Values) > 0:
+		return hintValues
+	case !option.TakesValue():
+		return hintNone
+	case option.Metavariable() == "PATH":
+		return hintPath
+	case option.Metavariable() == "DIR":
+		return hintDirectory
+	default:
+		return hintFree
+	}
+}
+
+// valuedOptions collects every option in the tree whose argument a shell can
+// complete, keyed by spelling. Options are matched on the word before the
+// cursor, which is a property of the flag rather than of the command it belongs
+// to; no two commands spell the same flag with different values.
+func valuedOptions(tree *Command) []Option {
+	seen := map[string]bool{}
+	var collected []Option
+	var walk func(command *Command)
+	walk = func(command *Command) {
+		if command.IsPlanned() {
+			return
+		}
+		for _, option := range command.Options {
+			if optionHint(option) == hintNone || optionHint(option) == hintFree {
+				continue
+			}
+			key := strings.Join(option.Spellings(), " ")
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			collected = append(collected, option)
+		}
+		for _, child := range command.Children {
+			walk(child)
+		}
+	}
+	walk(tree)
+	for _, option := range GlobalFlags() {
+		if hint := optionHint(option); hint == hintNone || hint == hintFree {
+			continue
+		}
+		collected = append(collected, option)
+	}
+	return collected
+}
+
+func globalSpellings() []string { return completionSpellings(GlobalFlags()) }
 
 func bashCompletion(tree *Command) string {
 	var output strings.Builder
-	output.WriteString("# kranz bash completion\n_kranz() {\n")
-	fmt.Fprintf(&output, "  local commands=%q\n", strings.Join(availableNames(tree), " "))
-	fmt.Fprintf(&output, "  local globals=%q\n", globalFlags)
-	output.WriteString("  local subcommands=\"\"\n  case \"${COMP_WORDS[1]}\" in\n")
-	for _, child := range tree.Children {
-		if child.IsPlanned() || len(child.Children) == 0 {
+	// The reply is collected in a loop rather than with mapfile because macOS
+	// still ships bash 3.2, where mapfile does not exist and every completion
+	// would answer "command not found" instead of a word list.
+	output.WriteString(`# kranz bash completion
+_kranz_reply() {
+  local word
+  COMPREPLY=()
+  while IFS= read -r word; do
+    COMPREPLY+=("$word")
+  done < <(compgen "$@" -- "$cur")
+}
+_kranz_reply_paths() {
+  if type compopt >/dev/null 2>&1; then
+    compopt -o filenames
+  fi
+  _kranz_reply "$@"
+}
+`)
+	output.WriteString("_kranz() {\n")
+	output.WriteString("  local cur prev commands globals subcommands options values\n")
+	output.WriteString("  cur=\"${COMP_WORDS[COMP_CWORD]}\"\n")
+	output.WriteString("  prev=\"${COMP_WORDS[COMP_CWORD-1]}\"\n")
+	fmt.Fprintf(&output, "  commands=%q\n", strings.Join(availableNames(tree), " "))
+	fmt.Fprintf(&output, "  globals=%q\n", strings.Join(globalSpellings(), " "))
+	output.WriteString("  subcommands=\"\"\n  options=\"\"\n  values=\"\"\n")
+
+	// The first word after `kranz` decides both what subcommands exist and,
+	// through the group default, which flags are already legal.
+	output.WriteString("  case \"${COMP_WORDS[1]}\" in\n")
+	for _, child := range availableChildren(tree) {
+		subcommands := strings.Join(availableNames(child), " ")
+		options := strings.Join(completionSpellings(completionOptions(child)), " ")
+		if subcommands == "" && options == "" {
 			continue
 		}
-		fmt.Fprintf(&output, "    %s) subcommands=%q ;;\n", child.Name, strings.Join(availableNames(child), " "))
+		fmt.Fprintf(&output, "    %s) subcommands=%q; options=%q ;;\n", child.Name, subcommands, options)
+	}
+	output.WriteString("  esac\n")
+
+	// A named subcommand replaces the group's flags with its own: `logs clear`
+	// takes neither --tail nor --follow.
+	output.WriteString("  case \"${COMP_WORDS[1]} ${COMP_WORDS[2]}\" in\n")
+	for _, child := range availableChildren(tree) {
+		for _, grandchild := range availableChildren(child) {
+			if !needsOwnOptions(child, grandchild) {
+				continue
+			}
+			fmt.Fprintf(&output, "    %q) options=%q ;;\n",
+				child.Name+" "+grandchild.Name,
+				strings.Join(completionSpellings(grandchild.Options), " "))
+		}
+	}
+	output.WriteString("  esac\n")
+
+	// An option that takes a value is answered from the value, not from the
+	// command: after `--source` the only useful reply is a source name.
+	output.WriteString("  case \"$prev\" in\n")
+	for _, option := range valuedOptions(tree) {
+		pattern := strings.Join(option.Spellings(), "|")
+		switch optionHint(option) {
+		case hintValues:
+			fmt.Fprintf(&output, "    %s) values=%q ;;\n", pattern, strings.Join(option.Values, " "))
+		case hintPath:
+			fmt.Fprintf(&output, "    %s) _kranz_reply_paths -f; return ;;\n", pattern)
+		case hintDirectory:
+			fmt.Fprintf(&output, "    %s) _kranz_reply_paths -d; return ;;\n", pattern)
+		}
 	}
 	output.WriteString(`  esac
-  if [ "$COMP_CWORD" -eq 1 ]; then
-    mapfile -t COMPREPLY < <(compgen -W "$commands $globals" -- "${COMP_WORDS[COMP_CWORD]}")
-  elif [ -n "$subcommands" ] && [ "$COMP_CWORD" -eq 2 ]; then
-    mapfile -t COMPREPLY < <(compgen -W "$subcommands" -- "${COMP_WORDS[COMP_CWORD]}")
-  else
-    mapfile -t COMPREPLY < <(compgen -W "$globals" -- "${COMP_WORDS[COMP_CWORD]}")
+  if [ -n "$values" ]; then
+    _kranz_reply -W "$values"
+    return
   fi
+  case "$cur" in
+    -*)
+      _kranz_reply -W "$options $globals"
+      return
+      ;;
+  esac
+  if [ "$COMP_CWORD" -eq 1 ]; then
+    _kranz_reply -W "$commands"
+    return
+  fi
+  if [ -n "$subcommands" ] && [ "$COMP_CWORD" -eq 2 ]; then
+    _kranz_reply -W "$subcommands"
+    return
+  fi
+  COMPREPLY=()
 }
 complete -F _kranz kranz
 `)
@@ -78,29 +263,94 @@ complete -F _kranz kranz
 
 func zshCompletion(tree *Command) string {
 	var output strings.Builder
-	output.WriteString("#compdef kranz\n# kranz zsh completion\n_kranz() {\n  local -a commands\n  commands=(\n")
-	for _, child := range tree.Children {
-		if child.IsPlanned() {
-			continue
-		}
+	output.WriteString("#compdef kranz\n# kranz zsh completion\n_kranz() {\n")
+	output.WriteString("  local -a commands sub opts\n  local previous=\"${words[CURRENT-1]}\"\n")
+	output.WriteString("  commands=(\n")
+	for _, child := range availableChildren(tree) {
 		fmt.Fprintf(&output, "    '%s:%s'\n", child.Name, quoteZsh(child.Summary))
 	}
-	output.WriteString("  )\n  if (( CURRENT == 2 )); then\n    _describe 'command' commands\n    return\n  fi\n  case \"${words[2]}\" in\n")
-	for _, child := range tree.Children {
-		if child.IsPlanned() || len(child.Children) == 0 {
+	output.WriteString("  )\n")
+
+	output.WriteString("  case \"${words[2]}\" in\n")
+	for _, child := range availableChildren(tree) {
+		children, options := availableChildren(child), completionOptions(child)
+		if len(children) == 0 && len(options) == 0 {
 			continue
 		}
-		fmt.Fprintf(&output, "    %s)\n      local -a sub\n      sub=(\n", child.Name)
-		for _, grandchild := range child.Children {
-			if grandchild.IsPlanned() {
+		fmt.Fprintf(&output, "    %s)\n", child.Name)
+		writeZshArray(&output, "sub", describeCommands(children))
+		writeZshArray(&output, "opts", describeOptions(options))
+		output.WriteString("      ;;\n")
+	}
+	output.WriteString("  esac\n")
+
+	output.WriteString("  case \"${words[2]} ${words[3]}\" in\n")
+	for _, child := range availableChildren(tree) {
+		for _, grandchild := range availableChildren(child) {
+			if !needsOwnOptions(child, grandchild) {
 				continue
 			}
-			fmt.Fprintf(&output, "        '%s:%s'\n", grandchild.Name, quoteZsh(grandchild.Summary))
+			fmt.Fprintf(&output, "    '%s %s')\n", child.Name, grandchild.Name)
+			writeZshArray(&output, "opts", describeOptions(grandchild.Options))
+			output.WriteString("      ;;\n")
 		}
-		output.WriteString("      )\n      _describe 'subcommand' sub\n      ;;\n")
 	}
-	output.WriteString("  esac\n}\n_kranz \"$@\"\n")
+	output.WriteString("  esac\n")
+
+	output.WriteString("  case \"$previous\" in\n")
+	for _, option := range valuedOptions(tree) {
+		pattern := strings.Join(option.Spellings(), "|")
+		switch optionHint(option) {
+		case hintValues:
+			fmt.Fprintf(&output, "    %s) compadd -- %s; return ;;\n", pattern, strings.Join(option.Values, " "))
+		case hintPath:
+			fmt.Fprintf(&output, "    %s) _files; return ;;\n", pattern)
+		case hintDirectory:
+			fmt.Fprintf(&output, "    %s) _files -/; return ;;\n", pattern)
+		}
+	}
+	output.WriteString("  esac\n")
+
+	output.WriteString("  if [[ \"${words[CURRENT]}\" == -* ]]; then\n    opts+=(\n")
+	for _, entry := range describeOptions(GlobalFlags()) {
+		fmt.Fprintf(&output, "      %s\n", entry)
+	}
+	output.WriteString("    )\n    _describe 'option' opts\n    return\n  fi\n")
+	output.WriteString("  if (( CURRENT == 2 )); then\n    _describe 'command' commands\n    return\n  fi\n")
+	output.WriteString("  if (( CURRENT == 3 )) && (( ${#sub} )); then\n    _describe 'subcommand' sub\n    return\n  fi\n")
+	output.WriteString("}\n_kranz \"$@\"\n")
 	return output.String()
+}
+
+// describeCommands and describeOptions build `value:description` entries, the
+// form _describe reads.
+func describeCommands(commands []*Command) []string {
+	entries := make([]string, 0, len(commands))
+	for _, command := range commands {
+		entries = append(entries, fmt.Sprintf("'%s:%s'", command.Name, quoteZsh(command.Summary)))
+	}
+	return entries
+}
+
+func describeOptions(options []Option) []string {
+	var entries []string
+	for _, option := range options {
+		for _, spelling := range option.Spellings() {
+			entries = append(entries, fmt.Sprintf("'%s:%s'", spelling, quoteZsh(option.Summary)))
+		}
+	}
+	return entries
+}
+
+func writeZshArray(output *strings.Builder, name string, entries []string) {
+	if len(entries) == 0 {
+		return
+	}
+	fmt.Fprintf(output, "      %s=(\n", name)
+	for _, entry := range entries {
+		fmt.Fprintf(output, "        %s\n", entry)
+	}
+	output.WriteString("      )\n")
 }
 
 // quoteZsh makes a summary safe inside a single-quoted _describe entry: a
@@ -108,28 +358,85 @@ func zshCompletion(tree *Command) string {
 // Each entry is quoted as a whole because an unquoted summary containing spaces
 // becomes several array elements rather than one description.
 func quoteZsh(summary string) string {
-	return strings.ReplaceAll(strings.ReplaceAll(summary, ":", " "), "'", "")
+	rewritten := strings.ReplaceAll(strings.ReplaceAll(summary, ":", " -"), "'", "")
+	return strings.Join(strings.Fields(rewritten), " ")
 }
 
 func fishCompletion(tree *Command) string {
 	var output strings.Builder
 	output.WriteString("# kranz fish completion\n")
 	output.WriteString("complete -c kranz -f\n")
-	for _, child := range tree.Children {
-		if child.IsPlanned() {
-			continue
-		}
+	for _, child := range availableChildren(tree) {
 		fmt.Fprintf(&output, "complete -c kranz -n __fish_use_subcommand -a %s -d %q\n", child.Name, child.Summary)
-		for _, grandchild := range child.Children {
-			if grandchild.IsPlanned() {
-				continue
-			}
-			fmt.Fprintf(&output, "complete -c kranz -n '__fish_seen_subcommand_from %s' -a %s -d %q\n", child.Name, grandchild.Name, grandchild.Summary)
+		// Once a subcommand has been named, the others are no longer candidates:
+		// `kranz config check` is not on its way to `kranz config show`.
+		condition := fishGroupCondition(child, availableNames(child))
+		for _, grandchild := range availableChildren(child) {
+			fmt.Fprintf(&output, "complete -c kranz -n '%s' -a %s -d %q\n", condition, grandchild.Name, grandchild.Summary)
 		}
 	}
-	output.WriteString("complete -c kranz -s f -l config -r -d 'configuration layer'\n")
-	output.WriteString("complete -c kranz -s C -l directory -r -d 'working directory'\n")
-	output.WriteString("complete -c kranz -s p -l project -r -d 'runtime name or ID'\n")
-	output.WriteString("complete -c kranz -l output -x -a 'text json' -d 'output format'\n")
+	for _, child := range availableChildren(tree) {
+		// A group's flags belong to it and to the subcommand it runs bare. Any
+		// other subcommand replaces them, so seeing one of those rules the
+		// group's own flags out: `logs clear` takes no --tail.
+		var replaced []string
+		for _, grandchild := range availableChildren(child) {
+			if grandchild.Name != child.Default {
+				replaced = append(replaced, grandchild.Name)
+			}
+		}
+		writeFishOptions(&output, fishGroupCondition(child, replaced), completionOptions(child))
+		for _, grandchild := range availableChildren(child) {
+			if !needsOwnOptions(child, grandchild) {
+				continue
+			}
+			// Two groups can own a subcommand of the same name — `config show`
+			// and `logs show` — so the condition names both words.
+			nested := fmt.Sprintf("__fish_seen_subcommand_from %s; and __fish_seen_subcommand_from %s", child.Name, grandchild.Name)
+			writeFishOptions(&output, nested, grandchild.Options)
+		}
+	}
+	writeFishOptions(&output, "", GlobalFlags())
 	return output.String()
+}
+
+// fishGroupCondition matches a command by name, optionally ruling it out once
+// one of the subcommands that supersede it has been typed.
+func fishGroupCondition(command *Command, superseded []string) string {
+	condition := "__fish_seen_subcommand_from " + command.Name
+	if len(superseded) > 0 {
+		condition += "; and not __fish_seen_subcommand_from " + strings.Join(superseded, " ")
+	}
+	return condition
+}
+
+// writeFishOptions renders one option per line, telling fish whether the flag
+// takes a value and what may follow it.
+func writeFishOptions(output *strings.Builder, condition string, options []Option) {
+	for _, option := range options {
+		var line strings.Builder
+		line.WriteString("complete -c kranz")
+		if condition != "" {
+			fmt.Fprintf(&line, " -n '%s'", condition)
+		}
+		for _, spelling := range option.Spellings() {
+			if strings.HasPrefix(spelling, "--") {
+				fmt.Fprintf(&line, " -l %s", strings.TrimPrefix(spelling, "--"))
+				continue
+			}
+			fmt.Fprintf(&line, " -s %s", strings.TrimPrefix(spelling, "-"))
+		}
+		switch optionHint(option) {
+		case hintValues:
+			fmt.Fprintf(&line, " -x -a '%s'", strings.Join(option.Values, " "))
+		case hintPath:
+			line.WriteString(" -r -F")
+		case hintDirectory:
+			line.WriteString(" -x -a '(__fish_complete_directories)'")
+		case hintFree:
+			line.WriteString(" -x")
+		}
+		fmt.Fprintf(&line, " -d %q\n", option.Summary)
+		output.WriteString(line.String())
+	}
 }

--- a/internal/cli/completion_shell_test.go
+++ b/internal/cli/completion_shell_test.go
@@ -1,0 +1,224 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeScript renders one shell's completion into a file the shell can read.
+func writeScript(t *testing.T, shell, name string) string {
+	t.Helper()
+	script, err := Completion(DefaultTree(), shell)
+	if err != nil {
+		t.Fatalf("%s: %v", shell, err)
+	}
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(script), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func lookShell(t *testing.T, name string) string {
+	t.Helper()
+	path, err := exec.LookPath(name)
+	if err != nil {
+		t.Skipf("%s is not installed", name)
+	}
+	return path
+}
+
+// bashReply drives the generated function the way the shell does: the words
+// typed so far, with the cursor on the last one, and whatever the function puts
+// in COMPREPLY as the answer.
+func bashReply(t *testing.T, bash, script string, words ...string) []string {
+	t.Helper()
+	const driver = `source "$1"
+shift
+COMP_WORDS=("$@")
+COMP_CWORD=$(($# - 1))
+_kranz
+printf '%s\n' "${COMPREPLY[@]}"`
+	arguments := append([]string{"-c", driver, "_", script}, words...)
+	output, err := exec.Command(bash, arguments...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("bash refused the script: %v\n%s", err, output)
+	}
+	var reply []string
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		if line != "" {
+			reply = append(reply, line)
+		}
+	}
+	return reply
+}
+
+// The generated script is a program, and the only proof it works is a shell
+// running it. These cases are the ones a user actually types: a flag prefix, a
+// value that has a fixed set, and a subcommand whose flags differ from the
+// group's.
+func TestBashCompletionAnswersTheWordsAUserTypes(t *testing.T) {
+	bash := lookShell(t, "bash")
+	script := writeScript(t, "bash", "kranz.bash")
+
+	for _, test := range []struct {
+		name    string
+		words   []string
+		want    []string
+		exclude []string
+	}{
+		{
+			name:  "a flag prefix narrows to one flag",
+			words: []string{"kranz", "logs", "--ta"},
+			want:  []string{"--tail"},
+		},
+		{
+			name:    "a subcommand replaces the group's flags",
+			words:   []string{"kranz", "logs", "clear", "--"},
+			want:    []string{"--with-actions", "--force"},
+			exclude: []string{"--tail", "--follow"},
+		},
+		{
+			name:  "a group offers the flags of the subcommand it runs bare",
+			words: []string{"kranz", "logs", "--"},
+			want:  []string{"--tail", "--follow", "--run"},
+		},
+		{
+			name:  "a selector does not hide the flags that follow it",
+			words: []string{"kranz", "logs", "api", "--r"},
+			want:  []string{"--run", "--runs"},
+		},
+		{
+			name:  "an option with a fixed set completes its value",
+			words: []string{"kranz", "logs", "--source", ""},
+			want:  []string{"stdout", "stderr", "kranz"},
+		},
+		{
+			name:    "the first word completes commands, not flags",
+			words:   []string{"kranz", "co"},
+			want:    []string{"completion", "config"},
+			exclude: []string{"--config"},
+		},
+		{
+			name:  "a group completes its subcommands",
+			words: []string{"kranz", "config", ""},
+			want:  []string{"check", "explain", "show"},
+		},
+		{
+			name:  "global flags are offered everywhere",
+			words: []string{"kranz", "status", "--outp"},
+			want:  []string{"--output"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			reply := bashReply(t, bash, script, test.words...)
+			for _, want := range test.want {
+				if !contains(reply, want) {
+					t.Errorf("`%s` offers %v, missing %q", strings.Join(test.words, " "), reply, want)
+				}
+			}
+			for _, unwanted := range test.exclude {
+				if contains(reply, unwanted) {
+					t.Errorf("`%s` offers %q, which that command does not accept", strings.Join(test.words, " "), unwanted)
+				}
+			}
+		})
+	}
+}
+
+// macOS still ships bash 3.2, so the script has to work without the builtins
+// added in bash 4. Sourcing under the system shell is what proves it.
+func TestBashCompletionRunsOnTheShellMacOSShips(t *testing.T) {
+	bash := lookShell(t, "bash")
+	script := writeScript(t, "bash", "kranz.bash")
+	if output, err := exec.Command(bash, "-n", script).CombinedOutput(); err != nil {
+		t.Fatalf("bash cannot parse the script: %v\n%s", err, output)
+	}
+	if strings.Contains(readFile(t, script), "mapfile") {
+		t.Error("the script uses mapfile, which bash 3.2 does not have")
+	}
+}
+
+func TestZshCompletionParses(t *testing.T) {
+	zsh := lookShell(t, "zsh")
+	script := writeScript(t, "zsh", "_kranz")
+	if output, err := exec.Command(zsh, "-n", script).CombinedOutput(); err != nil {
+		t.Fatalf("zsh cannot parse the script: %v\n%s", err, output)
+	}
+}
+
+// The zsh script is checked through stubs for the completion builtins it calls,
+// which is what makes its branching observable outside an interactive shell.
+func TestZshCompletionSelectsTheRightList(t *testing.T) {
+	zsh := lookShell(t, "zsh")
+	script := writeScript(t, "zsh", "_kranz")
+	const stubs = `_describe() { local name=$2; print -r -- ${(P)name}; }
+compadd() { local -a rest; rest=("${@:#--}"); print -r -- $rest; }
+_files() { print -r -- "<files>"; }
+words=("$@")
+CURRENT=$#
+source "$ZPROBE_SCRIPT"`
+	harness := filepath.Join(t.TempDir(), "probe.zsh")
+	if err := os.WriteFile(harness, []byte(stubs), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		words   []string
+		want    []string
+		exclude []string
+	}{
+		{words: []string{"kranz", "logs", "--"}, want: []string{"--tail:", "--follow:"}},
+		{words: []string{"kranz", "logs", "clear", "--"}, want: []string{"--force:"}, exclude: []string{"--tail:"}},
+		{words: []string{"kranz", "logs", "--source", ""}, want: []string{"stdout stderr kranz"}},
+		{words: []string{"kranz", "-f", ""}, want: []string{"<files>"}},
+		{words: []string{"kranz", ""}, want: []string{"logs:show and clear logs"}},
+	} {
+		t.Run(strings.Join(test.words, " "), func(t *testing.T) {
+			command := exec.Command(zsh, append([]string{"-f", harness}, test.words...)...)
+			command.Env = append(os.Environ(), "ZPROBE_SCRIPT="+script)
+			output, err := command.CombinedOutput()
+			if err != nil {
+				t.Fatalf("zsh refused the script: %v\n%s", err, output)
+			}
+			for _, want := range test.want {
+				if !strings.Contains(string(output), want) {
+					t.Errorf("`%s` offers %q, missing %q", strings.Join(test.words, " "), output, want)
+				}
+			}
+			for _, unwanted := range test.exclude {
+				if strings.Contains(string(output), unwanted) {
+					t.Errorf("`%s` offers %q, which that command does not accept", strings.Join(test.words, " "), unwanted)
+				}
+			}
+		})
+	}
+}
+
+func TestFishCompletionParses(t *testing.T) {
+	fish := lookShell(t, "fish")
+	script := writeScript(t, "fish", "kranz.fish")
+	if output, err := exec.Command(fish, "--no-execute", script).CombinedOutput(); err != nil {
+		t.Fatalf("fish cannot parse the script: %v\n%s", err, output)
+	}
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(content)
+}

--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -84,3 +84,68 @@ func TestCompletionIncludesSubcommands(t *testing.T) {
 		}
 	}
 }
+
+// A shell that completes commands but not their flags leaves the user typing
+// the part that is hardest to remember. Every option help documents has to
+// reach every script, under the command that accepts it.
+func TestCompletionOffersEveryDocumentedOption(t *testing.T) {
+	for _, shell := range CompletionShells() {
+		script, err := Completion(DefaultTree(), shell)
+		if err != nil {
+			t.Fatalf("%s: %v", shell, err)
+		}
+		var walk func(command *Command, path []string)
+		walk = func(command *Command, path []string) {
+			for _, option := range command.Options {
+				for _, spelling := range option.Spellings() {
+					// fish names a flag without its dashes, as -l tail or -s o.
+					needle := spelling
+					if shell == "fish" {
+						needle = "-l " + strings.TrimPrefix(spelling, "--")
+						if !strings.HasPrefix(spelling, "--") {
+							needle = "-s " + strings.TrimPrefix(spelling, "-")
+						}
+					}
+					if !strings.Contains(script, needle) {
+						t.Errorf("%s completion omits %s of `kranz %s`", shell, spelling, PathString(path))
+					}
+				}
+			}
+			for _, child := range command.Children {
+				walk(child, append(append([]string(nil), path...), child.Name))
+			}
+		}
+		walk(DefaultTree(), nil)
+		for _, option := range GlobalFlags() {
+			for _, spelling := range option.Spellings() {
+				if shell == "fish" {
+					continue
+				}
+				if !strings.Contains(script, spelling) {
+					t.Errorf("%s completion omits the global %s", shell, spelling)
+				}
+			}
+		}
+	}
+}
+
+// An option whose values a shell offers has to offer the values the parser
+// takes, or completion writes a command the CLI then rejects.
+func TestCompletionOffersTheValuesAnOptionAccepts(t *testing.T) {
+	for _, shell := range CompletionShells() {
+		script, err := Completion(DefaultTree(), shell)
+		if err != nil {
+			t.Fatalf("%s: %v", shell, err)
+		}
+		for _, option := range valuedOptions(DefaultTree()) {
+			if len(option.Values) == 0 {
+				continue
+			}
+			for _, value := range option.Values {
+				if !strings.Contains(script, value) {
+					t.Errorf("%s completion omits %q for %s", shell, value, option.Flags)
+				}
+			}
+		}
+	}
+}

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -41,6 +41,7 @@ func Help(tree *Command, path []string) (string, error) {
 	}
 	writeSection(&output, "Commands", available)
 	writeSection(&output, "Planned for v0.8.0 (not implemented yet)", planned)
+	writeOptions(&output, command.Options)
 
 	output.WriteString(`
 Global options:
@@ -62,4 +63,54 @@ func writeSection(output *strings.Builder, title string, commands []*Command) {
 	for _, command := range commands {
 		fmt.Fprintf(output, "  %-12s %s\n", command.Name, command.Summary)
 	}
+}
+
+// Option descriptions share the column the global options block already uses,
+// so a command's own flags and the global ones read as one list rather than two
+// tables that happen to sit next to each other.
+const (
+	optionColumn = 26
+	optionWidth  = 78
+)
+
+// writeOptions documents the flags a command parses. A usage line can only
+// spell an option; what its value means has to be written down somewhere the
+// user looks, and --help is where they look.
+func writeOptions(output *strings.Builder, options []Option) {
+	if len(options) == 0 {
+		return
+	}
+	output.WriteString("\nOptions:\n")
+	for _, option := range options {
+		fmt.Fprintf(output, "  %-*s", optionColumn-2, option.Flags)
+		// A flag too wide for the column starts its description on the next
+		// line rather than pushing the whole block out of alignment.
+		if len(option.Flags) > optionColumn-3 {
+			fmt.Fprintf(output, "\n%*s", optionColumn, "")
+		}
+		for index, line := range wrapText(option.Summary, optionWidth-optionColumn) {
+			if index > 0 {
+				fmt.Fprintf(output, "%*s", optionColumn, "")
+			}
+			output.WriteString(line + "\n")
+		}
+	}
+}
+
+// wrapText breaks a description into lines no longer than width, on spaces.
+func wrapText(text string, width int) []string {
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return []string{""}
+	}
+	lines := []string{words[0]}
+	for _, word := range words[1:] {
+		last := len(lines) - 1
+		if len(lines[last])+1+len(word) <= width {
+			lines[last] += " " + word
+			continue
+		}
+		lines = append(lines, word)
+	}
+	return lines
 }

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -41,17 +41,8 @@ func Help(tree *Command, path []string) (string, error) {
 	}
 	writeSection(&output, "Commands", available)
 	writeSection(&output, "Planned for v0.8.0 (not implemented yet)", planned)
-	writeOptions(&output, command.Options)
-
-	output.WriteString(`
-Global options:
-  -f, --config PATH       configuration layer; repeatable
-  -C, --directory DIR     working directory for discovery
-  -p, --project VALUE     runtime name, ID, or unique ID prefix
-      --output text|json  output format
-  -h, --help              show command help
-  -v, --version           show version and build metadata
-`)
+	writeOptions(&output, "Options", command.Options)
+	writeOptions(&output, "Global options", GlobalFlags())
 	return output.String(), nil
 }
 
@@ -76,16 +67,30 @@ const (
 // writeOptions documents the flags a command parses. A usage line can only
 // spell an option; what its value means has to be written down somewhere the
 // user looks, and --help is where they look.
-func writeOptions(output *strings.Builder, options []Option) {
+func writeOptions(output *strings.Builder, title string, options []Option) {
 	if len(options) == 0 {
 		return
 	}
-	output.WriteString("\nOptions:\n")
+	fmt.Fprintf(output, "\n%s:\n", title)
+	// Where a block mixes short and long spellings, the long-only flags are
+	// indented past the empty short-form column so every `--name` starts in the
+	// same place; a block with no short forms at all needs no such gap.
+	indent := ""
 	for _, option := range options {
-		fmt.Fprintf(output, "  %-*s", optionColumn-2, option.Flags)
+		if spellings := option.Spellings(); len(spellings) > 0 && !strings.HasPrefix(spellings[0], "--") {
+			indent = "    "
+			break
+		}
+	}
+	for _, option := range options {
+		flags := option.Flags
+		if spellings := option.Spellings(); len(spellings) > 0 && strings.HasPrefix(spellings[0], "--") {
+			flags = indent + flags
+		}
+		fmt.Fprintf(output, "  %-*s", optionColumn-2, flags)
 		// A flag too wide for the column starts its description on the next
 		// line rather than pushing the whole block out of alignment.
-		if len(option.Flags) > optionColumn-3 {
+		if len(flags) > optionColumn-3 {
 			fmt.Fprintf(output, "\n%*s", optionColumn, "")
 		}
 		for index, line := range wrapText(option.Summary, optionWidth-optionColumn) {

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -122,6 +123,87 @@ func TestHelpDocumentsLifecycleOptionsThatChangeCommandMeaning(t *testing.T) {
 			if !strings.Contains(output, want) {
 				t.Errorf("help %v omits %q:\n%s", test.command, want, output)
 			}
+		}
+	}
+}
+
+// usageFlag finds the option spellings a usage line advertises.
+var usageFlag = regexp.MustCompile(`--?[a-zA-Z][a-zA-Z-]*`)
+
+// A usage line can only spell an option. Every flag it spells therefore has to
+// have an entry saying what it means, or help names something it never explains
+// — which is how `--run N` shipped without anywhere saying that a negative N
+// counts back from the latest run.
+func TestEveryFlagInAUsageLineIsDocumented(t *testing.T) {
+	var walk func(command *Command, path []string)
+	walk = func(command *Command, path []string) {
+		documented := map[string]bool{}
+		for _, option := range command.Options {
+			for _, field := range strings.Fields(strings.ReplaceAll(option.Flags, ",", " ")) {
+				if strings.HasPrefix(field, "-") {
+					documented[field] = true
+				}
+			}
+		}
+		for _, flag := range usageFlag.FindAllString(command.Usage, -1) {
+			if !documented[flag] {
+				t.Errorf("`kranz %s` spells %s in its usage line but documents no such option", PathString(path), flag)
+			}
+		}
+		for _, child := range command.Children {
+			walk(child, append(append([]string(nil), path...), child.Name))
+		}
+	}
+	walk(DefaultTree(), nil)
+}
+
+// The option block is what the user reads instead of the source, so it has to
+// reach them: rendered under its own heading, with a description beside every
+// flag.
+func TestHelpRendersDocumentedOptions(t *testing.T) {
+	var walk func(command *Command, path []string)
+	walk = func(command *Command, path []string) {
+		if len(command.Options) > 0 {
+			output, err := Help(DefaultTree(), path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(output, "\nOptions:\n") {
+				t.Errorf("help for `kranz %s` has no options section:\n%s", PathString(path), output)
+			}
+			for _, option := range command.Options {
+				if option.Summary == "" {
+					t.Errorf("`kranz %s` documents %s with no description", PathString(path), option.Flags)
+				}
+				if !strings.Contains(output, option.Flags) {
+					t.Errorf("help for `kranz %s` omits %s:\n%s", PathString(path), option.Flags, output)
+				}
+			}
+		}
+		for _, child := range command.Children {
+			walk(child, append(append([]string(nil), path...), child.Name))
+		}
+	}
+	walk(DefaultTree(), nil)
+}
+
+// A described flag has to keep its description on one screen. Wrapping is what
+// lets an entry explain a value instead of restating its name.
+func TestOptionDescriptionsWrapWithinTheColumn(t *testing.T) {
+	output, err := Help(DefaultTree(), []string{"logs", "show"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, line := range strings.Split(output, "\n") {
+		if len(line) > optionWidth {
+			t.Errorf("help line runs past %d columns: %q", optionWidth, line)
+		}
+	}
+	// The sentence wraps, so the assertion is on words that survive wrapping:
+	// what matters is that help says a negative run is an offset at all.
+	for _, want := range []string{"negative offset", "before it"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("logs help does not explain what a negative --run means (missing %q):\n%s", want, output)
 		}
 	}
 }

--- a/internal/cli/tree.go
+++ b/internal/cli/tree.go
@@ -9,11 +9,21 @@ import (
 	"strings"
 )
 
+// Option documents one flag a command accepts. The usage line lists the
+// spellings; this is where the meaning lives, because a name alone cannot say
+// what a value means — `--run N` reads as a run number until help explains
+// that a negative N counts back from the latest execution.
+type Option struct {
+	Flags   string
+	Summary string
+}
+
 // Command describes one node in the public command tree.
 type Command struct {
 	Name     string
 	Summary  string
 	Usage    string
+	Options  []Option
 	Children []*Command
 
 	// Default names the subcommand to run when a group is invoked bare. A group
@@ -36,11 +46,22 @@ type Command struct {
 // change, which is what moves the command into the working help section.
 func DefaultTree() *Command {
 	return &Command{Name: "kranz", Summary: "a local service orchestrator", Children: []*Command{
-		{Name: "init", Summary: "create a Kranz configuration", Usage: "kranz init [--from PATH] [--project NAME] [--service NAME] [--command COMMAND] [-o PATH] [-y|--yes]"},
+		{Name: "init", Summary: "create a Kranz configuration", Usage: "kranz init [--from PATH] [--project NAME] [--service NAME] [--command COMMAND] [-o PATH] [-y|--yes]", Options: []Option{
+			{Flags: "--from PATH", Summary: "convert an existing Procfile or compose file"},
+			{Flags: "--project NAME", Summary: "project name to write"},
+			{Flags: "--service NAME", Summary: "name of the first service"},
+			{Flags: "--command COMMAND", Summary: "command that first service runs"},
+			{Flags: "-o, --output-file PATH", Summary: "file to write; defaults to kranz.yaml"},
+			{Flags: "-y, --yes", Summary: "answer every prompt yes, overwriting any file"},
+		}},
 		{Name: "config", Summary: "inspect effective configuration", Default: "show", Children: []*Command{
 			{Name: "check", Summary: "load and validate configuration"},
-			{Name: "show", Summary: "print redacted effective configuration", Usage: "kranz config show [--provenance]"},
-			{Name: "explain", Summary: "show field provenance", Usage: "kranz config explain [SERVICE] [--all]"},
+			{Name: "show", Summary: "print redacted effective configuration", Usage: "kranz config show [--provenance]", Options: []Option{
+				{Flags: "--provenance", Summary: "annotate each field with the layer it came from"},
+			}},
+			{Name: "explain", Summary: "show field provenance", Usage: "kranz config explain [SERVICE] [--all]", Options: []Option{
+				{Flags: "--all", Summary: "explain every service instead of one"},
+			}},
 		}},
 		{Name: "doctor", Summary: "run project preflight checks"},
 		{Name: "ps", Summary: "list active project runtimes"},
@@ -48,21 +69,43 @@ func DefaultTree() *Command {
 		{Name: "info", Summary: "show project or service details", Usage: "kranz info [SERVICE]"},
 		{Name: "status", Summary: "show runtime status", Usage: "kranz status [SELECTOR ...]"},
 		{Name: "plan", Summary: "show the resolved start plan", Usage: "kranz plan [SELECTOR ...]"},
-		{Name: "graph", Summary: "print the dependency graph", Usage: "kranz graph [--format text|json|dot]"},
+		{Name: "graph", Summary: "print the dependency graph", Usage: "kranz graph [--format text|json|dot]", Options: []Option{
+			{Flags: "--format FORMAT", Summary: "text, json, or dot; defaults to text"},
+		}},
 		{Name: "ports", Summary: "list configured and detected ports", Usage: "kranz ports [SELECTOR ...]"},
 		{Name: "port", Summary: "inspect a local port", Default: "inspect", Children: []*Command{
 			{Name: "inspect", Summary: "identify a port listener", Usage: "kranz port inspect PORT"},
 		}},
-		{Name: "up", Summary: "create a project runtime", Usage: "kranz up [SELECTOR ...] [-d|--detach]\n  kranz up --no-start [-d|--detach]"},
+		{Name: "up", Summary: "create a project runtime", Usage: "kranz up [SELECTOR ...] [-d|--detach]\n  kranz up --no-start [-d|--detach]", Options: []Option{
+			{Flags: "-d, --detach", Summary: "leave the runtime in the background and return"},
+			{Flags: "--no-start", Summary: "create the runtime without starting any service"},
+		}},
 		{Name: "start", Summary: "start services", Usage: "kranz start SELECTOR ..."},
 		{Name: "stop", Summary: "stop services", Usage: "kranz stop SELECTOR ..."},
 		{Name: "restart", Summary: "restart services", Usage: "kranz restart SELECTOR ..."},
 		{Name: "reload", Summary: "reload runtime configuration"},
-		{Name: "down", Summary: "stop a project runtime", Usage: "kranz down [--force]"},
+		{Name: "down", Summary: "stop a project runtime", Usage: "kranz down [--force]", Options: []Option{
+			{Flags: "--force", Summary: "discard a runtime that no longer answers its socket"},
+		}},
 		{Name: "attach", Summary: "open the TUI for an active runtime"},
 		{Name: "logs", Summary: "show and clear logs", Default: "show", Children: []*Command{
-			{Name: "show", Summary: "show service and action logs", Usage: "kranz logs [SELECTOR ...] [--tail N | --all] [--since D]\n  [--run N | --runs N] [--source S] [--with-actions]\n  [--plain | --no-timestamps | --no-labels] [--follow]"},
-			{Name: "clear", Summary: "discard buffered logs", Usage: "kranz logs clear [SELECTOR ...] [--with-actions] [--force]"},
+			{Name: "show", Summary: "show service and action logs", Usage: "kranz logs [SELECTOR ...] [--tail N | --all] [--since D]\n  [--run N | --runs N] [--source S] [--with-actions]\n  [--plain | --no-timestamps | --no-labels] [--follow]", Options: []Option{
+				{Flags: "--tail N", Summary: "show the last N lines; a service defaults to 50"},
+				{Flags: "--all", Summary: "show every buffered line, however far back it goes"},
+				{Flags: "--since D", Summary: "show lines newer than a duration such as 5m or 2h"},
+				{Flags: "--run N", Summary: "show one execution of an action: run number N, or a negative offset from the newest buffered run, so -1 is the latest and -2 the one before it"},
+				{Flags: "--runs N", Summary: "show the last N executions of an action"},
+				{Flags: "--source S", Summary: "keep only stdout, stderr, or kranz; comma-separated"},
+				{Flags: "--with-actions", Summary: "fold the actions an owner has run into its timeline"},
+				{Flags: "--plain", Summary: "print the output as the command printed it"},
+				{Flags: "--no-timestamps", Summary: "drop the time column"},
+				{Flags: "--no-labels", Summary: "drop the stream-name column"},
+				{Flags: "--follow", Summary: "keep printing new lines until interrupted"},
+			}},
+			{Name: "clear", Summary: "discard buffered logs", Usage: "kranz logs clear [SELECTOR ...] [--with-actions] [--force]", Options: []Option{
+				{Flags: "--with-actions", Summary: "clear the actions an owner has run as well"},
+				{Flags: "--force", Summary: "required to clear every buffer at once"},
+			}},
 		}},
 		{Name: "action", Summary: "inspect and run actions", Default: "list", Children: []*Command{
 			{Name: "list", Summary: "list actions", Usage: "kranz action list [OWNER]"},

--- a/internal/cli/tree.go
+++ b/internal/cli/tree.go
@@ -16,6 +16,60 @@ import (
 type Option struct {
 	Flags   string
 	Summary string
+
+	// Values lists the fixed values the option's argument may take, for shells
+	// that can offer them. It is completion metadata rather than display text:
+	// Flags stays what help prints, because a set worth completing is often too
+	// long to read in a description column.
+	Values []string
+}
+
+// Spellings lists the flag forms an option accepts, in the order help prints
+// them and without the metavariable trailing the last one.
+func (o Option) Spellings() []string {
+	var spellings []string
+	for _, field := range optionFields(o.Flags) {
+		if strings.HasPrefix(field, "-") {
+			spellings = append(spellings, field)
+		}
+	}
+	return spellings
+}
+
+// Metavariable returns the placeholder standing for the option's value, or the
+// empty string when the option takes none. Completion needs the distinction:
+// offering a filename after a flag that takes no argument is worse than
+// offering nothing.
+func (o Option) Metavariable() string {
+	fields := optionFields(o.Flags)
+	if len(fields) == 0 {
+		return ""
+	}
+	if last := fields[len(fields)-1]; !strings.HasPrefix(last, "-") {
+		return last
+	}
+	return ""
+}
+
+// TakesValue reports whether a spelling has to be followed by an argument.
+func (o Option) TakesValue() bool { return o.Metavariable() != "" }
+
+func optionFields(flags string) []string {
+	return strings.Fields(strings.ReplaceAll(flags, ",", " "))
+}
+
+// GlobalFlags are the options every command accepts. Help and the completion
+// scripts read them from here rather than each spelling them out, so the two
+// cannot describe the same flag differently.
+func GlobalFlags() []Option {
+	return []Option{
+		{Flags: "-f, --config PATH", Summary: "configuration layer; repeatable"},
+		{Flags: "-C, --directory DIR", Summary: "working directory for discovery"},
+		{Flags: "-p, --project VALUE", Summary: "runtime name, ID, or unique ID prefix"},
+		{Flags: "--output text|json", Summary: "output format", Values: []string{"text", "json"}},
+		{Flags: "-h, --help", Summary: "show command help"},
+		{Flags: "-v, --version", Summary: "show version and build metadata"},
+	}
 }
 
 // Command describes one node in the public command tree.
@@ -70,7 +124,7 @@ func DefaultTree() *Command {
 		{Name: "status", Summary: "show runtime status", Usage: "kranz status [SELECTOR ...]"},
 		{Name: "plan", Summary: "show the resolved start plan", Usage: "kranz plan [SELECTOR ...]"},
 		{Name: "graph", Summary: "print the dependency graph", Usage: "kranz graph [--format text|json|dot]", Options: []Option{
-			{Flags: "--format FORMAT", Summary: "text, json, or dot; defaults to text"},
+			{Flags: "--format FORMAT", Summary: "text, json, or dot; defaults to text", Values: []string{"text", "json", "dot"}},
 		}},
 		{Name: "ports", Summary: "list configured and detected ports", Usage: "kranz ports [SELECTOR ...]"},
 		{Name: "port", Summary: "inspect a local port", Default: "inspect", Children: []*Command{
@@ -95,7 +149,7 @@ func DefaultTree() *Command {
 				{Flags: "--since D", Summary: "show lines newer than a duration such as 5m or 2h"},
 				{Flags: "--run N", Summary: "show one execution of an action: run number N, or a negative offset from the newest buffered run, so -1 is the latest and -2 the one before it"},
 				{Flags: "--runs N", Summary: "show the last N executions of an action"},
-				{Flags: "--source S", Summary: "keep only stdout, stderr, or kranz; comma-separated"},
+				{Flags: "--source S", Summary: "keep only stdout, stderr, or kranz; comma-separated", Values: []string{"stdout", "stderr", "kranz"}},
 				{Flags: "--with-actions", Summary: "fold the actions an owner has run into its timeline"},
 				{Flags: "--plain", Summary: "print the output as the command printed it"},
 				{Flags: "--no-timestamps", Summary: "drop the time column"},


### PR DESCRIPTION
## Summary

- document every parsed command option in CLI help and reference docs
- generate bash, zsh, and fish option completions from the shared command tree
- complete fixed values and paths, including Bash 3.2-compatible behavior

## Verification

- make verify
- make lint
- real Bash 3.2 completion scenarios
- zsh syntax, stubbed logic, and interactive zpty completion
- fish parser test when fish is available

## Release

Target: 0.8.2