### PR TITLE
docs: prepare Kranz 0.8.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 
 ## [Unreleased]
 
+## [0.8.2] - 2026-08-24
+
 ### Added
 
 - `--help` documents the options each command parses, not just their spellings
@@ -395,7 +397,8 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 - Explicit global-user and project-config save destinations in the live theme picker.
 - Native compatibility for common Process Compose configurations.
 
-[Unreleased]: https://github.com/kranz-org/kranz/compare/v0.8.1...HEAD
+[Unreleased]: https://github.com/kranz-org/kranz/compare/v0.8.2...HEAD
+[0.8.2]: https://github.com/kranz-org/kranz/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/kranz-org/kranz/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/kranz-org/kranz/compare/v0.7.2...v0.8.0
 [0.7.2]: https://github.com/kranz-org/kranz/compare/v0.7.1...v0.7.2


### PR DESCRIPTION
## Summary

- date the completed changelog as 0.8.2
- update release comparison links
- prepare changelog-backed GitHub release notes

## Verification

- make verify lint release-check
- npm run docs:build
- npm run docs:check-links
- make snapshot RELEASE_VERSION=0.8.2
- exact-version binary reports 0.8.2
- checksums verified for all four archives and four Linux packages
- npm audit: 0 vulnerabilities
- govulncheck: no vulnerabilities

Linux package installation smoke was not repeated because packaging configuration and verification scripts are unchanged from the previously verified 0.8.0 release.