### PR TITLE
feat(runtime): add bounded run catalog

### DIFF
--- a/internal/service/action.go
+++ b/internal/service/action.go
@@ -159,10 +159,13 @@ type ActionRunner struct {
 	shuttingDown bool
 	leaseSeq     atomic.Uint64
 	journal      *Journal
+	catalog      *RunCatalog
 }
 
 // SetJournal attaches the runtime transition journal action runs record into.
 func (r *ActionRunner) SetJournal(journal *Journal) { r.journal = journal }
+
+func (r *ActionRunner) SetRunCatalog(catalog *RunCatalog) { r.catalog = catalog }
 
 // recordActionTransition writes one action lifecycle fact. A service-owned
 // action also names its owner, so "what happened to api" can be answered
@@ -264,6 +267,8 @@ func (r *ActionRunner) RunDefinition(ctx context.Context, id config.ActionID, ac
 	r.nextRun[id] = run
 	r.states[id] = ActionResult{ID: id, Run: run, Status: ActionRunning, ExitCode: -1, StartedAt: started}
 	r.mu.Unlock()
+	r.catalog.Begin(RunSummary{Target: ActionRunTarget(id), Run: run, Status: ActionRunning.String(), StartedAt: started,
+		StartReason: "invoked"})
 
 	stream := r.logStreamFor(id)
 	if stream != nil {
@@ -285,6 +290,7 @@ func (r *ActionRunner) RunDefinition(ctx context.Context, id config.ActionID, ac
 	r.mu.Unlock()
 	r.recordActionTransition(id, run, ActionRunning, result.Status, result.ExitCode,
 		fmt.Sprintf("%s/%s #%d %s · exit %d", id.Owner, id.Name, run, result.Status, result.ExitCode))
+	r.catalog.Finish(ActionRunTarget(id), run, result.Status.String(), result.FinishedAt, result.ExitCode, nil)
 	return result, runErr
 }
 
@@ -357,6 +363,7 @@ func (r *ActionRunner) setActionPID(id config.ActionID, pid int) {
 	state.PID = pid
 	r.states[id] = state
 	r.mu.Unlock()
+	r.catalog.Update(ActionRunTarget(id), state.Run, "", pid, nil)
 }
 
 func (r *ActionRunner) setActionProcess(id config.ActionID, process *ProcessManager) {
@@ -593,6 +600,7 @@ func (r *ActionRunner) logStreamFor(id config.ActionID) *logStream {
 	stream, exists := r.logs[id]
 	if !exists {
 		stream = newLogStream(r.logBufSize)
+		stream.SetCatalog(r.catalog, ActionRunTarget(id))
 		r.logs[id] = stream
 	}
 	return stream

--- a/internal/service/action_interactive.go
+++ b/internal/service/action_interactive.go
@@ -58,6 +58,8 @@ func (r *ActionRunner) PrepareInteractive(id config.ActionID) (*exec.Cmd, func(e
 	r.nextRun[id] = run
 	r.states[id] = ActionResult{ID: id, Run: run, Status: ActionRunning, ExitCode: -1, StartedAt: started}
 	r.mu.Unlock()
+	r.catalog.Begin(RunSummary{Target: ActionRunTarget(id), Run: run, Status: ActionRunning.String(), StartedAt: started,
+		StartReason: "interactive handoff"})
 
 	finish := func(runErr error) ActionResult {
 		result := ActionResult{
@@ -85,6 +87,8 @@ func (r *ActionRunner) PrepareInteractive(id config.ActionID) (*exec.Cmd, func(e
 		r.retainResultLocked(result)
 		close(active.done)
 		r.mu.Unlock()
+		r.catalog.Update(ActionRunTarget(id), run, "", result.PID, nil)
+		r.catalog.Finish(ActionRunTarget(id), run, result.Status.String(), result.FinishedAt, result.ExitCode, nil)
 		return result
 	}
 	return command, finish, nil
@@ -130,6 +134,8 @@ func (r *ActionRunner) AcquireInteractive(id config.ActionID) (config.Action, st
 	r.nextRun[id] = run
 	r.states[id] = ActionResult{ID: id, Run: run, Status: ActionRunning, ExitCode: -1, StartedAt: started}
 	r.mu.Unlock()
+	r.catalog.Begin(RunSummary{Target: ActionRunTarget(id), Run: run, Status: ActionRunning.String(), StartedAt: started,
+		StartReason: "interactive handoff"})
 	return action, lease, nil
 }
 
@@ -168,6 +174,8 @@ func (r *ActionRunner) CompleteInteractive(id config.ActionID, lease string, exi
 	r.retainResultLocked(result)
 	close(active.done)
 	r.mu.Unlock()
+	r.catalog.Update(ActionRunTarget(id), run, "", result.PID, nil)
+	r.catalog.Finish(ActionRunTarget(id), run, result.Status.String(), result.FinishedAt, result.ExitCode, nil)
 	return result, nil
 }
 

--- a/internal/service/logstream.go
+++ b/internal/service/logstream.go
@@ -14,7 +14,9 @@ import (
 // one, so `kranz logs api` and `kranz logs analytics/stats` read the same
 // structure through the same filters rather than two parallel implementations.
 type logStream struct {
-	buffer *ringbuffer.RingBuffer
+	buffer  *ringbuffer.RingBuffer
+	catalog *RunCatalog
+	target  RunTarget
 
 	mu        sync.RWMutex
 	times     []time.Time
@@ -24,6 +26,7 @@ type logStream struct {
 	// continuous stream and leaves this zero; an action restarts the numbering
 	// story on every invocation, which is what --run addresses.
 	runs       []uint32
+	lineBytes  []uint64
 	write      int
 	count      int
 	nextSeq    uint64
@@ -40,7 +43,15 @@ func newLogStream(size int) *logStream {
 		sources:   make([]string, size),
 		sequences: make([]uint64, size),
 		runs:      make([]uint32, size),
+		lineBytes: make([]uint64, size),
 	}
+}
+
+func (s *logStream) SetCatalog(catalog *RunCatalog, target RunTarget) {
+	s.mu.Lock()
+	s.catalog = catalog
+	s.target = target
+	s.mu.Unlock()
 }
 
 // BeginRun opens a new numbered execution and returns its number. Numbering is
@@ -88,12 +99,18 @@ func (s *logStream) Append(timestamp time.Time, source, text string) {
 }
 
 func (s *logStream) appendLineLocked(timestamp time.Time, source, line string) {
+	if s.count == len(s.times) {
+		s.catalog.EvictOutput(s.target, s.runs[s.write], s.lineBytes[s.write])
+	}
 	s.nextSeq++
 	s.buffer.Write(line)
 	s.times[s.write] = timestamp
 	s.sources[s.write] = source
 	s.sequences[s.write] = s.nextSeq
 	s.runs[s.write] = s.currentRun
+	lineBytes := uint64(len(line))
+	s.lineBytes[s.write] = lineBytes
+	s.catalog.RecordOutput(s.target, s.currentRun, lineBytes)
 	s.write = (s.write + 1) % len(s.times)
 	if s.count < len(s.times) {
 		s.count++
@@ -154,9 +171,12 @@ func (s *logStream) Clear() {
 	clear(s.sources)
 	clear(s.sequences)
 	clear(s.runs)
+	clear(s.lineBytes)
 	s.write = 0
 	s.count = 0
+	catalog, target := s.catalog, s.target
 	s.mu.Unlock()
+	catalog.ClearOutput(target)
 }
 
 // CopyFrom preserves a logical stream across a hot reload.
@@ -170,6 +190,7 @@ func (s *logStream) CopyFrom(previous *logStream) {
 	s.sources = append(s.sources[:0], previous.sources...)
 	s.sequences = append(s.sequences[:0], previous.sequences...)
 	s.runs = append(s.runs[:0], previous.runs...)
+	s.lineBytes = append(s.lineBytes[:0], previous.lineBytes...)
 	s.write = previous.write
 	s.count = previous.count
 	s.nextSeq = previous.nextSeq

--- a/internal/service/manager.go
+++ b/internal/service/manager.go
@@ -40,17 +40,23 @@ type Manager struct {
 	prereqSatisfied      map[config.ActionID]bool
 	prereqRuns           map[config.ActionID]*prereqRun
 	journal              *Journal
+	runs                 *RunCatalog
 }
 
 // Journal returns the runtime transition journal shared by every service and
 // action this manager owns.
 func (m *Manager) Journal() *Journal { return m.journal }
 
+func (m *Manager) RunSummaries(target RunTarget) []RunSummary { return m.runs.List(target) }
+
+func (m *Manager) AllRunSummaries() []RunSummary { return m.runs.All() }
+
 // newService constructs a service already attached to this manager's journal,
 // so no construction path can produce a service whose changes go unrecorded.
 func (m *Manager) newService(name string, cfg config.Service) *Service {
 	svc := NewService(name, cfg, 1000)
 	svc.SetJournal(m.journal)
+	svc.SetRunCatalog(m.runs)
 	return svc
 }
 
@@ -200,8 +206,10 @@ func NewManager(cfg *config.Config) *Manager {
 		prereqSatisfied:      make(map[config.ActionID]bool),
 		prereqRuns:           make(map[config.ActionID]*prereqRun),
 		journal:              NewJournal(defaultJournalSize),
+		runs:                 NewRunCatalog(defaultRunCatalogSize),
 	}
 	m.actions.SetJournal(m.journal)
+	m.actions.SetRunCatalog(m.runs)
 
 	for name, svcCfg := range cfg.Services {
 		m.services[name] = m.newService(name, svcCfg)

--- a/internal/service/manager_process.go
+++ b/internal/service/manager_process.go
@@ -35,9 +35,9 @@ func (m *Manager) monitorProcess(name string, svc *Service, pm *ProcessManager, 
 			shouldEvaluate := false
 			if current, _ := svc.runtime(); current == pm && svc.Status() != config.StatusStopping {
 				svc.clearRuntime(pm)
+				svc.RecordExit(exitCode, waitErr)
 				svc.SetStatus(config.StatusStopped)
 				svc.SetPID(0)
-				svc.RecordExit(exitCode, waitErr)
 				shouldEvaluate = true
 				if m.successfulExit(svc.Config, exitCode) {
 					svc.AppendLog(fmt.Sprintf("[Kranz] Process exited · code %d", exitCode))

--- a/internal/service/manager_start.go
+++ b/internal/service/manager_start.go
@@ -107,6 +107,7 @@ func (m *Manager) startService(ctx context.Context, name string, recovery bool) 
 	pid, err := pm.Start(context.Background(), start.Command, start.Dir, start.Env, start.Shell)
 	if err != nil {
 		svc.SetDesiredRunning(false)
+		svc.RecordExit(-1, err)
 		svc.SetCause(&config.StateCause{Type: "start_failed", Message: err.Error()})
 		svc.SetStatus(config.StatusStopped)
 		svc.AppendLog("[Kranz] Start failed: " + err.Error())

--- a/internal/service/manager_start.go
+++ b/internal/service/manager_start.go
@@ -174,6 +174,11 @@ func (m *Manager) startDetachedService(ctx context.Context, svc *Service) error 
 	result, err := m.actions.RunDefinition(ctx, id, *start)
 	m.appendLifecycleResult(svc, "start", result)
 	if err != nil {
+		var resultErr error
+		if result.Error != "" {
+			resultErr = errors.New(result.Error)
+		}
+		svc.RecordExit(result.ExitCode, resultErr)
 		svc.SetDesiredRunning(false)
 		// A detached start can mutate external state before failing, timing out,
 		// or being canceled. Never claim it is stopped without observing that.

--- a/internal/service/manager_stop.go
+++ b/internal/service/manager_stop.go
@@ -94,6 +94,7 @@ func (m *Manager) stopDetachedService(svc *Service) error {
 		m.wakeStatusMonitor(svc.Name)
 		return fmt.Errorf("stop detached service %q: %w", svc.Name, err)
 	}
+	svc.RecordExit(result.ExitCode, nil)
 	svc.SetPID(0)
 	svc.SetStatus(config.StatusStopped)
 	m.wakeStatusMonitor(svc.Name)
@@ -127,11 +128,6 @@ func (m *Manager) appendLifecycleResult(svc *Service, operation string, result A
 			svc.AppendLog(line)
 		}
 	}
-	var resultErr error
-	if result.Error != "" {
-		resultErr = errors.New(result.Error)
-	}
-	svc.RecordExit(result.ExitCode, resultErr)
 	svc.AppendLog(fmt.Sprintf("[Kranz] Lifecycle %s %s · exit %d", operation, result.Status.String(), result.ExitCode))
 }
 

--- a/internal/service/manager_stop.go
+++ b/internal/service/manager_stop.go
@@ -57,6 +57,11 @@ func (m *Manager) StopService(name string) error {
 		svc.AppendLog(fmt.Sprintf("[Kranz] Failed to stop %s: %v", name, stopErr))
 	}
 
+	exitCode := 0
+	if pm != nil {
+		exitCode = pm.ExitCode()
+	}
+	svc.RecordExit(exitCode, stopErr)
 	svc.SetPID(0)
 	svc.SetStatus(config.StatusStopped)
 	svc.AppendLog("[Kranz] Stopped")

--- a/internal/service/process.go
+++ b/internal/service/process.go
@@ -273,7 +273,11 @@ func (pm *ProcessManager) Wait() error {
 func (pm *ProcessManager) ExitCode() int {
 	pm.mu.RLock()
 	defer pm.mu.RUnlock()
-	if pm.cmd == nil || pm.cmd.ProcessState == nil {
+	// exec.Cmd.Wait writes ProcessState before reap closes waitDone. Reading it
+	// while the process is still being reaped races inside os/exec even though
+	// our pointer is protected. The close is both the completion signal and the
+	// memory barrier that makes ProcessState safe to inspect.
+	if pm.cmd == nil || pm.waitDone == nil || !channelClosed(pm.waitDone) || pm.cmd.ProcessState == nil {
 		return -1
 	}
 	if status, ok := pm.cmd.ProcessState.Sys().(syscall.WaitStatus); ok && status.Signaled() {

--- a/internal/service/process_test.go
+++ b/internal/service/process_test.go
@@ -57,6 +57,24 @@ func TestProcessManagerUsesUnixSignalExitConvention(t *testing.T) {
 	}
 }
 
+func TestProcessManagerExitCodeStaysUnknownUntilReaped(t *testing.T) {
+	pm := NewProcessManager(10)
+	if _, err := pm.Start(t.Context(), "sleep 0.1", "", nil, "/bin/sh"); err != nil {
+		t.Fatal(err)
+	}
+	for range 100 {
+		if code := pm.ExitCode(); code != -1 {
+			t.Fatalf("ExitCode() while running = %d, want -1", code)
+		}
+	}
+	if err := pm.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	if code := pm.ExitCode(); code != 0 {
+		t.Fatalf("ExitCode() after reap = %d, want 0", code)
+	}
+}
+
 func TestShutdownCommandFailureStillKillsManagedProcess(t *testing.T) {
 	pm := NewProcessManager(32)
 	if _, err := pm.Start(context.Background(), "while :; do sleep 1; done", ".", nil, "sh"); err != nil {

--- a/internal/service/run_catalog.go
+++ b/internal/service/run_catalog.go
@@ -1,0 +1,263 @@
+package service
+
+import (
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/kranz-org/kranz/internal/config"
+)
+
+const defaultRunCatalogSize = 100
+
+// RunKind identifies the runtime subject that owns a numbered execution.
+type RunKind string
+
+const (
+	RunKindService RunKind = "service"
+	RunKindAction  RunKind = "action"
+)
+
+// RunTarget is the stable, comparable address of one run-producing subject.
+// Service targets fill Name. Action targets retain the complete ActionID so a
+// group action cannot collide with a service action that has the same spelling.
+type RunTarget struct {
+	Kind   RunKind         `json:"kind"`
+	Name   string          `json:"name,omitempty"`
+	Action config.ActionID `json:"action,omitempty"`
+}
+
+func ServiceRunTarget(name string) RunTarget {
+	return RunTarget{Kind: RunKindService, Name: name}
+}
+
+func ActionRunTarget(id config.ActionID) RunTarget {
+	return RunTarget{Kind: RunKindAction, Action: id}
+}
+
+// RunOutputState distinguishes intact output from known retention loss. An
+// empty run with no captured output is complete; unavailable means output did
+// exist but none of it remains.
+type RunOutputState string
+
+const (
+	RunOutputComplete    RunOutputState = "complete"
+	RunOutputPartial     RunOutputState = "partial"
+	RunOutputUnavailable RunOutputState = "unavailable"
+)
+
+// RunOutputSummary makes retention loss explicit and exactly measurable.
+type RunOutputSummary struct {
+	State         RunOutputState `json:"state"`
+	CapturedLines uint64         `json:"captured_lines"`
+	CapturedBytes uint64         `json:"captured_bytes"`
+	RetainedLines uint64         `json:"retained_lines"`
+	RetainedBytes uint64         `json:"retained_bytes"`
+	MissingLines  uint64         `json:"missing_lines"`
+	MissingBytes  uint64         `json:"missing_bytes"`
+}
+
+// RunSummary is the bounded catalog record kept independently from log lines
+// and the transition journal.
+type RunSummary struct {
+	Target      RunTarget          `json:"target"`
+	Run         uint32             `json:"run"`
+	Status      string             `json:"status"`
+	StartedAt   time.Time          `json:"started_at"`
+	FinishedAt  time.Time          `json:"finished_at,omitempty"`
+	PID         int                `json:"pid,omitempty"`
+	ExitCode    *int               `json:"exit_code,omitempty"`
+	Cause       *config.StateCause `json:"cause,omitempty"`
+	Initiator   string             `json:"initiator,omitempty"`
+	StartReason string             `json:"start_reason,omitempty"`
+	Live        bool               `json:"live"`
+	Output      RunOutputSummary   `json:"output"`
+}
+
+// RunCatalog retains a fair, per-target bounded history. A noisy target can
+// evict only its own old summaries, never another service or action's history.
+type RunCatalog struct {
+	mu               sync.RWMutex
+	maxRunsPerTarget int
+	runs             map[RunTarget][]RunSummary
+}
+
+func NewRunCatalog(maxRunsPerTarget int) *RunCatalog {
+	if maxRunsPerTarget <= 0 {
+		maxRunsPerTarget = defaultRunCatalogSize
+	}
+	return &RunCatalog{maxRunsPerTarget: maxRunsPerTarget, runs: make(map[RunTarget][]RunSummary)}
+}
+
+func (c *RunCatalog) Begin(summary RunSummary) {
+	if c == nil || summary.Run == 0 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	summary.Live = true
+	summary.FinishedAt = time.Time{}
+	summary.ExitCode = nil
+	summary.Output.State = RunOutputComplete
+	history := c.runs[summary.Target]
+	for index := range history {
+		if history[index].Run == summary.Run {
+			history[index] = cloneRunSummary(summary)
+			c.runs[summary.Target] = history
+			return
+		}
+	}
+	history = append(history, cloneRunSummary(summary))
+	if len(history) > c.maxRunsPerTarget {
+		history = append([]RunSummary(nil), history[len(history)-c.maxRunsPerTarget:]...)
+	}
+	c.runs[summary.Target] = history
+}
+
+func (c *RunCatalog) Update(target RunTarget, run uint32, status string, pid int, cause *config.StateCause) {
+	c.update(target, run, func(summary *RunSummary) {
+		if status != "" {
+			summary.Status = status
+		}
+		if pid > 0 {
+			summary.PID = pid
+		}
+		if cause != nil {
+			summary.Cause = cloneStateCause(cause)
+		}
+	})
+}
+
+func (c *RunCatalog) Finish(target RunTarget, run uint32, status string, finishedAt time.Time, exitCode int, cause *config.StateCause) {
+	c.update(target, run, func(summary *RunSummary) {
+		summary.Status = status
+		summary.Live = false
+		summary.FinishedAt = finishedAt
+		exit := exitCode
+		summary.ExitCode = &exit
+		summary.Cause = cloneStateCause(cause)
+	})
+}
+
+func (c *RunCatalog) RecordOutput(target RunTarget, run uint32, bytes uint64) {
+	if run == 0 {
+		return
+	}
+	c.update(target, run, func(summary *RunSummary) {
+		summary.Output.CapturedLines++
+		summary.Output.CapturedBytes += bytes
+		summary.Output.RetainedLines++
+		summary.Output.RetainedBytes += bytes
+		summary.Output.State = outputState(summary.Output)
+	})
+}
+
+func (c *RunCatalog) EvictOutput(target RunTarget, run uint32, bytes uint64) {
+	if run == 0 {
+		return
+	}
+	c.update(target, run, func(summary *RunSummary) {
+		if summary.Output.RetainedLines > 0 {
+			summary.Output.RetainedLines--
+		}
+		if bytes <= summary.Output.RetainedBytes {
+			summary.Output.RetainedBytes -= bytes
+		} else {
+			summary.Output.RetainedBytes = 0
+		}
+		summary.Output.MissingLines++
+		summary.Output.MissingBytes += bytes
+		summary.Output.State = outputState(summary.Output)
+	})
+}
+
+func (c *RunCatalog) ClearOutput(target RunTarget) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	history := c.runs[target]
+	for index := range history {
+		history[index].Output.MissingLines += history[index].Output.RetainedLines
+		history[index].Output.MissingBytes += history[index].Output.RetainedBytes
+		history[index].Output.RetainedLines = 0
+		history[index].Output.RetainedBytes = 0
+		history[index].Output.State = outputState(history[index].Output)
+	}
+	c.runs[target] = history
+}
+
+func outputState(output RunOutputSummary) RunOutputState {
+	if output.MissingLines == 0 && output.MissingBytes == 0 {
+		return RunOutputComplete
+	}
+	if output.RetainedLines == 0 {
+		return RunOutputUnavailable
+	}
+	return RunOutputPartial
+}
+
+func (c *RunCatalog) List(target RunTarget) []RunSummary {
+	if c == nil {
+		return nil
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	history := c.runs[target]
+	result := make([]RunSummary, len(history))
+	for index := range history {
+		result[index] = cloneRunSummary(history[index])
+	}
+	return result
+}
+
+func (c *RunCatalog) All() []RunSummary {
+	if c == nil {
+		return nil
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	result := make([]RunSummary, 0)
+	for _, history := range c.runs {
+		for _, summary := range history {
+			result = append(result, cloneRunSummary(summary))
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].StartedAt.Equal(result[j].StartedAt) {
+			return result[i].Run < result[j].Run
+		}
+		return result[i].StartedAt.Before(result[j].StartedAt)
+	})
+	return result
+}
+
+func (c *RunCatalog) update(target RunTarget, run uint32, update func(*RunSummary)) {
+	if c == nil || run == 0 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	history := c.runs[target]
+	for index := range history {
+		if history[index].Run == run {
+			update(&history[index])
+			c.runs[target] = history
+			return
+		}
+	}
+}
+
+func cloneRunSummary(summary RunSummary) RunSummary {
+	summary.Cause = cloneStateCause(summary.Cause)
+	return summary
+}
+
+func cloneStateCause(cause *config.StateCause) *config.StateCause {
+	if cause == nil {
+		return nil
+	}
+	copy := *cause
+	return &copy
+}

--- a/internal/service/run_catalog.go
+++ b/internal/service/run_catalog.go
@@ -226,11 +226,30 @@ func (c *RunCatalog) All() []RunSummary {
 	}
 	sort.Slice(result, func(i, j int) bool {
 		if result[i].StartedAt.Equal(result[j].StartedAt) {
+			if result[i].Target != result[j].Target {
+				return runTargetLess(result[i].Target, result[j].Target)
+			}
 			return result[i].Run < result[j].Run
 		}
 		return result[i].StartedAt.Before(result[j].StartedAt)
 	})
 	return result
+}
+
+func runTargetLess(left, right RunTarget) bool {
+	if left.Kind != right.Kind {
+		return left.Kind < right.Kind
+	}
+	if left.Name != right.Name {
+		return left.Name < right.Name
+	}
+	if left.Action.OwnerKind != right.Action.OwnerKind {
+		return left.Action.OwnerKind < right.Action.OwnerKind
+	}
+	if left.Action.Owner != right.Action.Owner {
+		return left.Action.Owner < right.Action.Owner
+	}
+	return left.Action.Name < right.Action.Name
 }
 
 func (c *RunCatalog) update(target RunTarget, run uint32, update func(*RunSummary)) {

--- a/internal/service/run_catalog_test.go
+++ b/internal/service/run_catalog_test.go
@@ -119,3 +119,29 @@ func TestFailedStartFinishesItsServiceRun(t *testing.T) {
 		t.Fatalf("failed start summary = %#v", runs)
 	}
 }
+
+func TestDetachedServiceRunStaysLiveAfterStartAction(t *testing.T) {
+	manager := NewManager(&config.Config{Services: map[string]config.Service{
+		"stack": {
+			Supervision: config.SupervisionDetached,
+			Lifecycle: config.LifecycleConfig{
+				Start: &config.Action{Command: "true", Shell: "/bin/sh"},
+				Stop:  &config.Action{Command: "true", Shell: "/bin/sh"},
+			},
+		},
+	}})
+	if err := manager.StartService("stack"); err != nil {
+		t.Fatal(err)
+	}
+	runs := manager.RunSummaries(ServiceRunTarget("stack"))
+	if len(runs) != 1 || !runs[0].Live || runs[0].ExitCode != nil || runs[0].Status != config.StatusRunning.String() {
+		t.Fatalf("running detached summary = %#v", runs)
+	}
+	if err := manager.StopService("stack"); err != nil {
+		t.Fatal(err)
+	}
+	runs = manager.RunSummaries(ServiceRunTarget("stack"))
+	if len(runs) != 1 || runs[0].Live || runs[0].ExitCode == nil || *runs[0].ExitCode != 0 || runs[0].Status != config.StatusStopped.String() {
+		t.Fatalf("stopped detached summary = %#v", runs)
+	}
+}

--- a/internal/service/run_catalog_test.go
+++ b/internal/service/run_catalog_test.go
@@ -1,0 +1,121 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kranz-org/kranz/internal/config"
+)
+
+func TestRunCatalogRetentionIsFairPerTarget(t *testing.T) {
+	catalog := NewRunCatalog(2)
+	api := ServiceRunTarget("api")
+	worker := ServiceRunTarget("worker")
+	for run := uint32(1); run <= 3; run++ {
+		catalog.Begin(RunSummary{Target: api, Run: run, Status: "running", StartedAt: time.Unix(int64(run), 0)})
+	}
+	catalog.Begin(RunSummary{Target: worker, Run: 1, Status: "running", StartedAt: time.Unix(1, 0)})
+
+	apiRuns := catalog.List(api)
+	if len(apiRuns) != 2 || apiRuns[0].Run != 2 || apiRuns[1].Run != 3 {
+		t.Fatalf("api runs = %#v, want #2 and #3", apiRuns)
+	}
+	workerRuns := catalog.List(worker)
+	if len(workerRuns) != 1 || workerRuns[0].Run != 1 {
+		t.Fatalf("worker history was displaced by api: %#v", workerRuns)
+	}
+}
+
+func TestRunCatalogReportsPartialAndUnavailableOutput(t *testing.T) {
+	catalog := NewRunCatalog(10)
+	target := ServiceRunTarget("api")
+	catalog.Begin(RunSummary{Target: target, Run: 1, Status: "running", StartedAt: time.Now()})
+	catalog.RecordOutput(target, 1, 5)
+	catalog.RecordOutput(target, 1, 7)
+	catalog.EvictOutput(target, 1, 5)
+
+	output := catalog.List(target)[0].Output
+	if output.State != RunOutputPartial || output.MissingLines != 1 || output.MissingBytes != 5 || output.RetainedLines != 1 || output.RetainedBytes != 7 {
+		t.Fatalf("partial output = %#v", output)
+	}
+	catalog.ClearOutput(target)
+	output = catalog.List(target)[0].Output
+	if output.State != RunOutputUnavailable || output.MissingLines != 2 || output.MissingBytes != 12 || output.RetainedLines != 0 {
+		t.Fatalf("unavailable output = %#v", output)
+	}
+}
+
+func TestManagerCatalogTracksServiceAndActionRuns(t *testing.T) {
+	cfg := &config.Config{Services: map[string]config.Service{
+		"api": {Command: "true", Actions: map[string]config.Action{"check": {Command: "true"}}},
+	}}
+	manager := NewManager(cfg)
+	if err := manager.StartService("api"); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.StopService("api"); err != nil {
+		t.Fatal(err)
+	}
+	serviceRuns := manager.RunSummaries(ServiceRunTarget("api"))
+	if len(serviceRuns) != 1 || serviceRuns[0].Run != 1 || serviceRuns[0].Live || serviceRuns[0].ExitCode == nil {
+		t.Fatalf("service summaries = %#v", serviceRuns)
+	}
+
+	id := config.ActionID{OwnerKind: config.ActionOwnerService, Owner: "api", Name: "check"}
+	if _, err := manager.RunAction(t.Context(), id); err != nil {
+		t.Fatal(err)
+	}
+	actionRuns := manager.RunSummaries(ActionRunTarget(id))
+	if len(actionRuns) != 1 || actionRuns[0].Run != 1 || actionRuns[0].Live || actionRuns[0].Status != ActionSucceeded.String() {
+		t.Fatalf("action summaries = %#v", actionRuns)
+	}
+}
+
+func TestManagerCatalogTracksInteractiveActionRuns(t *testing.T) {
+	interactive := true
+	id := config.ActionID{OwnerKind: config.ActionOwnerService, Owner: "api", Name: "shell"}
+	manager := NewManager(&config.Config{Services: map[string]config.Service{
+		"api": {Command: "true", Actions: map[string]config.Action{"shell": {Command: "true", Interactive: &interactive}}},
+	}})
+	_, lease, err := manager.AcquireInteractiveAction(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CompleteInteractiveAction(id, lease, 0, 123, nil); err != nil {
+		t.Fatal(err)
+	}
+	runs := manager.RunSummaries(ActionRunTarget(id))
+	if len(runs) != 1 || runs[0].Live || runs[0].PID != 123 || runs[0].ExitCode == nil || *runs[0].ExitCode != 0 {
+		t.Fatalf("interactive summaries = %#v", runs)
+	}
+}
+
+func TestLogStreamEvictionUpdatesCatalogBoundary(t *testing.T) {
+	catalog := NewRunCatalog(10)
+	target := ServiceRunTarget("api")
+	catalog.Begin(RunSummary{Target: target, Run: 1, Status: "running", StartedAt: time.Now()})
+	stream := newLogStream(2)
+	stream.SetCatalog(catalog, target)
+	stream.BeginRunNumber(1)
+	stream.Append(time.Now(), "stdout", "one")
+	stream.Append(time.Now(), "stdout", "two")
+	stream.Append(time.Now(), "stdout", "three")
+
+	output := catalog.List(target)[0].Output
+	if output.State != RunOutputPartial || output.CapturedLines != 3 || output.RetainedLines != 2 || output.MissingLines != 1 || output.MissingBytes != 3 {
+		t.Fatalf("output boundary = %#v", output)
+	}
+}
+
+func TestFailedStartFinishesItsServiceRun(t *testing.T) {
+	manager := NewManager(&config.Config{Services: map[string]config.Service{
+		"api": {Command: "true", Shell: "/definitely/missing/kranz-shell"},
+	}})
+	if err := manager.StartService("api"); err == nil {
+		t.Fatal("start unexpectedly succeeded")
+	}
+	runs := manager.RunSummaries(ServiceRunTarget("api"))
+	if len(runs) != 1 || runs[0].Live || runs[0].ExitCode == nil || *runs[0].ExitCode != -1 || runs[0].Cause == nil || runs[0].Cause.Type != "start_failed" {
+		t.Fatalf("failed start summary = %#v", runs)
+	}
+}

--- a/internal/service/run_catalog_test.go
+++ b/internal/service/run_catalog_test.go
@@ -45,6 +45,19 @@ func TestRunCatalogReportsPartialAndUnavailableOutput(t *testing.T) {
 	}
 }
 
+func TestRunCatalogAllIsDeterministicWhenRunsStartTogether(t *testing.T) {
+	catalog := NewRunCatalog(10)
+	started := time.Now()
+	catalog.Begin(RunSummary{Target: ServiceRunTarget("worker"), Run: 1, StartedAt: started})
+	catalog.Begin(RunSummary{Target: ActionRunTarget(config.ActionID{OwnerKind: config.ActionOwnerService, Owner: "api", Name: "check"}), Run: 1, StartedAt: started})
+	catalog.Begin(RunSummary{Target: ServiceRunTarget("api"), Run: 1, StartedAt: started})
+
+	all := catalog.All()
+	if len(all) != 3 || all[0].Target.Kind != RunKindAction || all[1].Target.Name != "api" || all[2].Target.Name != "worker" {
+		t.Fatalf("All() order = %#v", all)
+	}
+}
+
 func TestManagerCatalogTracksServiceAndActionRuns(t *testing.T) {
 	cfg := &config.Config{Services: map[string]config.Service{
 		"api": {Command: "true", Actions: map[string]config.Action{"check": {Command: "true"}}},

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -21,7 +21,8 @@ type Service struct {
 	State   config.ServiceState
 	stateMu sync.RWMutex
 
-	stream *logStream
+	stream  *logStream
+	catalog *RunCatalog
 
 	// journal records this service's transitions for readers that need what
 	// happened rather than what is. It is nil for services constructed outside
@@ -159,6 +160,11 @@ func NewService(name string, cfg config.Service, logBufSize int) *Service {
 // SetJournal attaches the runtime journal this service records into.
 func (s *Service) SetJournal(journal *Journal) { s.journal = journal }
 
+func (s *Service) SetRunCatalog(catalog *RunCatalog) {
+	s.catalog = catalog
+	s.stream.SetCatalog(catalog, ServiceRunTarget(s.Name))
+}
+
 // SetStatus atomically updates lifecycle status and transition timestamps, and
 // records the transition. Every lifecycle path funnels through here, so the
 // journal cannot miss a change some other path made.
@@ -179,6 +185,8 @@ func (s *Service) SetStatus(status config.ServiceStatus) {
 		s.State.ExitCode = 0
 		s.State.ExitError = ""
 		s.State.Cause = nil
+		s.catalog.Begin(RunSummary{Target: ServiceRunTarget(s.Name), Run: s.State.Run, Status: status.String(),
+			StartedAt: s.State.StartedAt, StartReason: "start"})
 	}
 	if status == config.StatusRunning && s.State.StartedAt.IsZero() {
 		s.State.StartedAt = time.Now()
@@ -193,11 +201,15 @@ func (s *Service) SetStatus(status config.ServiceStatus) {
 		Cause:   s.State.Cause,
 		Summary: s.Name + " " + status.String(),
 	}
-	if status == config.StatusStopped && s.State.Completed {
+	if (status == config.StatusStopped || status == config.StatusUnknown) && s.State.Completed {
 		exit := s.State.ExitCode
 		transition.ExitCode = &exit
 	}
 	s.stateMu.Unlock()
+	s.catalog.Update(ServiceRunTarget(s.Name), transition.Run, status.String(), transition.PID, transition.Cause)
+	if (status == config.StatusStopped || status == config.StatusUnknown) && transition.ExitCode != nil {
+		s.catalog.Finish(ServiceRunTarget(s.Name), transition.Run, status.String(), time.Now(), *transition.ExitCode, transition.Cause)
+	}
 	if previous != status {
 		s.journal.Record(transition)
 	}
@@ -208,11 +220,13 @@ func (s *Service) SetStatus(status config.ServiceStatus) {
 // with it instead of a reader having to correlate two records by time.
 func (s *Service) SetCause(cause *config.StateCause) {
 	s.stateMu.Lock()
-	defer s.stateMu.Unlock()
 	if cause != nil && cause.At.IsZero() {
 		cause.At = time.Now()
 	}
 	s.State.Cause = cause
+	run := s.State.Run
+	s.stateMu.Unlock()
+	s.catalog.Update(ServiceRunTarget(s.Name), run, "", -1, cause)
 }
 
 // Run returns the current execution number of this service.
@@ -307,8 +321,10 @@ func (s *Service) Status() config.ServiceStatus {
 // SetPID updates the owned process ID.
 func (s *Service) SetPID(pid int) {
 	s.stateMu.Lock()
-	defer s.stateMu.Unlock()
 	s.State.PID = pid
+	run := s.State.Run
+	s.stateMu.Unlock()
+	s.catalog.Update(ServiceRunTarget(s.Name), run, "", pid, nil)
 }
 
 // PID returns the owned process ID, or zero while stopped.


### PR DESCRIPTION
## Summary
- add a per-target bounded catalog for service and action runs
- retain run summaries independently from output and the transition journal
- report exact retained and missing output lines/bytes
- cover captured, interactive, stopped, and failed-start lifecycles

## Validation
- make verify
- make lint
- go test -race ./internal/service
- kranz action run development/build