### PR TITLE
feat(runtime): expose run provenance and history

### DIFF
--- a/cmd/kranz/attach.go
+++ b/cmd/kranz/attach.go
@@ -33,7 +33,8 @@ func runAttach(options kranzcli.GlobalOptions, args []string) (runErr error) {
 		return fmt.Errorf("open runtime directory %s: %w", record.Directory, err)
 	}
 	defer func() { runErr = errors.Join(runErr, os.Chdir(originalDirectory)) }()
-	client, err := kranzruntime.Dial(record.Socket, version)
+	client, err := kranzruntime.DialWithIdentity(record.Socket, version,
+		kranzruntime.ClientIdentity{Surface: "tui", Label: "Kranz attach"})
 	if err != nil {
 		return classifyRuntimeError(err)
 	}

--- a/cmd/kranz/main.go
+++ b/cmd/kranz/main.go
@@ -131,6 +131,11 @@ func execute(args []string, stdout, stderr io.Writer) int {
 			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
 		}
 		return 0
+	case "runs":
+		if err := runRuns(invocation.Globals, invocation.Args, stdout); err != nil {
+			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
+		}
+		return 0
 	case "graph":
 		if err := runGraph(invocation.Globals, invocation.Args, stdout); err != nil {
 			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
@@ -399,7 +404,8 @@ func runTUI(options kranzcli.GlobalOptions) (runErr error) {
 	record, lookupErr := registry.Resolve(lookupCtx, cfg.RuntimeName(), version)
 	cancelLookup()
 	if lookupErr == nil {
-		client, dialErr := kranzruntime.Dial(record.Socket, version)
+		client, dialErr := kranzruntime.DialWithIdentity(record.Socket, version,
+			kranzruntime.ClientIdentity{Surface: "tui", Label: "Kranz dashboard"})
 		if dialErr != nil {
 			return classifyRuntimeError(dialErr)
 		}
@@ -467,7 +473,8 @@ func runTUI(options kranzcli.GlobalOptions) (runErr error) {
 		}
 	}()
 
-	client, err := kranzruntime.Dial(metadata.Socket, version)
+	client, err := kranzruntime.DialWithIdentity(metadata.Socket, version,
+		kranzruntime.ClientIdentity{Surface: "tui", Label: "Kranz dashboard"})
 	if err != nil {
 		return fmt.Errorf("connect to runtime: %w", err)
 	}

--- a/cmd/kranz/mcp.go
+++ b/cmd/kranz/mcp.go
@@ -120,7 +120,8 @@ func attachMCPRecord(reference string, record kranzruntime.SessionRecord) (*kran
 	if record.State != kranzruntime.SessionRunning {
 		return nil, record.SessionMetadata, "", nil, fmt.Errorf("runtime %s is %s; refusing to create a second supervisor", reference, record.State)
 	}
-	client, err := kranzruntime.Dial(record.Socket, version)
+	client, err := kranzruntime.DialWithIdentity(record.Socket, version,
+		kranzruntime.ClientIdentity{Surface: "mcp", Label: "Kranz MCP"})
 	if err != nil {
 		return nil, record.SessionMetadata, "", nil, fmt.Errorf("attach runtime %s: %w", reference, err)
 	}

--- a/cmd/kranz/runs.go
+++ b/cmd/kranz/runs.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/kranz-org/kranz/internal/app"
+	kranzcli "github.com/kranz-org/kranz/internal/cli"
+)
+
+func runRuns(options kranzcli.GlobalOptions, targets []string, stdout io.Writer) error {
+	client, closeClient, err := dialProjectRuntime(options)
+	if err != nil {
+		return err
+	}
+	defer closeClient()
+	runs := filterRuns(client.Runs(), targets)
+	if options.Output == kranzcli.OutputJSON {
+		return kranzcli.WriteJSON(stdout, runs)
+	}
+	w := tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "RUN\tSTATUS\tSTARTED\tDURATION\tEXIT\tREASON\tINITIATOR\tOUTPUT")
+	for _, run := range runs {
+		exit := "-"
+		if run.ExitCode != nil {
+			exit = fmt.Sprint(*run.ExitCode)
+		}
+		duration := time.Since(run.StartedAt)
+		if !run.FinishedAt.IsZero() {
+			duration = run.FinishedAt.Sub(run.StartedAt)
+		}
+		_, _ = fmt.Fprintf(w, "%s#%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			runTargetName(run.Target), run.Run, run.Status, run.StartedAt.Format(time.RFC3339), duration.Round(time.Millisecond), exit,
+			run.StartReason, runInitiator(run), run.Output.State)
+	}
+	return w.Flush()
+}
+
+func runTargetName(target app.RunTarget) string {
+	if target.Kind == app.RunKindService {
+		return target.Name
+	}
+	return target.Action.Owner + "/" + target.Action.Name
+}
+
+func runInitiator(run app.RunSummary) string {
+	if run.ClientLabel == "" {
+		return run.Surface
+	}
+	return run.Surface + ":" + run.ClientLabel
+}
+
+func filterRuns(runs []app.RunSummary, targets []string) []app.RunSummary {
+	if len(targets) == 0 {
+		return runs
+	}
+	selected := make(map[string]bool, len(targets))
+	for _, target := range targets {
+		selected[strings.ToLower(target)] = true
+	}
+	result := make([]app.RunSummary, 0, len(runs))
+	for _, run := range runs {
+		if selected[strings.ToLower(runTargetName(run.Target))] {
+			result = append(result, run)
+		}
+	}
+	return result
+}

--- a/cmd/kranz/runtime_commands.go
+++ b/cmd/kranz/runtime_commands.go
@@ -92,7 +92,8 @@ func startRuntime(options kranzcli.GlobalOptions, mode string) (*runtimeHost, *c
 	}
 	serveErr := make(chan error, 1)
 	go func() { serveErr <- supervisor.Serve() }()
-	client, err := kranzruntime.Dial(metadata.Socket, version)
+	client, err := kranzruntime.DialWithIdentity(metadata.Socket, version,
+		kranzruntime.ClientIdentity{Surface: mode, Label: "kranz " + mode})
 	if err != nil {
 		_ = supervisor.Close()
 		<-serveErr

--- a/internal/app/api.go
+++ b/internal/app/api.go
@@ -83,6 +83,7 @@ type API interface {
 	// ForceStartServices starts exactly names, without expanding or
 	// waiting on dependencies.
 	ForceStartServices(names []string) error
+	ForceStartServicesContext(ctx context.Context, names []string) error
 	// StopAll stops every configured service in reverse dependency order.
 	StopAll() error
 	// RestartAll restarts every service that was active when called.
@@ -124,11 +125,14 @@ type API interface {
 	// lets an IPC-backed API implementation support interactive actions:
 	// neither a process handle nor a closure over one survives the wire.
 	AcquireInteractiveAction(id config.ActionID) (config.Action, string, error)
+	AcquireInteractiveActionContext(ctx context.Context, id config.ActionID) (config.Action, string, error)
 	// CompleteInteractiveAction finishes an AcquireInteractiveAction lease
 	// with the outcome the caller observed running the command: the error
 	// tea.ExecProcess reported, if any, plus the exit code and PID read
 	// from the command's ProcessState.
 	CompleteInteractiveAction(id config.ActionID, lease string, execErr error, exitCode, pid int) (ActionResult, error)
+	// Runs returns the bounded run catalog independently from retained output.
+	Runs() []RunSummary
 
 	// Logs returns the current buffered log entries for a service.
 	Logs(name string) []config.LogEntry

--- a/internal/app/local.go
+++ b/internal/app/local.go
@@ -286,6 +286,10 @@ func (l *Local) ForceStartServices(names []string) error {
 	return l.manager.ForceStartServices(names)
 }
 
+func (l *Local) ForceStartServicesContext(ctx context.Context, names []string) error {
+	return l.manager.ForceStartServicesContext(ctx, names)
+}
+
 func (l *Local) StopAll() error {
 	return l.manager.StopAll()
 }
@@ -294,12 +298,20 @@ func (l *Local) RestartAll() error {
 	return l.manager.RestartAll()
 }
 
+func (l *Local) RestartAllContext(ctx context.Context) error {
+	return l.manager.RestartAllContext(ctx)
+}
+
 func (l *Local) RestartService(name string) error {
 	return l.manager.RestartService(name)
 }
 
 func (l *Local) RestartServices(names []string) error {
 	return l.manager.RestartServices(names)
+}
+
+func (l *Local) RestartServicesContext(ctx context.Context, names []string) error {
+	return l.manager.RestartServicesContext(ctx, names)
 }
 
 func (l *Local) HasRunningServices() bool {
@@ -335,9 +347,15 @@ func (l *Local) AcquireInteractiveAction(id config.ActionID) (config.Action, str
 	return l.manager.AcquireInteractiveAction(id)
 }
 
+func (l *Local) AcquireInteractiveActionContext(ctx context.Context, id config.ActionID) (config.Action, string, error) {
+	return l.manager.AcquireInteractiveActionContext(ctx, id)
+}
+
 func (l *Local) CompleteInteractiveAction(id config.ActionID, lease string, execErr error, exitCode, pid int) (ActionResult, error) {
 	return l.manager.CompleteInteractiveAction(id, lease, exitCode, pid, execErr)
 }
+
+func (l *Local) Runs() []RunSummary { return l.manager.AllRunSummaries() }
 
 func (l *Local) Logs(name string) []config.LogEntry {
 	svc, ok := l.manager.GetService(name)

--- a/internal/app/operations.go
+++ b/internal/app/operations.go
@@ -203,12 +203,12 @@ func (l *Local) ExecutePlan(ctx context.Context, request PlanRequest, token stri
 		if request.IncludeDependencies {
 			err = l.StartServicesContext(ctx, plan.Targets)
 		} else {
-			err = l.ForceStartServices(plan.Targets)
+			err = l.ForceStartServicesContext(ctx, plan.Targets)
 		}
 	case "stop":
 		err = l.StopServices(plan.Targets)
 	case "restart":
-		err = l.RestartServices(plan.Targets)
+		err = l.RestartServicesContext(ctx, plan.Targets)
 	case "action":
 		var actionResult ActionResult
 		// A delivery request is only waiting for an action result; it does not

--- a/internal/app/reload.go
+++ b/internal/app/reload.go
@@ -84,6 +84,7 @@ func (l *Local) Reload(force bool) (ReloadResult, error) {
 	l.loadedAt = time.Now()
 	l.lastReloadErr = ""
 	l.cfgMu.Unlock()
+	l.manager.RecordConfigReload(generation, result.Restarted)
 	l.recordReloadTransition(generation, result)
 	if stamps, err := readConfigStamps(l.watchPathsSnapshot()); err == nil {
 		l.recordReloadStamps(stamps)

--- a/internal/app/types.go
+++ b/internal/app/types.go
@@ -37,6 +37,21 @@ type (
 	ActionBusyError       = service.ActionBusyError
 	ActionExitError       = service.ActionExitError
 	ActionRunEvictedError = service.ActionRunEvictedError
+	RunKind               = service.RunKind
+	RunTarget             = service.RunTarget
+	RunOutputState        = service.RunOutputState
+	RunOutputSummary      = service.RunOutputSummary
+	RunSummary            = service.RunSummary
+)
+
+const (
+	RunKindService = service.RunKindService
+	RunKindAction  = service.RunKindAction
+)
+
+var (
+	ServiceRunTarget = service.ServiceRunTarget
+	ActionRunTarget  = service.ActionRunTarget
 )
 
 // Re-exported so a caller never has to import internal/service for a

--- a/internal/cli/tree.go
+++ b/internal/cli/tree.go
@@ -122,6 +122,7 @@ func DefaultTree() *Command {
 		{Name: "list", Summary: "list services, actions, or tags", Usage: "kranz list [services|actions|tags]"},
 		{Name: "info", Summary: "show project or service details", Usage: "kranz info [SERVICE]"},
 		{Name: "status", Summary: "show runtime status", Usage: "kranz status [SELECTOR ...]"},
+		{Name: "runs", Summary: "list retained service and action runs", Usage: "kranz runs [TARGET ...]"},
 		{Name: "plan", Summary: "show the resolved start plan", Usage: "kranz plan [SELECTOR ...]"},
 		{Name: "graph", Summary: "print the dependency graph", Usage: "kranz graph [--format text|json|dot]", Options: []Option{
 			{Flags: "--format FORMAT", Summary: "text, json, or dot; defaults to text", Values: []string{"text", "json", "dot"}},

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -14,6 +14,7 @@ func (s *Server) installResources() {
 		{URI: "kranz://config", Name: "config", Title: "Redacted effective configuration", Description: "Effective config and provenance paths with secret-like environment values redacted.", MimeType: "application/json", handler: s.configResource},
 		{URI: "kranz://services", Name: "services", Title: "Services", Description: "Declared services and their live runtime snapshots.", MimeType: "application/json", handler: s.servicesResource},
 		{URI: "kranz://actions", Name: "actions", Title: "Actions", Description: "Service and project actions in declaration order.", MimeType: "application/json", handler: s.actionsResource},
+		{URI: "kranz://runs", Name: "runs", Title: "Run catalog", Description: "Bounded service and action run summaries with provenance and retention state.", MimeType: "application/json", handler: s.runsResource},
 		{URI: "kranz://graph", Name: "graph", Title: "Dependency and prerequisite graph", Description: "Nodes for services, action groups, and actions, with dependency, prerequisite, and ownership edges.", MimeType: "application/json", handler: s.graphResource},
 		{URI: "kranz://tags", Name: "tags", Title: "Service tags", Description: "The shared service/tag selector index.", MimeType: "application/json", handler: s.tagsResource},
 		{URI: "kranz://capabilities", Name: "capabilities", Title: "MCP capabilities", Description: "Explicit Kranz MCP allow-list and unavailable unsafe operations.", MimeType: "application/json", handler: s.capabilitiesResource},
@@ -23,6 +24,10 @@ func (s *Server) installResources() {
 		s.resources[definition.URI] = definition
 		s.resourceOrder = append(s.resourceOrder, definition.URI)
 	}
+}
+
+func (s *Server) runsResource(context.Context) ResultEnvelope {
+	return s.envelope(map[string]any{"runs": s.api.Runs()})
 }
 
 func (s *Server) envelope(data any) ResultEnvelope {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -330,8 +330,8 @@ func TestCapabilitySurfaceIsExactAllowList(t *testing.T) {
 			t.Fatalf("unsafe tool %q is reachable", forbidden)
 		}
 	}
-	if got := len(server.resourceOrder); got != 7 {
-		t.Fatalf("resources = %d, want 7", got)
+	if got := len(server.resourceOrder); got != 8 {
+		t.Fatalf("resources = %d, want 8", got)
 	}
 	for _, definition := range server.listTools() {
 		if definition.InputSchema["additionalProperties"] != false {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -25,7 +25,7 @@ const waitTransportGrace = 5 * time.Second
 // exactly, so a tool cannot appear without being listed here, and a listed
 // name cannot resolve to nothing.
 var toolNames = []string{
-	"status", "changes", "plan", "graph", "ports", "port_inspect", "logs", "wait", "health",
+	"status", "runs", "changes", "plan", "graph", "ports", "port_inspect", "logs", "wait", "health",
 	"action_list", "action_info", "action_result",
 	"doctor", "start", "stop", "restart", "action_run", "action_cancel", "logs_clear", "reload",
 }
@@ -46,6 +46,7 @@ var (
 func (s *Server) installTools() {
 	definitions := []toolDefinition{
 		{Name: "status", Description: "Return live status for selected services, including the structured cause of a state whose reason is not the state itself.", InputSchema: objectSchema(map[string]any{"selectors": selectorsProperty}), handler: s.statusTool},
+		{Name: "runs", Description: "Return the bounded service and action run catalog with provenance and output retention state.", InputSchema: objectSchema(map[string]any{}), handler: s.runsTool},
 		{Name: "changes", Description: "Return what changed in the runtime after a cursor: service and action transitions, detected-port changes, and configuration reloads.", InputSchema: objectSchema(map[string]any{
 			"since":            map[string]any{"type": "integer", "minimum": 0, "description": "Cursor from a previous changes or wait result. Zero reads the whole retained journal."},
 			"since_generation": map[string]any{"type": "integer", "minimum": 0, "description": "Alternative anchor: read everything after the reload that produced this configuration generation."},
@@ -89,6 +90,14 @@ func (s *Server) installTools() {
 			panic("MCP tool allow-list names an unimplemented tool: " + name)
 		}
 	}
+}
+
+func (s *Server) runsTool(_ context.Context, raw json.RawMessage) ResultEnvelope {
+	var args struct{}
+	if err := decodeArgs(raw, &args); err != nil {
+		return s.argError(err)
+	}
+	return s.envelope(map[string]any{"runs": s.api.Runs()})
 }
 
 func mutationSchema(includeDependencies bool) map[string]any {

--- a/internal/runtime/client.go
+++ b/internal/runtime/client.go
@@ -43,16 +43,29 @@ type Client struct {
 	doneOnce  sync.Once
 }
 
+type ClientIdentity struct {
+	Surface string
+	Label   string
+}
+
 // Dial connects to a Supervisor listening on socketPath and performs the
 // hello handshake. clientVersion is advertised to the server for its own
 // diagnostics; it does not affect protocol negotiation in this stream, since
 // client and server are always built from the same binary.
 func Dial(socketPath, clientVersion string) (*Client, error) {
-	return DialContext(context.Background(), socketPath, clientVersion)
+	return DialWithIdentity(socketPath, clientVersion, ClientIdentity{Surface: "cli", Label: "kranz CLI"})
+}
+
+func DialWithIdentity(socketPath, clientVersion string, identity ClientIdentity) (*Client, error) {
+	return DialContextWithIdentity(context.Background(), socketPath, clientVersion, identity)
 }
 
 // DialContext bounds both connection establishment and the hello handshake.
 func DialContext(ctx context.Context, socketPath, clientVersion string) (*Client, error) {
+	return DialContextWithIdentity(ctx, socketPath, clientVersion, ClientIdentity{Surface: "cli", Label: "kranz CLI"})
+}
+
+func DialContextWithIdentity(ctx context.Context, socketPath, clientVersion string, identity ClientIdentity) (*Client, error) {
 	conn, err := (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
 	if err != nil {
 		return nil, fmt.Errorf("dial %s: %w", socketPath, err)
@@ -77,7 +90,8 @@ func DialContext(ctx context.Context, socketPath, clientVersion string) (*Client
 		return nil, err
 	}
 
-	helloBody, err := json.Marshal(helloRequest{ProtocolMin: protocolVersion, ProtocolMax: protocolVersion, ClientVersion: clientVersion})
+	helloBody, err := json.Marshal(helloRequest{ProtocolMin: protocolVersion, ProtocolMax: protocolVersion,
+		ClientVersion: clientVersion, Surface: identity.Surface, ClientLabel: identity.Label})
 	if err != nil {
 		_ = conn.Close()
 		return nil, err
@@ -347,7 +361,11 @@ func (c *Client) ForceStopServices(names []string) error {
 }
 
 func (c *Client) ForceStartServices(names []string) error {
-	_, err := call[namesRequest, emptyResponse](c, context.Background(), methodForceStartServices, namesRequest{Names: names})
+	return c.ForceStartServicesContext(context.Background(), names)
+}
+
+func (c *Client) ForceStartServicesContext(ctx context.Context, names []string) error {
+	_, err := call[namesRequest, emptyResponse](c, ctx, methodForceStartServices, namesRequest{Names: names})
 	return err
 }
 
@@ -408,7 +426,11 @@ func (c *Client) CancelAction(id config.ActionID) bool {
 }
 
 func (c *Client) AcquireInteractiveAction(id config.ActionID) (config.Action, string, error) {
-	resp, err := call[actionIDRequest, acquireInteractiveActionResponse](c, context.Background(), methodAcquireInteractiveAction, actionIDRequest{ID: id})
+	return c.AcquireInteractiveActionContext(context.Background(), id)
+}
+
+func (c *Client) AcquireInteractiveActionContext(ctx context.Context, id config.ActionID) (config.Action, string, error) {
+	resp, err := call[actionIDRequest, acquireInteractiveActionResponse](c, ctx, methodAcquireInteractiveAction, actionIDRequest{ID: id})
 	return resp.Action, resp.Lease, err
 }
 
@@ -418,6 +440,11 @@ func (c *Client) CompleteInteractiveAction(id config.ActionID, lease string, exe
 		req.ExecErr = execErr.Error()
 	}
 	return call[completeInteractiveActionRequest, app.ActionResult](c, context.Background(), methodCompleteInteractiveAction, req)
+}
+
+func (c *Client) Runs() []app.RunSummary {
+	runs, _ := call[emptyRequest, []app.RunSummary](c, context.Background(), methodRuns, emptyRequest{})
+	return runs
 }
 
 func (c *Client) Logs(name string) []config.LogEntry {

--- a/internal/runtime/envelope.go
+++ b/internal/runtime/envelope.go
@@ -45,6 +45,8 @@ type helloRequest struct {
 	ProtocolMin   int    `json:"protocol_min"`
 	ProtocolMax   int    `json:"protocol_max"`
 	ClientVersion string `json:"client_version"`
+	Surface       string `json:"surface,omitempty"`
+	ClientLabel   string `json:"client_label,omitempty"`
 }
 
 // helloResponse is the server's answer once it has picked a protocol version

--- a/internal/runtime/handlers.go
+++ b/internal/runtime/handlers.go
@@ -105,20 +105,20 @@ var handlers = map[string]handlerFunc{
 	methodForceStopServices: handler(func(_ context.Context, l *app.Local, req namesRequest) (emptyResponse, error) {
 		return emptyResponse{}, l.ForceStopServices(req.Names)
 	}),
-	methodForceStartServices: handler(func(_ context.Context, l *app.Local, req namesRequest) (emptyResponse, error) {
-		return emptyResponse{}, l.ForceStartServices(req.Names)
+	methodForceStartServices: handler(func(ctx context.Context, l *app.Local, req namesRequest) (emptyResponse, error) {
+		return emptyResponse{}, l.ForceStartServicesContext(ctx, req.Names)
 	}),
 	methodStopAll: handler(func(_ context.Context, l *app.Local, _ emptyRequest) (emptyResponse, error) {
 		return emptyResponse{}, l.StopAll()
 	}),
-	methodRestartAll: handler(func(_ context.Context, l *app.Local, _ emptyRequest) (emptyResponse, error) {
-		return emptyResponse{}, l.RestartAll()
+	methodRestartAll: handler(func(ctx context.Context, l *app.Local, _ emptyRequest) (emptyResponse, error) {
+		return emptyResponse{}, l.RestartAllContext(ctx)
 	}),
-	methodRestartService: handler(func(_ context.Context, l *app.Local, req nameRequest) (emptyResponse, error) {
-		return emptyResponse{}, l.RestartService(req.Name)
+	methodRestartService: handler(func(ctx context.Context, l *app.Local, req nameRequest) (emptyResponse, error) {
+		return emptyResponse{}, l.RestartServicesContext(ctx, []string{req.Name})
 	}),
-	methodRestartServices: handler(func(_ context.Context, l *app.Local, req namesRequest) (emptyResponse, error) {
-		return emptyResponse{}, l.RestartServices(req.Names)
+	methodRestartServices: handler(func(ctx context.Context, l *app.Local, req namesRequest) (emptyResponse, error) {
+		return emptyResponse{}, l.RestartServicesContext(ctx, req.Names)
 	}),
 	methodHasRunningServices: handler(func(_ context.Context, l *app.Local, _ emptyRequest) (boolResponse, error) {
 		return boolResponse{Value: l.HasRunningServices()}, nil
@@ -143,8 +143,8 @@ var handlers = map[string]handlerFunc{
 	methodCancelAction: handler(func(_ context.Context, l *app.Local, req actionIDRequest) (cancelActionResponse, error) {
 		return cancelActionResponse{Cancelled: l.CancelAction(req.ID)}, nil
 	}),
-	methodAcquireInteractiveAction: handler(func(_ context.Context, l *app.Local, req actionIDRequest) (acquireInteractiveActionResponse, error) {
-		action, lease, err := l.AcquireInteractiveAction(req.ID)
+	methodAcquireInteractiveAction: handler(func(ctx context.Context, l *app.Local, req actionIDRequest) (acquireInteractiveActionResponse, error) {
+		action, lease, err := l.AcquireInteractiveActionContext(ctx, req.ID)
 		return acquireInteractiveActionResponse{Action: action, Lease: lease}, err
 	}),
 	methodCompleteInteractiveAction: handler(func(_ context.Context, l *app.Local, req completeInteractiveActionRequest) (app.ActionResult, error) {
@@ -153,6 +153,9 @@ var handlers = map[string]handlerFunc{
 			execErr = fmt.Errorf("%s", req.ExecErr)
 		}
 		return l.CompleteInteractiveAction(req.ID, req.Lease, execErr, req.ExitCode, req.PID)
+	}),
+	methodRuns: handler(func(_ context.Context, l *app.Local, _ emptyRequest) ([]app.RunSummary, error) {
+		return l.Runs(), nil
 	}),
 	methodActionLogs: handler(func(_ context.Context, l *app.Local, req actionIDRequest) (logsResponse, error) {
 		return logsResponse{Entries: l.ActionLogs(req.ID)}, nil

--- a/internal/runtime/integration_test.go
+++ b/internal/runtime/integration_test.go
@@ -17,6 +17,10 @@ import (
 // tears both down. It is the RPC-boundary equivalent of the manual smoke
 // test поток 1 ran by hand against examples/*/kranz.yaml.
 func startTestSupervisor(t *testing.T, cfg *config.Config, configPaths []string) (*Client, func()) {
+	return startTestSupervisorIdentity(t, cfg, configPaths, ClientIdentity{Surface: "cli", Label: "kranz CLI"})
+}
+
+func startTestSupervisorIdentity(t *testing.T, cfg *config.Config, configPaths []string, identity ClientIdentity) (*Client, func()) {
 	t.Helper()
 	local := app.NewLocal(cfg, configPaths, app.Options{})
 	supervisor := NewSupervisor(local)
@@ -36,7 +40,7 @@ func startTestSupervisor(t *testing.T, cfg *config.Config, configPaths []string)
 	var client *Client
 	deadline := time.Now().Add(2 * time.Second)
 	for {
-		client, err = Dial(socketPath, "test")
+		client, err = DialWithIdentity(socketPath, "test", identity)
 		if err == nil {
 			break
 		}
@@ -216,6 +220,26 @@ func TestSupervisorClientRunNonInteractiveAction(t *testing.T) {
 	state, ok := client.ActionState(id)
 	if !ok || state.Status != app.ActionSucceeded {
 		t.Fatalf("action state = %#v, ok=%v", state, ok)
+	}
+}
+
+func TestRunCatalogPreservesConnectionProvenanceAcrossRPC(t *testing.T) {
+	cfg := &config.Config{Project: "RPC provenance", ActionGroups: map[string]config.ActionGroup{
+		"ops": {Actions: map[string]config.Action{"ping": {Command: "echo pong"}}},
+	}}
+	client, cleanup := startTestSupervisorIdentity(t, cfg, nil, ClientIdentity{Surface: "mcp", Label: "agent session"})
+	defer cleanup()
+
+	id := config.ActionID{OwnerKind: config.ActionOwnerGroup, Owner: "ops", Name: "ping"}
+	if _, err := client.RunAction(context.Background(), id); err != nil {
+		t.Fatal(err)
+	}
+	runs := client.Runs()
+	if len(runs) != 1 {
+		t.Fatalf("runs = %#v, want one", runs)
+	}
+	if runs[0].Surface != "mcp" || runs[0].ClientLabel != "agent session" || runs[0].StartReason != "invoked" {
+		t.Fatalf("run provenance = %+v", runs[0])
 	}
 }
 

--- a/internal/runtime/messages.go
+++ b/internal/runtime/messages.go
@@ -50,6 +50,7 @@ const (
 	methodCancelAction                    = "cancelAction"
 	methodAcquireInteractiveAction        = "acquireInteractiveAction"
 	methodCompleteInteractiveAction       = "completeInteractiveAction"
+	methodRuns                            = "runs"
 	methodActionLogs                      = "actionLogs"
 	methodQueryLogs                       = "queryLogs"
 	methodClearLogStreams                 = "clearLogStreams"

--- a/internal/runtime/supervisor.go
+++ b/internal/runtime/supervisor.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kranz-org/kranz/internal/app"
 	"github.com/kranz-org/kranz/internal/config"
+	"github.com/kranz-org/kranz/internal/service"
 )
 
 // backgroundReloadInterval is how often the Supervisor's own watcher checks
@@ -194,7 +195,8 @@ func (s *Supervisor) handleConn(conn *net.UnixConn) {
 	}
 
 	c := newCodec(conn)
-	if !s.handshake(c) {
+	provenance, ok := s.handshake(c)
+	if !ok {
 		return
 	}
 
@@ -219,7 +221,8 @@ func (s *Supervisor) handleConn(conn *net.UnixConn) {
 			}
 			pendingMu.Unlock()
 		case messageRequest:
-			ctx, cancel := context.WithCancel(context.Background())
+			base := service.WithRunProvenance(context.Background(), provenance)
+			ctx, cancel := context.WithCancel(base)
 			pendingMu.Lock()
 			pending[msg.ID] = cancel
 			pendingMu.Unlock()
@@ -297,14 +300,14 @@ func (l *connectionLeases) releaseAll(local *app.Local) {
 // server decodes before any method dispatch table applies, matching the
 // README's requirement that hello, inspect, and down stay readable across
 // protocol versions.
-func (s *Supervisor) handshake(c *codec) bool {
+func (s *Supervisor) handshake(c *codec) (service.RunProvenance, bool) {
 	msg, err := c.receive()
 	if err != nil || msg.Type != messageRequest || msg.Method != methodHello {
-		return false
+		return service.RunProvenance{}, false
 	}
 	var req helloRequest
 	if err := json.Unmarshal(msg.Body, &req); err != nil {
-		return false
+		return service.RunProvenance{}, false
 	}
 	if req.ProtocolMin > protocolVersion || req.ProtocolMax < protocolVersion {
 		payload := errorPayload{
@@ -318,7 +321,7 @@ func (s *Supervisor) handshake(c *codec) bool {
 		}
 		body, _ := json.Marshal(payload)
 		_ = c.send(envelope{Type: messageError, ID: msg.ID, Body: body})
-		return false
+		return service.RunProvenance{}, false
 	}
 	resp := helloResponse{
 		ProtocolMin: protocolVersion, ProtocolMax: protocolVersion,
@@ -326,9 +329,12 @@ func (s *Supervisor) handshake(c *codec) bool {
 	}
 	body, err := json.Marshal(resp)
 	if err != nil {
-		return false
+		return service.RunProvenance{}, false
 	}
-	return c.send(envelope{Type: messageResponse, ID: msg.ID, Body: body}) == nil
+	if c.send(envelope{Type: messageResponse, ID: msg.ID, Body: body}) != nil {
+		return service.RunProvenance{}, false
+	}
+	return service.RunProvenance{Surface: req.Surface, ClientLabel: req.ClientLabel}, true
 }
 
 func (s *Supervisor) dispatch(ctx context.Context, c *codec, msg envelope, leases *connectionLeases) {

--- a/internal/service/action.go
+++ b/internal/service/action.go
@@ -267,8 +267,12 @@ func (r *ActionRunner) RunDefinition(ctx context.Context, id config.ActionID, ac
 	r.nextRun[id] = run
 	r.states[id] = ActionResult{ID: id, Run: run, Status: ActionRunning, ExitCode: -1, StartedAt: started}
 	r.mu.Unlock()
+	provenance := RunProvenanceFromContext(ctx)
+	if provenance.StartReason == "" {
+		provenance.StartReason = "invoked"
+	}
 	r.catalog.Begin(RunSummary{Target: ActionRunTarget(id), Run: run, Status: ActionRunning.String(), StartedAt: started,
-		StartReason: "invoked"})
+		Surface: provenance.Surface, ClientLabel: provenance.ClientLabel, StartReason: provenance.StartReason})
 
 	stream := r.logStreamFor(id)
 	if stream != nil {
@@ -632,21 +636,15 @@ func (r *ActionRunner) ClearActionLogs(id config.ActionID) {
 
 // startOutputPump copies a process's captured output into stream until the
 // returned stop function is called, which sweeps whatever arrived last. It
-// reads by offset rather than draining, so the ActionResult snapshot the caller
-// builds from the same buffers stays complete.
+// drains only the canonical capture queue; per-source buffers remain intact for
+// the ActionResult snapshot the caller builds at completion.
 func startOutputPump(stream *logStream, process *ProcessManager) func() {
 	if stream == nil || process == nil {
 		return func() {}
 	}
-	stdoutOffset, stderrOffset := 0, 0
 	sweep := func() {
-		lines := process.Stdout().Lines()
-		for ; stdoutOffset < len(lines); stdoutOffset++ {
-			stream.Append(time.Now(), "stdout", lines[stdoutOffset])
-		}
-		lines = process.Stderr().Lines()
-		for ; stderrOffset < len(lines); stderrOffset++ {
-			stream.Append(time.Now(), "stderr", lines[stderrOffset])
+		for _, entry := range process.DrainCapturedOutput() {
+			stream.Append(entry.CapturedAt, entry.Source, entry.Text)
 		}
 	}
 	done, finished := make(chan struct{}), make(chan struct{})
@@ -663,8 +661,8 @@ func startOutputPump(stream *logStream, process *ProcessManager) func() {
 			}
 		}
 	}()
-	// The offsets are owned by the pump goroutine; the final sweep runs only
-	// after it has exited, so the two never advance them concurrently.
+	// The capture queue has one consumer; the final sweep runs only after the
+	// pump goroutine exits, so the two never drain concurrently.
 	return func() {
 		close(done)
 		<-finished

--- a/internal/service/action_interactive.go
+++ b/internal/service/action_interactive.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -59,7 +60,7 @@ func (r *ActionRunner) PrepareInteractive(id config.ActionID) (*exec.Cmd, func(e
 	r.states[id] = ActionResult{ID: id, Run: run, Status: ActionRunning, ExitCode: -1, StartedAt: started}
 	r.mu.Unlock()
 	r.catalog.Begin(RunSummary{Target: ActionRunTarget(id), Run: run, Status: ActionRunning.String(), StartedAt: started,
-		StartReason: "interactive handoff"})
+		Surface: "tui", ClientLabel: "interactive terminal", StartReason: "interactive_handoff"})
 
 	finish := func(runErr error) ActionResult {
 		result := ActionResult{
@@ -101,6 +102,10 @@ func (r *ActionRunner) PrepareInteractive(id config.ActionID) (*exec.Cmd, func(e
 // opaque lease token; CompleteInteractive finishes the accounting once the
 // caller has run the command itself and observed its outcome.
 func (r *ActionRunner) AcquireInteractive(id config.ActionID) (config.Action, string, error) {
+	return r.AcquireInteractiveContext(context.Background(), id)
+}
+
+func (r *ActionRunner) AcquireInteractiveContext(ctx context.Context, id config.ActionID) (config.Action, string, error) {
 	r.mu.Lock()
 	if r.shuttingDown {
 		r.mu.Unlock()
@@ -134,8 +139,12 @@ func (r *ActionRunner) AcquireInteractive(id config.ActionID) (config.Action, st
 	r.nextRun[id] = run
 	r.states[id] = ActionResult{ID: id, Run: run, Status: ActionRunning, ExitCode: -1, StartedAt: started}
 	r.mu.Unlock()
+	provenance := RunProvenanceFromContext(ctx)
+	if provenance.StartReason == "" {
+		provenance.StartReason = "interactive_handoff"
+	}
 	r.catalog.Begin(RunSummary{Target: ActionRunTarget(id), Run: run, Status: ActionRunning.String(), StartedAt: started,
-		StartReason: "interactive handoff"})
+		Surface: provenance.Surface, ClientLabel: provenance.ClientLabel, StartReason: provenance.StartReason})
 	return action, lease, nil
 }
 
@@ -203,7 +212,11 @@ func (m *Manager) PrepareInteractiveAction(id config.ActionID) (*exec.Cmd, func(
 // AcquireInteractiveAction reserves an interactive action for a delivery
 // surface that runs the command itself, out of process from the runtime.
 func (m *Manager) AcquireInteractiveAction(id config.ActionID) (config.Action, string, error) {
-	return m.actions.AcquireInteractive(id)
+	return m.AcquireInteractiveActionContext(context.Background(), id)
+}
+
+func (m *Manager) AcquireInteractiveActionContext(ctx context.Context, id config.ActionID) (config.Action, string, error) {
+	return m.actions.AcquireInteractiveContext(ctx, id)
 }
 
 // CompleteInteractiveAction finishes an AcquireInteractiveAction lease with

--- a/internal/service/manager.go
+++ b/internal/service/manager.go
@@ -51,6 +51,22 @@ func (m *Manager) RunSummaries(target RunTarget) []RunSummary { return m.runs.Li
 
 func (m *Manager) AllRunSummaries() []RunSummary { return m.runs.All() }
 
+// RecordConfigReload marks a new configuration generation inside every
+// continuing service run. Services restarted by ApplyConfig get a new run and
+// therefore do not receive a marker that would imply process continuity.
+func (m *Manager) RecordConfigReload(generation uint64, restarted []string) {
+	restartedSet := make(map[string]bool, len(restarted))
+	for _, name := range restarted {
+		restartedSet[name] = true
+	}
+	for _, svc := range m.Services() {
+		if restartedSet[svc.Name] || svc.Run() == 0 || svc.Status() == config.StatusStopped {
+			continue
+		}
+		svc.AppendLog(fmt.Sprintf("[Kranz] Config reloaded · generation %d", generation))
+	}
+}
+
 // newService constructs a service already attached to this manager's journal,
 // so no construction path can produce a service whose changes go unrecorded.
 func (m *Manager) newService(name string, cfg config.Service) *Service {

--- a/internal/service/manager_process.go
+++ b/internal/service/manager_process.go
@@ -124,11 +124,8 @@ func (m *Manager) ProjectExitRequested() (bool, int) {
 }
 
 func (m *Manager) drainProcessLogs(svc *Service, pm *ProcessManager) {
-	for _, line := range pm.Stdout().Drain() {
-		svc.AppendLogAtSource(time.Now(), "stdout", line)
-	}
-	for _, line := range pm.Stderr().Drain() {
-		svc.AppendLogAtSource(time.Now(), "stderr", line)
+	for _, entry := range pm.DrainCapturedOutput() {
+		svc.AppendLogAtSource(entry.CapturedAt, entry.Source, entry.Text)
 	}
 }
 

--- a/internal/service/manager_start.go
+++ b/internal/service/manager_start.go
@@ -27,6 +27,16 @@ func (m *Manager) startService(ctx context.Context, name string, recovery bool) 
 	if !ok {
 		return fmt.Errorf("service %q not found", name)
 	}
+	provenance := RunProvenanceFromContext(ctx)
+	if recovery {
+		provenance = RunProvenance{Surface: "runtime", ClientLabel: "availability policy", StartReason: "automatic_restart"}
+	} else if provenance.StartReason == "" {
+		if svc.stream.LastRun() == 0 {
+			provenance.StartReason = "first_start"
+		} else {
+			provenance.StartReason = "manual_start"
+		}
+	}
 	svc.lifecycleMu.Lock()
 	defer svc.lifecycleMu.Unlock()
 	if svc.Config.IsDetached() {
@@ -36,6 +46,7 @@ func (m *Manager) startService(ctx context.Context, name string, recovery bool) 
 		if err := m.runPrerequisites(ctx, svc); err != nil {
 			return err
 		}
+		svc.SetNextRunProvenance(provenance)
 		return m.startDetachedService(ctx, svc)
 	}
 
@@ -84,6 +95,7 @@ func (m *Manager) startService(ctx context.Context, name string, recovery bool) 
 		}
 	}
 
+	svc.SetNextRunProvenance(provenance)
 	svc.SetStatus(config.StatusStarting)
 	svc.AppendLog("[Kranz] Starting")
 
@@ -237,6 +249,10 @@ func (m *Manager) StartServices(names []string) error {
 // checks still apply.
 
 func (m *Manager) ForceStartServices(names []string) error {
+	return m.ForceStartServicesContext(context.Background(), names)
+}
+
+func (m *Manager) ForceStartServicesContext(ctx context.Context, names []string) error {
 	unique := make([]string, 0, len(names))
 	seen := make(map[string]bool, len(names))
 	for _, name := range names {
@@ -256,7 +272,7 @@ func (m *Manager) ForceStartServices(names []string) error {
 		if !svc.CanStart() {
 			continue
 		}
-		if err := m.StartService(name); err != nil {
+		if err := m.startService(ctx, name, false); err != nil {
 			wrapped := fmt.Errorf("%s: %w", name, err)
 			startErrors = append(startErrors, wrapped)
 			svc.AppendLog(fmt.Sprintf("[Kranz] Force start failed: %v", err))
@@ -381,13 +397,17 @@ func (m *Manager) StartByTags(tags []string) error {
 // StopAll stops every service in reverse dependency order.
 
 func (m *Manager) RestartService(name string) error {
-	return m.RestartServices([]string{name})
+	return m.RestartServicesContext(context.Background(), []string{name})
 }
 
 // RestartServices performs one stop/start plan while holding the reload lock,
 // so a watcher reload cannot split a multi-selector CLI request across config
 // generations.
 func (m *Manager) RestartServices(names []string) error {
+	return m.RestartServicesContext(context.Background(), names)
+}
+
+func (m *Manager) RestartServicesContext(ctx context.Context, names []string) error {
 	// Hold reloadMu for the whole operation so a concurrent config reload
 	// cannot swap or remove services mid-restart out from under this plan.
 	m.reloadMu.Lock()
@@ -426,8 +446,9 @@ func (m *Manager) RestartServices(names []string) error {
 	}
 
 	// Start dependencies before their dependents.
+	ctx = WithStartReason(ctx, "manual_restart")
 	for _, n := range affected {
-		if err := m.StartService(n); err != nil {
+		if err := m.startService(ctx, n, false); err != nil {
 			return fmt.Errorf("start service %q: %w", n, err)
 		}
 	}
@@ -438,6 +459,10 @@ func (m *Manager) RestartServices(names []string) error {
 // RestartAll restarts only services that were active when the operation began.
 
 func (m *Manager) RestartAll() error {
+	return m.RestartAllContext(context.Background())
+}
+
+func (m *Manager) RestartAllContext(ctx context.Context) error {
 	// See RestartService: block a concurrent reload for the whole operation.
 	m.reloadMu.Lock()
 	defer m.reloadMu.Unlock()
@@ -458,9 +483,10 @@ func (m *Manager) RestartAll() error {
 			}
 		}
 	}
+	ctx = WithStartReason(ctx, "manual_restart")
 	for _, name := range order {
 		if running[name] {
-			if err := m.StartService(name); err != nil {
+			if err := m.startService(ctx, name, false); err != nil {
 				return err
 			}
 		}

--- a/internal/service/process.go
+++ b/internal/service/process.go
@@ -16,22 +16,60 @@ import (
 
 // ProcessManager owns one child process and its bounded stdout/stderr buffers.
 type ProcessManager struct {
-	mu       sync.RWMutex
-	stopMu   sync.Mutex
-	cmd      *exec.Cmd
-	stdout   *ringbuffer.RingBuffer
-	stderr   *ringbuffer.RingBuffer
-	waitDone chan struct{}
-	waitErr  error
+	mu        sync.RWMutex
+	stopMu    sync.Mutex
+	outputMu  sync.Mutex
+	cmd       *exec.Cmd
+	stdout    *ringbuffer.RingBuffer
+	stderr    *ringbuffer.RingBuffer
+	output    []CapturedOutput
+	outputSeq uint64
+	waitDone  chan struct{}
+	waitErr   error
 }
 
-type ringBufferWriter struct {
-	buffer *ringbuffer.RingBuffer
+// CapturedOutput is one stdout/stderr write ordered at the instant Kranz
+// receives it. Consumers split Text into lines only after preserving Sequence.
+type CapturedOutput struct {
+	Sequence   uint64
+	CapturedAt time.Time
+	Source     string
+	Text       string
 }
 
-func (w ringBufferWriter) Write(data []byte) (int, error) {
-	w.buffer.Write(string(data))
+type processOutputWriter struct {
+	process *ProcessManager
+	buffer  *ringbuffer.RingBuffer
+	source  string
+}
+
+func (w processOutputWriter) Write(data []byte) (int, error) {
+	text := string(data)
+	w.process.captureOutput(w.buffer, w.source, text)
 	return len(data), nil
+}
+
+func (pm *ProcessManager) captureOutput(buffer *ringbuffer.RingBuffer, source, text string) {
+	pm.outputMu.Lock()
+	// The same lock serializes both per-source retention and canonical capture,
+	// so a goroutine cannot publish its stdout chunk and then lose the sequence
+	// race to a later stderr chunk before recording the shared order.
+	buffer.Write(text)
+	pm.outputSeq++
+	pm.output = append(pm.output, CapturedOutput{
+		Sequence: pm.outputSeq, CapturedAt: time.Now(), Source: source, Text: text,
+	})
+	pm.outputMu.Unlock()
+}
+
+// DrainCapturedOutput returns stdout and stderr writes in canonical capture
+// order. The per-source buffers remain intact for action result snapshots.
+func (pm *ProcessManager) DrainCapturedOutput() []CapturedOutput {
+	pm.outputMu.Lock()
+	defer pm.outputMu.Unlock()
+	entries := append([]CapturedOutput(nil), pm.output...)
+	pm.output = pm.output[:0]
+	return entries
 }
 
 // StopOptions customizes graceful shutdown for one process.
@@ -81,8 +119,8 @@ func (pm *ProcessManager) Start(ctx context.Context, command, dir string, env ma
 
 	// Non-file writers make os/exec own the stream-copy goroutines. Wait then
 	// cannot complete until both streams have been copied into their buffers.
-	cmd.Stdout = ringBufferWriter{buffer: pm.stdout}
-	cmd.Stderr = ringBufferWriter{buffer: pm.stderr}
+	cmd.Stdout = processOutputWriter{process: pm, buffer: pm.stdout, source: "stdout"}
+	cmd.Stderr = processOutputWriter{process: pm, buffer: pm.stderr, source: "stderr"}
 
 	if err := cmd.Start(); err != nil {
 		return 0, fmt.Errorf("start process: %w", err)

--- a/internal/service/process_test.go
+++ b/internal/service/process_test.go
@@ -46,6 +46,32 @@ func TestProcessManagerWaitIncludesShortLivedOutput(t *testing.T) {
 	}
 }
 
+func TestProcessManagerCapturesStdoutAndStderrInOneSequence(t *testing.T) {
+	pm := NewProcessManager(32)
+	stdout := processOutputWriter{process: pm, buffer: pm.stdout, source: "stdout"}
+	stderr := processOutputWriter{process: pm, buffer: pm.stderr, source: "stderr"}
+	_, _ = stdout.Write([]byte("out one"))
+	_, _ = stderr.Write([]byte("err one"))
+	_, _ = stdout.Write([]byte("out two"))
+
+	entries := pm.DrainCapturedOutput()
+	if len(entries) != 3 {
+		t.Fatalf("captured entries = %#v", entries)
+	}
+	wantSources := []string{"stdout", "stderr", "stdout"}
+	for index, entry := range entries {
+		if entry.Sequence != uint64(index+1) || entry.Source != wantSources[index] || entry.CapturedAt.IsZero() {
+			t.Fatalf("entry %d = %#v", index, entry)
+		}
+	}
+	if remaining := pm.DrainCapturedOutput(); len(remaining) != 0 {
+		t.Fatalf("second drain = %#v", remaining)
+	}
+	if got := strings.Join(pm.Stdout().Lines(), ""); got != "out oneout two" {
+		t.Fatalf("stdout snapshot = %q", got)
+	}
+}
+
 func TestProcessManagerUsesUnixSignalExitConvention(t *testing.T) {
 	pm := NewProcessManager(32)
 	if _, err := pm.Start(context.Background(), "kill -TERM $$", ".", nil, "sh"); err != nil {

--- a/internal/service/run_catalog.go
+++ b/internal/service/run_catalog.go
@@ -68,7 +68,8 @@ type RunSummary struct {
 	PID         int                `json:"pid,omitempty"`
 	ExitCode    *int               `json:"exit_code,omitempty"`
 	Cause       *config.StateCause `json:"cause,omitempty"`
-	Initiator   string             `json:"initiator,omitempty"`
+	Surface     string             `json:"surface"`
+	ClientLabel string             `json:"client_label,omitempty"`
 	StartReason string             `json:"start_reason,omitempty"`
 	Live        bool               `json:"live"`
 	Output      RunOutputSummary   `json:"output"`

--- a/internal/service/run_catalog_test.go
+++ b/internal/service/run_catalog_test.go
@@ -158,3 +158,24 @@ func TestDetachedServiceRunStaysLiveAfterStartAction(t *testing.T) {
 		t.Fatalf("stopped detached summary = %#v", runs)
 	}
 }
+
+func TestConfigReloadMarkerStaysInsideContinuingRun(t *testing.T) {
+	manager := NewManager(&config.Config{Services: map[string]config.Service{
+		"api": {Command: "sleep 30", Shell: "/bin/sh"},
+	}})
+	t.Cleanup(func() { _ = manager.Shutdown() })
+	ctx := WithRunProvenance(t.Context(), RunProvenance{Surface: "tui", ClientLabel: "dashboard"})
+	if err := manager.StartServicesContext(ctx, []string{"api"}); err != nil {
+		t.Fatal(err)
+	}
+	manager.RecordConfigReload(2, nil)
+	svc, _ := manager.GetService("api")
+	entries := svc.LogEntries()
+	if len(entries) == 0 || entries[len(entries)-1].Run != 1 || entries[len(entries)-1].Raw != "[Kranz] Config reloaded · generation 2" {
+		t.Fatalf("reload marker entries = %#v", entries)
+	}
+	runs := manager.RunSummaries(ServiceRunTarget("api"))
+	if len(runs) != 1 || runs[0].Run != 1 || runs[0].Surface != "tui" || runs[0].ClientLabel != "dashboard" || runs[0].StartReason != "first_start" {
+		t.Fatalf("continuing run = %#v", runs)
+	}
+}

--- a/internal/service/run_provenance.go
+++ b/internal/service/run_provenance.go
@@ -1,0 +1,61 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"unicode"
+)
+
+const maxRunClientLabelRunes = 80
+
+// RunProvenance records which delivery surface initiated work and why. Client
+// labels are deliberately short, stable product labels rather than socket,
+// process, user, or request identifiers that could disclose local details.
+type RunProvenance struct {
+	Surface     string `json:"surface"`
+	ClientLabel string `json:"client_label,omitempty"`
+	StartReason string `json:"start_reason,omitempty"`
+}
+
+type runProvenanceContextKey struct{}
+
+func WithRunProvenance(ctx context.Context, provenance RunProvenance) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, runProvenanceContextKey{}, normalizeRunProvenance(provenance))
+}
+
+func RunProvenanceFromContext(ctx context.Context) RunProvenance {
+	if ctx != nil {
+		if provenance, ok := ctx.Value(runProvenanceContextKey{}).(RunProvenance); ok {
+			return normalizeRunProvenance(provenance)
+		}
+	}
+	return RunProvenance{Surface: "runtime"}
+}
+
+func WithStartReason(ctx context.Context, reason string) context.Context {
+	provenance := RunProvenanceFromContext(ctx)
+	provenance.StartReason = reason
+	return WithRunProvenance(ctx, provenance)
+}
+
+func normalizeRunProvenance(provenance RunProvenance) RunProvenance {
+	switch provenance.Surface {
+	case "tui", "cli", "mcp", "runtime":
+	default:
+		provenance.Surface = "runtime"
+	}
+	label := []rune(strings.TrimSpace(strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, provenance.ClientLabel)))
+	if len(label) > maxRunClientLabelRunes {
+		label = label[:maxRunClientLabelRunes]
+	}
+	provenance.ClientLabel = string(label)
+	return provenance
+}

--- a/internal/service/run_provenance_test.go
+++ b/internal/service/run_provenance_test.go
@@ -1,0 +1,19 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestRunProvenanceSanitizesUntrustedClientIdentity(t *testing.T) {
+	provenance := RunProvenanceFromContext(WithRunProvenance(context.Background(), RunProvenance{
+		Surface: "socket", ClientLabel: "  agent\n" + strings.Repeat("x", 100),
+	}))
+	if provenance.Surface != "runtime" {
+		t.Fatalf("surface = %q", provenance.Surface)
+	}
+	if strings.ContainsAny(provenance.ClientLabel, "\r\n") || len([]rune(provenance.ClientLabel)) != maxRunClientLabelRunes {
+		t.Fatalf("unsafe label = %q", provenance.ClientLabel)
+	}
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -21,8 +21,9 @@ type Service struct {
 	State   config.ServiceState
 	stateMu sync.RWMutex
 
-	stream  *logStream
-	catalog *RunCatalog
+	stream            *logStream
+	catalog           *RunCatalog
+	nextRunProvenance RunProvenance
 
 	// journal records this service's transitions for readers that need what
 	// happened rather than what is. It is nil for services constructed outside
@@ -165,6 +166,12 @@ func (s *Service) SetRunCatalog(catalog *RunCatalog) {
 	s.stream.SetCatalog(catalog, ServiceRunTarget(s.Name))
 }
 
+func (s *Service) SetNextRunProvenance(provenance RunProvenance) {
+	s.stateMu.Lock()
+	s.nextRunProvenance = normalizeRunProvenance(provenance)
+	s.stateMu.Unlock()
+}
+
 // SetStatus atomically updates lifecycle status and transition timestamps, and
 // records the transition. Every lifecycle path funnels through here, so the
 // journal cannot miss a change some other path made.
@@ -185,8 +192,11 @@ func (s *Service) SetStatus(status config.ServiceStatus) {
 		s.State.ExitCode = 0
 		s.State.ExitError = ""
 		s.State.Cause = nil
+		provenance := normalizeRunProvenance(s.nextRunProvenance)
+		s.nextRunProvenance = RunProvenance{}
 		s.catalog.Begin(RunSummary{Target: ServiceRunTarget(s.Name), Run: s.State.Run, Status: status.String(),
-			StartedAt: s.State.StartedAt, StartReason: "start"})
+			StartedAt: s.State.StartedAt, Surface: provenance.Surface, ClientLabel: provenance.ClientLabel,
+			StartReason: provenance.StartReason})
 	}
 	if status == config.StatusRunning && s.State.StartedAt.IsZero() {
 		s.State.StartedAt = time.Now()


### PR DESCRIPTION
## Summary
- preserve canonical stdout/stderr capture order with sequence and timestamps
- carry safe TUI/CLI/MCP provenance and start reasons into service/action run summaries
- mark config reloads inside continuing runs without creating a new run
- expose the bounded catalog through runtime API, `kranz runs`, and MCP tool/resource

## Validation
- `go test -race ./...`
- `make lint`
- `kranz -p kranz-workspace action run development/build --output json`