### PR TITLE
feat: complete v0.10 run retention and export

### DIFF
--- a/cmd/kranz/logs.go
+++ b/cmd/kranz/logs.go
@@ -58,6 +58,9 @@ func runLogs(options kranzcli.GlobalOptions, args []string, stdout io.Writer) er
 	if err != nil {
 		return classifyLogQueryError(err)
 	}
+	if err := writeLogRetentionNotices(stdout, options.Output, result.Retention, parsed); err != nil {
+		return err
+	}
 	if err := writeLogEvents(stdout, options.Output, result.Events, parsed); err != nil {
 		return err
 	}
@@ -87,6 +90,19 @@ func runLogs(options kranzcli.GlobalOptions, args []string, stdout io.Writer) er
 			}
 		}
 	}
+}
+
+func writeLogRetentionNotices(stdout io.Writer, format kranzcli.OutputFormat, notices []app.RunOutputNotice, options logOptions) error {
+	if format == kranzcli.OutputJSON {
+		return nil
+	}
+	for _, notice := range notices {
+		marker := fmt.Sprintf("[Kranz] Output truncated · %s#%d · missing %d lines / %d bytes · retained %d lines / %d bytes", notice.Stream, notice.Run, notice.Output.MissingLines, notice.Output.MissingBytes, notice.Output.RetainedLines, notice.Output.RetainedBytes)
+		if _, err := fmt.Fprintln(stdout, logEventPrefix(app.LogEvent{Timestamp: time.Now(), Stream: notice.Stream, Run: notice.Run, Source: "kranz"}, options, true)+marker); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func runLogsClear(options kranzcli.GlobalOptions, args []string, stdout io.Writer) error {
@@ -274,13 +290,10 @@ func parseLogSources(value string) ([]string, error) {
 
 const logTimestampLayout = "2006-01-02T15:04:05.000Z07:00"
 
-// logEventLabel names the stream a line came from, and its run when the run is
-// what distinguishes it. An action's output is always read as one numbered
-// invocation among several, so it always carries the number; a service reads
-// as one continuous stream, and the number is noise until the window actually
-// spans more than one start.
-func logEventLabel(event app.LogEvent, showRun bool) string {
-	if event.Run > 0 && (event.Kind == "action" || showRun) {
+// logEventLabel always publishes the stable absolute run identity. Relative
+// selectors remain query syntax only; output never invents a second identity.
+func logEventLabel(event app.LogEvent, _ bool) string {
+	if event.Run > 0 {
 		return fmt.Sprintf("%s#%d %s", event.Stream, event.Run, event.Source)
 	}
 	return event.Stream + " " + event.Source

--- a/cmd/kranz/logs_test.go
+++ b/cmd/kranz/logs_test.go
@@ -71,8 +71,8 @@ func TestServiceRunAppearsOnlyWhenTheWindowSpansRuns(t *testing.T) {
 	if got := streamsSpanningRuns(single); got["api"] {
 		t.Error("one run must not be labelled as spanning")
 	}
-	if got := logEventLabel(single[0], false); got != "api stdout" {
-		t.Errorf("single-run label = %q", got)
+	if got := logEventLabel(single[0], false); got != "api#2 stdout" {
+		t.Errorf("stable single-run label = %q", got)
 	}
 	if got := streamsSpanningRuns(spanning); !got["api"] {
 		t.Error("two runs of one service must be labelled")

--- a/cmd/kranz/main_test.go
+++ b/cmd/kranz/main_test.go
@@ -327,7 +327,7 @@ func TestLogsSnapshotFollowAndClientInterrupt(t *testing.T) {
 	if code := execute([]string{"-p", name, "logs", "emitter"}, &stdout, &stderr); code != 0 {
 		t.Fatalf("logs exit=%d stderr=%s", code, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "[emitter stdout]") || !strings.Contains(stdout.String(), "[emitter stderr]") {
+	if !strings.Contains(stdout.String(), "[emitter#1 stdout]") || !strings.Contains(stdout.String(), "[emitter#1 stderr]") {
 		t.Fatalf("text logs lost identity:\n%s", stdout.String())
 	}
 	stdout.Reset()
@@ -354,7 +354,7 @@ func TestLogsSnapshotFollowAndClientInterrupt(t *testing.T) {
 	if err := follow.Wait(); err != nil {
 		t.Fatalf("follow interrupted with %v; stderr=%s", err, followErr.String())
 	}
-	if !strings.Contains(followOut.String(), "[emitter ") {
+	if !strings.Contains(followOut.String(), "[emitter#2 ") {
 		t.Fatalf("follow did not stream new events: %s", followOut.String())
 	}
 	stdout.Reset()

--- a/cmd/kranz/runs.go
+++ b/cmd/kranz/runs.go
@@ -18,10 +18,18 @@ func runRuns(options kranzcli.GlobalOptions, targets []string, stdout io.Writer)
 	}
 	defer closeClient()
 	runs := filterRuns(client.Runs(), targets)
+	retention := filterRunRetention(client.RunRetention(), targets)
 	if options.Output == kranzcli.OutputJSON {
-		return kranzcli.WriteJSON(stdout, runs)
+		return kranzcli.WriteJSON(stdout, struct {
+			Runs      []app.RunSummary           `json:"runs"`
+			Retention []app.RunRetentionBoundary `json:"retention"`
+		}{Runs: runs, Retention: retention})
 	}
 	w := tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
+	for _, boundary := range retention {
+		_, _ = fmt.Fprintf(w, "RETENTION\t%s\toldest #%d\t%d runs / %d entries / %d bytes\tevicted %d runs\n",
+			runTargetName(boundary.Target), boundary.OldestRetainedRun, boundary.MaxRuns, boundary.MaxEntries, boundary.MaxBytes, boundary.EvictedRuns)
+	}
 	_, _ = fmt.Fprintln(w, "RUN\tSTATUS\tSTARTED\tDURATION\tEXIT\tREASON\tINITIATOR\tOUTPUT")
 	for _, run := range runs {
 		exit := "-"
@@ -37,6 +45,23 @@ func runRuns(options kranzcli.GlobalOptions, targets []string, stdout io.Writer)
 			run.StartReason, runInitiator(run), run.Output.State)
 	}
 	return w.Flush()
+}
+
+func filterRunRetention(boundaries []app.RunRetentionBoundary, targets []string) []app.RunRetentionBoundary {
+	if len(targets) == 0 {
+		return boundaries
+	}
+	selected := make(map[string]bool, len(targets))
+	for _, target := range targets {
+		selected[strings.ToLower(target)] = true
+	}
+	result := make([]app.RunRetentionBoundary, 0, len(boundaries))
+	for _, boundary := range boundaries {
+		if selected[strings.ToLower(runTargetName(boundary.Target))] {
+			result = append(result, boundary)
+		}
+	}
+	return result
 }
 
 func runTargetName(target app.RunTarget) string {

--- a/cmd/kranz/runtime_commands.go
+++ b/cmd/kranz/runtime_commands.go
@@ -12,6 +12,7 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"text/tabwriter"
 	"time"
@@ -33,15 +34,33 @@ type runtimeHost struct {
 	closed        bool
 }
 
+// startRuntime changes the process working directory for the lifetime of an
+// in-process runtime. Serialize owners so a replacement cannot capture the
+// outgoing runtime's project directory as its restore point while Close is
+// still unwinding. That race left the test process (and an embedded caller)
+// inside a temp directory after it had been removed.
+var runtimeDirectoryMu sync.Mutex
+
 func startRuntime(options kranzcli.GlobalOptions, mode string) (*runtimeHost, *config.Config, error) {
+	runtimeDirectoryMu.Lock()
 	originalDirectory, err := os.Getwd()
 	if err != nil {
+		runtimeDirectoryMu.Unlock()
 		return nil, nil, err
 	}
+	var restoreOnce sync.Once
+	var restoreErr error
+	restore := func() error {
+		restoreOnce.Do(func() {
+			restoreErr = os.Chdir(originalDirectory)
+			runtimeDirectoryMu.Unlock()
+		})
+		return restoreErr
+	}
 	if err := os.Chdir(options.Directory); err != nil {
+		_ = restore()
 		return nil, nil, fmt.Errorf("change directory to %s: %w", options.Directory, err)
 	}
-	restore := func() error { return os.Chdir(originalDirectory) }
 	fail := func(err error) (*runtimeHost, *config.Config, error) { return nil, nil, errors.Join(err, restore()) }
 
 	cfgPaths := options.ConfigPaths

--- a/docs/guide/tui.md
+++ b/docs/guide/tui.md
@@ -118,6 +118,10 @@ runtime. A restart from either is reflected immediately in this TUI.
 | `s` | Start, stop with confirmation, or run a focused action |
 | `r` | Review and confirm a restart |
 | `/` | Search logs with a regular expression |
+| `x` | Toggle Combined/Single run logs |
+| `[` / `]` | Move to the previous/next run |
+| `v` | Open run history; filter and select with keyboard or mouse |
+| `e` / `Shift+E` | Export the selected run to clipboard / a chosen file |
 | `Ctrl+T` | Open the theme and appearance picker |
 | `Ctrl+L` | Reload configuration |
 | `?` | Open help |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -215,17 +215,22 @@ kranz logs analytics/stats --run -1       # the latest run
 kranz logs analytics/stats --run -2       # the run before it
 kranz logs analytics/stats --runs 3       # the last three runs
 kranz logs api --run -1                   # only the newest start of a service
+kranz runs                                # bounded catalog and retention limits
+kranz runs api analytics/stats            # narrow catalog by target
 ```
 
-A service reads as one continuous stream, so its lines are labelled with a run
-number only when the window you asked for spans more than one start. An action
-reads as one invocation among several and always carries its number.
+Every line carries its stable absolute identity (`api#7` or
+`analytics/stats#3`). Relative values are query syntax only and are never
+printed as identities.
 
 A positive `--run` is the absolute run number Kranz assigned. A negative one is
-an offset from the newest run still buffered, so `-1` keeps meaning "the latest"
-however many older runs have aged out, and `-2` is the one before it. Asking for
-a run that has already been evicted prints nothing rather than failing: the run
-is gone, not misnamed.
+an offset from the newest run in the independent run catalog, so `-1` keeps
+meaning "the latest" even after its output has aged out. When a retained run
+has lost its output prefix, text output prints the exact missing lines/bytes
+marker before the available tail. `kranz runs` publishes the oldest retained
+run, catalog/output budgets, evicted summary count, provenance, and output
+state (`complete`, `partial`, or `unavailable`). The catalog belongs to the
+live runtime session and is not restored after `down`.
 
 ### Actions
 

--- a/docs/reference/controls.md
+++ b/docs/reference/controls.md
@@ -48,6 +48,12 @@ directions.
 | `c` | Confirm clear focused logs |
 | `h` | Health history |
 | `n` | Notifications when highlight search is inactive |
+| `x` | Toggle Combined/Single run |
+| `[` / `]` | Previous/next run |
+| `Shift+F` / `l` | Previous failed run / latest run |
+| `v` | Open the filterable run list |
+| `Shift+3` | Pin the selected `{target, run, view mode}` snapshot |
+| `e` / `Shift+E` | Export selected run to clipboard / chosen file |
 
 ## Application
 

--- a/internal/app/api.go
+++ b/internal/app/api.go
@@ -133,6 +133,8 @@ type API interface {
 	CompleteInteractiveAction(id config.ActionID, lease string, execErr error, exitCode, pid int) (ActionResult, error)
 	// Runs returns the bounded run catalog independently from retained output.
 	Runs() []RunSummary
+	RunRetention() []RunRetentionBoundary
+	ExportRun(target RunTarget, run uint32) (RunExport, error)
 
 	// Logs returns the current buffered log entries for a service.
 	Logs(name string) []config.LogEntry

--- a/internal/app/local.go
+++ b/internal/app/local.go
@@ -357,6 +357,8 @@ func (l *Local) CompleteInteractiveAction(id config.ActionID, lease string, exec
 
 func (l *Local) Runs() []RunSummary { return l.manager.AllRunSummaries() }
 
+func (l *Local) RunRetention() []RunRetentionBoundary { return l.manager.RunRetentionBoundaries() }
+
 func (l *Local) Logs(name string) []config.LogEntry {
 	svc, ok := l.manager.GetService(name)
 	if !ok {

--- a/internal/app/logs.go
+++ b/internal/app/logs.go
@@ -62,11 +62,22 @@ type LogWindow struct {
 }
 
 type LogResult struct {
-	Events     []LogEvent `json:"events"`
-	Truncated  bool       `json:"truncated"`
-	NextCursor string     `json:"next_cursor,omitempty"`
-	Generation uint64     `json:"generation"`
-	Window     LogWindow  `json:"window"`
+	Events     []LogEvent        `json:"events"`
+	Retention  []RunOutputNotice `json:"retention,omitempty"`
+	Truncated  bool              `json:"truncated"`
+	NextCursor string            `json:"next_cursor,omitempty"`
+	Generation uint64            `json:"generation"`
+	Window     LogWindow         `json:"window"`
+}
+
+// RunOutputNotice makes a known retention gap observable without fabricating
+// log events. It is returned for every selected run whose captured prefix is
+// no longer available.
+type RunOutputNotice struct {
+	Stream    string           `json:"stream"`
+	Run       uint32           `json:"run"`
+	Output    RunOutputSummary `json:"output"`
+	OldestRun uint32           `json:"oldest_retained_run,omitempty"`
 }
 
 // LogQueryError provides a stable causal code without importing a delivery
@@ -142,6 +153,25 @@ func queryLogs(local *Local, query LogQuery) (LogResult, error) {
 		if target.isAction() {
 			entries = local.ActionLogs(target.action)
 		}
+		runTarget := serviceRunTargetForLogTarget(target)
+		summaries := local.manager.RunSummaries(runTarget)
+		low, high, selected := selectedRunRange(summaries, query.Run, query.Runs)
+		if query.Run != 0 || query.Runs != 0 {
+			entries = filterEntriesByRange(entries, low, high, selected)
+			for _, summary := range summaries {
+				if selected && summary.Run >= low && summary.Run <= high && summary.Output.MissingLines > 0 {
+					notice := RunOutputNotice{Stream: target.address, Run: summary.Run, Output: summary.Output}
+					for _, boundary := range local.manager.RunRetentionBoundaries() {
+						if boundary.Target == runTarget {
+							notice.OldestRun = boundary.OldestRetainedRun
+							break
+						}
+					}
+					result.Retention = append(result.Retention, notice)
+					result.Truncated = true
+				}
+			}
+		}
 		window := LogStreamWindow{Stream: target.address}
 		if len(entries) > 0 {
 			window.OldestSequence = entries[0].Sequence
@@ -154,7 +184,6 @@ func queryLogs(local *Local, query LogQuery) (LogResult, error) {
 			}
 		}
 		windows = append(windows, window)
-		entries = filterEntriesByRun(entries, query.Run, query.Runs)
 		for _, entry := range entries {
 			if entry.Sequence <= cursor.After[target.address] {
 				continue
@@ -294,24 +323,30 @@ func findActionID(cfg *config.Config, address string) (config.ActionID, bool) {
 	return config.ActionID{}, false
 }
 
-func filterEntriesByRun(entries []config.LogEntry, run, runs int) []config.LogEntry {
+func serviceRunTargetForLogTarget(target logTarget) RunTarget {
+	if target.isAction() {
+		return ActionRunTarget(target.action)
+	}
+	return ServiceRunTarget(target.service)
+}
+
+func selectedRunRange(summaries []RunSummary, run, runs int) (low, high uint32, ok bool) {
 	if run == 0 && runs == 0 {
-		return entries
+		return 0, 0, false
 	}
 	var latest uint32
-	for _, entry := range entries {
-		latest = max(latest, entry.Run)
+	for _, summary := range summaries {
+		latest = max(latest, summary.Run)
 	}
 	if latest == 0 {
-		return nil
+		return 0, 0, false
 	}
-	var low, high uint32
 	if run > 0 {
 		low, high = uint32(run), uint32(run)
 	} else if run < 0 {
 		offset := uint32(-run) - 1
 		if offset >= latest {
-			return nil
+			return 0, 0, false
 		}
 		low, high = latest-offset, latest-offset
 	} else {
@@ -321,6 +356,13 @@ func filterEntriesByRun(entries []config.LogEntry, run, runs int) []config.LogEn
 		} else {
 			low = latest - uint32(runs) + 1
 		}
+	}
+	return low, high, true
+}
+
+func filterEntriesByRange(entries []config.LogEntry, low, high uint32, ok bool) []config.LogEntry {
+	if !ok {
+		return nil
 	}
 	return slices.DeleteFunc(append([]config.LogEntry(nil), entries...), func(entry config.LogEntry) bool { return entry.Run < low || entry.Run > high })
 }

--- a/internal/app/logs_test.go
+++ b/internal/app/logs_test.go
@@ -179,3 +179,31 @@ func TestServiceLogsAreAddressableByRun(t *testing.T) {
 		t.Fatalf("service run = %#v", snapshot)
 	}
 }
+
+func TestQueryLogsResolvesLatestFromCatalogAndReportsExactRetentionGap(t *testing.T) {
+	local := logQueryTestLocal(t)
+	local.SetServiceStatusForTest("api", config.StatusStarting)
+	for index := 0; index < 10010; index++ {
+		local.AppendLogForTest("api", "x")
+	}
+
+	summaries := local.manager.RunSummaries(ServiceRunTarget("api"))
+	if len(summaries) != 1 || summaries[0].Output.MissingLines == 0 {
+		t.Fatalf("summary = %#v", summaries)
+	}
+	result, err := local.QueryLogs(LogQuery{Selectors: []string{"api"}, Run: -1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Retention) != 1 || result.Retention[0].Run != 1 || result.Retention[0].Output != summaries[0].Output {
+		t.Fatalf("retention = %#v; summary = %#v", result.Retention, summaries[0])
+	}
+	if !result.Truncated || len(result.Events) == 0 {
+		t.Fatalf("result = %#v", result)
+	}
+	for _, event := range result.Events {
+		if event.Run != 1 {
+			t.Fatalf("latest catalog run returned #%d", event.Run)
+		}
+	}
+}

--- a/internal/app/runs.go
+++ b/internal/app/runs.go
@@ -1,0 +1,52 @@
+package app
+
+import (
+	"fmt"
+
+	"github.com/kranz-org/kranz/internal/config"
+)
+
+func (l *Local) ExportRun(target RunTarget, run uint32) (RunExport, error) {
+	var summary RunSummary
+	found := false
+	for _, candidate := range l.manager.RunSummaries(target) {
+		if candidate.Run == run {
+			summary, found = candidate, true
+			break
+		}
+	}
+	if !found {
+		return RunExport{}, fmt.Errorf("run %s#%d is not retained", runTargetName(target), run)
+	}
+	var entries []config.LogEntry
+	if target.Kind == RunKindService {
+		service, ok := l.manager.GetService(target.Name)
+		if !ok {
+			return RunExport{}, fmt.Errorf("service %q not found", target.Name)
+		}
+		entries = service.LogEntries()
+	} else {
+		entries = l.manager.ActionLogs(target.Action)
+	}
+	filtered := make([]config.LogEntry, 0)
+	for _, entry := range entries {
+		if entry.Run == run {
+			filtered = append(filtered, entry)
+		}
+	}
+	var retention RunRetentionBoundary
+	for _, boundary := range l.manager.RunRetentionBoundaries() {
+		if boundary.Target == target {
+			retention = boundary
+			break
+		}
+	}
+	return RunExport{Summary: summary, Retention: retention, Entries: filtered}, nil
+}
+
+func runTargetName(target RunTarget) string {
+	if target.Kind == RunKindService {
+		return target.Name
+	}
+	return target.Action.Owner + "/" + target.Action.Name
+}

--- a/internal/app/runs_test.go
+++ b/internal/app/runs_test.go
@@ -1,0 +1,32 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/kranz-org/kranz/internal/config"
+)
+
+func TestExportRunCarriesCanonicalEntriesProvenanceAndRetention(t *testing.T) {
+	local := NewLocal(&config.Config{Project: "export", Services: map[string]config.Service{
+		"api": {Command: "exit 0", Dir: ".", Shell: "sh"},
+	}}, nil, Options{})
+	defer func() { _ = local.Shutdown() }()
+	local.SetServiceStatusForTest("api", config.StatusStarting)
+	local.AppendLogForTest("api", "exported line")
+	snapshot, _ := local.Service("api")
+	state := snapshot.State
+	state.Completed = true
+	local.SetServiceStateForTest("api", state)
+	local.SetServiceStatusForTest("api", config.StatusStopped)
+
+	export, err := local.ExportRun(ServiceRunTarget("api"), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if export.Summary.Run != 1 || export.Summary.Surface != "runtime" || len(export.Entries) != 1 || export.Entries[0].Raw != "exported line" {
+		t.Fatalf("export = %+v entries=%#v", export.Summary, export.Entries)
+	}
+	if export.Retention.OldestRetainedRun != 1 || export.Retention.MaxEntries == 0 || export.Retention.MaxBytes == 0 {
+		t.Fatalf("retention = %+v", export.Retention)
+	}
+}

--- a/internal/app/types.go
+++ b/internal/app/types.go
@@ -42,6 +42,7 @@ type (
 	RunOutputState        = service.RunOutputState
 	RunOutputSummary      = service.RunOutputSummary
 	RunSummary            = service.RunSummary
+	RunRetentionBoundary  = service.RunRetentionBoundary
 )
 
 const (
@@ -103,6 +104,15 @@ type ServiceSnapshot struct {
 	CanStart       bool                `json:"can_start"`
 	CanStop        bool                `json:"can_stop"`
 	Health         HealthSnapshot      `json:"health"`
+}
+
+// RunExport is a detached, explicit snapshot suitable for clipboard or file
+// export. It includes identity/provenance and retention metadata beside the
+// exact canonical entries that remain available.
+type RunExport struct {
+	Summary   RunSummary           `json:"summary"`
+	Retention RunRetentionBoundary `json:"retention"`
+	Entries   []config.LogEntry    `json:"entries"`
 }
 
 // ServiceStartPlanned reports whether a service is running, starting, or

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -27,7 +27,7 @@ func (s *Server) installResources() {
 }
 
 func (s *Server) runsResource(context.Context) ResultEnvelope {
-	return s.envelope(map[string]any{"runs": s.api.Runs()})
+	return s.envelope(map[string]any{"runs": s.api.Runs(), "retention": s.api.RunRetention()})
 }
 
 func (s *Server) envelope(data any) ResultEnvelope {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -97,7 +97,7 @@ func (s *Server) runsTool(_ context.Context, raw json.RawMessage) ResultEnvelope
 	if err := decodeArgs(raw, &args); err != nil {
 		return s.argError(err)
 	}
-	return s.envelope(map[string]any{"runs": s.api.Runs()})
+	return s.envelope(map[string]any{"runs": s.api.Runs(), "retention": s.api.RunRetention()})
 }
 
 func mutationSchema(includeDependencies bool) map[string]any {

--- a/internal/runtime/client.go
+++ b/internal/runtime/client.go
@@ -447,6 +447,15 @@ func (c *Client) Runs() []app.RunSummary {
 	return runs
 }
 
+func (c *Client) RunRetention() []app.RunRetentionBoundary {
+	boundaries, _ := call[emptyRequest, []app.RunRetentionBoundary](c, context.Background(), methodRunRetention, emptyRequest{})
+	return boundaries
+}
+
+func (c *Client) ExportRun(target app.RunTarget, run uint32) (app.RunExport, error) {
+	return call[exportRunRequest, app.RunExport](c, context.Background(), methodExportRun, exportRunRequest{Target: target, Run: run})
+}
+
 func (c *Client) Logs(name string) []config.LogEntry {
 	resp, _ := call[nameRequest, logsResponse](c, context.Background(), methodLogs, nameRequest{Name: name})
 	return resp.Entries

--- a/internal/runtime/handlers.go
+++ b/internal/runtime/handlers.go
@@ -157,6 +157,12 @@ var handlers = map[string]handlerFunc{
 	methodRuns: handler(func(_ context.Context, l *app.Local, _ emptyRequest) ([]app.RunSummary, error) {
 		return l.Runs(), nil
 	}),
+	methodRunRetention: handler(func(_ context.Context, l *app.Local, _ emptyRequest) ([]app.RunRetentionBoundary, error) {
+		return l.RunRetention(), nil
+	}),
+	methodExportRun: handler(func(_ context.Context, l *app.Local, req exportRunRequest) (app.RunExport, error) {
+		return l.ExportRun(req.Target, req.Run)
+	}),
 	methodActionLogs: handler(func(_ context.Context, l *app.Local, req actionIDRequest) (logsResponse, error) {
 		return logsResponse{Entries: l.ActionLogs(req.ID)}, nil
 	}),

--- a/internal/runtime/integration_test.go
+++ b/internal/runtime/integration_test.go
@@ -241,6 +241,22 @@ func TestRunCatalogPreservesConnectionProvenanceAcrossRPC(t *testing.T) {
 	if runs[0].Surface != "mcp" || runs[0].ClientLabel != "agent session" || runs[0].StartReason != "invoked" {
 		t.Fatalf("run provenance = %+v", runs[0])
 	}
+	boundaries := client.RunRetention()
+	if len(boundaries) != 1 || boundaries[0].Target != app.ActionRunTarget(id) || boundaries[0].OldestRetainedRun != 1 || boundaries[0].MaxEntries == 0 || boundaries[0].MaxBytes == 0 {
+		t.Fatalf("retention = %#v", boundaries)
+	}
+	exported, err := client.ExportRun(app.ActionRunTarget(id), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exported.Summary.Surface != "mcp" || exported.Summary.ClientLabel != "agent session" || exported.Retention != boundaries[0] || len(exported.Entries) == 0 {
+		t.Fatalf("export = %#v", exported)
+	}
+	for index, entry := range exported.Entries {
+		if entry.Run != 1 || entry.Sequence == 0 || entry.Timestamp.IsZero() || entry.Source == "" {
+			t.Fatalf("export entry %d = %#v", index, entry)
+		}
+	}
 }
 
 func TestExecutePlanPreservesFailedActionRunAcrossIPC(t *testing.T) {

--- a/internal/runtime/messages.go
+++ b/internal/runtime/messages.go
@@ -51,6 +51,8 @@ const (
 	methodAcquireInteractiveAction        = "acquireInteractiveAction"
 	methodCompleteInteractiveAction       = "completeInteractiveAction"
 	methodRuns                            = "runs"
+	methodRunRetention                    = "runRetention"
+	methodExportRun                       = "exportRun"
 	methodActionLogs                      = "actionLogs"
 	methodQueryLogs                       = "queryLogs"
 	methodClearLogStreams                 = "clearLogStreams"
@@ -95,6 +97,11 @@ type actionIDRequest struct {
 type actionResultRequest struct {
 	ID  config.ActionID `json:"id"`
 	Run int             `json:"run"`
+}
+
+type exportRunRequest struct {
+	Target app.RunTarget `json:"target"`
+	Run    uint32        `json:"run"`
 }
 
 type reloadRequest struct {

--- a/internal/service/logstream.go
+++ b/internal/service/logstream.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/kranz-org/kranz/internal/config"
-	"github.com/kranz-org/kranz/pkg/ringbuffer"
 )
 
 // logStream is one addressable log history: the bounded line buffer plus the
@@ -14,7 +13,7 @@ import (
 // one, so `kranz logs api` and `kranz logs analytics/stats` read the same
 // structure through the same filters rather than two parallel implementations.
 type logStream struct {
-	buffer  *ringbuffer.RingBuffer
+	lines   []string
 	catalog *RunCatalog
 	target  RunTarget
 
@@ -25,25 +24,35 @@ type logStream struct {
 	// runs records which execution produced each line. A service produces one
 	// continuous stream and leaves this zero; an action restarts the numbering
 	// story on every invocation, which is what --run addresses.
-	runs       []uint32
-	lineBytes  []uint64
-	write      int
-	count      int
-	nextSeq    uint64
-	currentRun uint32
+	runs          []uint32
+	lineBytes     []uint64
+	write         int
+	count         int
+	retainedBytes uint64
+	maxBytes      uint64
+	nextSeq       uint64
+	currentRun    uint32
 }
 
 func newLogStream(size int) *logStream {
+	return newLogStreamWithLimits(size, defaultLogBufferBytes)
+}
+
+func newLogStreamWithLimits(size int, maxBytes uint64) *logStream {
 	if size <= 0 {
 		size = defaultLogBufferSize
 	}
+	if maxBytes == 0 {
+		maxBytes = defaultLogBufferBytes
+	}
 	return &logStream{
-		buffer:    ringbuffer.New(size),
+		lines:     make([]string, size),
 		times:     make([]time.Time, size),
 		sources:   make([]string, size),
 		sequences: make([]uint64, size),
 		runs:      make([]uint32, size),
 		lineBytes: make([]uint64, size),
+		maxBytes:  maxBytes,
 	}
 }
 
@@ -51,6 +60,9 @@ func (s *logStream) SetCatalog(catalog *RunCatalog, target RunTarget) {
 	s.mu.Lock()
 	s.catalog = catalog
 	s.target = target
+	if catalog != nil {
+		catalog.SetOutputLimits(target, len(s.lines), s.maxBytes)
+	}
 	s.mu.Unlock()
 }
 
@@ -100,10 +112,10 @@ func (s *logStream) Append(timestamp time.Time, source, text string) {
 
 func (s *logStream) appendLineLocked(timestamp time.Time, source, line string) {
 	if s.count == len(s.times) {
-		s.catalog.EvictOutput(s.target, s.runs[s.write], s.lineBytes[s.write])
+		s.evictOldestLocked()
 	}
 	s.nextSeq++
-	s.buffer.Write(line)
+	s.lines[s.write] = line
 	s.times[s.write] = timestamp
 	s.sources[s.write] = source
 	s.sequences[s.write] = s.nextSeq
@@ -111,10 +123,35 @@ func (s *logStream) appendLineLocked(timestamp time.Time, source, line string) {
 	lineBytes := uint64(len(line))
 	s.lineBytes[s.write] = lineBytes
 	s.catalog.RecordOutput(s.target, s.currentRun, lineBytes)
+	s.retainedBytes += lineBytes
 	s.write = (s.write + 1) % len(s.times)
 	if s.count < len(s.times) {
 		s.count++
 	}
+	for s.count > 0 && s.retainedBytes > s.maxBytes {
+		s.evictOldestLocked()
+	}
+}
+
+func (s *logStream) evictOldestLocked() {
+	if s.count == 0 {
+		return
+	}
+	index := (s.write - s.count + len(s.lines)) % len(s.lines)
+	bytes := s.lineBytes[index]
+	s.catalog.EvictOutput(s.target, s.runs[index], bytes)
+	if bytes <= s.retainedBytes {
+		s.retainedBytes -= bytes
+	} else {
+		s.retainedBytes = 0
+	}
+	s.lines[index] = ""
+	s.times[index] = time.Time{}
+	s.sources[index] = ""
+	s.sequences[index] = 0
+	s.runs[index] = 0
+	s.lineBytes[index] = 0
+	s.count--
 }
 
 // splitCapturedLines breaks captured text into stored lines. A trailing
@@ -135,8 +172,7 @@ func splitCapturedLines(text string) []string {
 func (s *logStream) Entries() []config.LogEntry {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	lines := s.buffer.Lines()
-	count := min(len(lines), s.count)
+	count := s.count
 	entries := make([]config.LogEntry, 0, count)
 	// The metadata rings are written in lockstep with the text buffer, so one
 	// index walked back from the write cursor addresses all of them. Rebuilding
@@ -148,7 +184,7 @@ func (s *logStream) Entries() []config.LogEntry {
 			Timestamp: s.times[metadataIndex],
 			Source:    s.sources[metadataIndex],
 			Run:       s.runs[metadataIndex],
-			Raw:       lines[len(lines)-count+index],
+			Raw:       s.lines[metadataIndex],
 		})
 	}
 	return entries
@@ -158,7 +194,12 @@ func (s *logStream) Entries() []config.LogEntry {
 func (s *logStream) Lines() []string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.buffer.Lines()
+	lines := make([]string, 0, s.count)
+	for index := range s.count {
+		metadataIndex := (s.write - s.count + index + len(s.lines)) % len(s.lines)
+		lines = append(lines, s.lines[metadataIndex])
+	}
+	return lines
 }
 
 // Clear atomically discards both log text and its metadata. The run counter
@@ -166,7 +207,7 @@ func (s *logStream) Lines() []string {
 // afterwards would make an address point at two different executions.
 func (s *logStream) Clear() {
 	s.mu.Lock()
-	s.buffer.Clear()
+	clear(s.lines)
 	clear(s.times)
 	clear(s.sources)
 	clear(s.sequences)
@@ -174,6 +215,7 @@ func (s *logStream) Clear() {
 	clear(s.lineBytes)
 	s.write = 0
 	s.count = 0
+	s.retainedBytes = 0
 	catalog, target := s.catalog, s.target
 	s.mu.Unlock()
 	catalog.ClearOutput(target)
@@ -185,7 +227,7 @@ func (s *logStream) CopyFrom(previous *logStream) {
 	defer previous.mu.RUnlock()
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.buffer = previous.buffer
+	s.lines = append(s.lines[:0], previous.lines...)
 	s.times = append(s.times[:0], previous.times...)
 	s.sources = append(s.sources[:0], previous.sources...)
 	s.sequences = append(s.sequences[:0], previous.sequences...)
@@ -193,9 +235,14 @@ func (s *logStream) CopyFrom(previous *logStream) {
 	s.lineBytes = append(s.lineBytes[:0], previous.lineBytes...)
 	s.write = previous.write
 	s.count = previous.count
+	s.retainedBytes = previous.retainedBytes
+	s.maxBytes = previous.maxBytes
 	s.nextSeq = previous.nextSeq
 	s.currentRun = previous.currentRun
 }
 
 // defaultLogBufferSize bounds one stream's history when no size is configured.
 const defaultLogBufferSize = 1000
+
+// defaultLogBufferBytes independently bounds retained output for one target.
+const defaultLogBufferBytes = 4 * 1024 * 1024

--- a/internal/service/manager.go
+++ b/internal/service/manager.go
@@ -51,6 +51,8 @@ func (m *Manager) RunSummaries(target RunTarget) []RunSummary { return m.runs.Li
 
 func (m *Manager) AllRunSummaries() []RunSummary { return m.runs.All() }
 
+func (m *Manager) RunRetentionBoundaries() []RunRetentionBoundary { return m.runs.Boundaries() }
+
 // RecordConfigReload marks a new configuration generation inside every
 // continuing service run. Services restarted by ApplyConfig get a new run and
 // therefore do not receive a marker that would imply process continuity.
@@ -63,7 +65,7 @@ func (m *Manager) RecordConfigReload(generation uint64, restarted []string) {
 		if restartedSet[svc.Name] || svc.Run() == 0 || svc.Status() == config.StatusStopped {
 			continue
 		}
-		svc.AppendLog(fmt.Sprintf("[Kranz] Config reloaded · generation %d", generation))
+		svc.AppendLog(fmt.Sprintf("[Kranz] Config reloaded · generation %d · %s#%d", generation, svc.Name, svc.Run()))
 	}
 }
 

--- a/internal/service/manager_process.go
+++ b/internal/service/manager_process.go
@@ -40,9 +40,9 @@ func (m *Manager) monitorProcess(name string, svc *Service, pm *ProcessManager, 
 				svc.SetPID(0)
 				shouldEvaluate = true
 				if m.successfulExit(svc.Config, exitCode) {
-					svc.AppendLog(fmt.Sprintf("[Kranz] Process exited · code %d", exitCode))
+					svc.AppendLog(fmt.Sprintf("[Kranz] Process exited · code %d · %s#%d", exitCode, svc.Name, svc.Run()))
 				} else {
-					svc.AppendLog(fmt.Sprintf("[Kranz] Process failed · exit code %d", exitCode))
+					svc.AppendLog(fmt.Sprintf("[Kranz] Process failed · exit code %d · %s#%d", exitCode, svc.Name, svc.Run()))
 				}
 			}
 			svc.lifecycleMu.Unlock()

--- a/internal/service/manager_start.go
+++ b/internal/service/manager_start.go
@@ -97,7 +97,7 @@ func (m *Manager) startService(ctx context.Context, name string, recovery bool) 
 
 	svc.SetNextRunProvenance(provenance)
 	svc.SetStatus(config.StatusStarting)
-	svc.AppendLog("[Kranz] Starting")
+	svc.AppendLog(fmt.Sprintf("[Kranz] Starting · %s#%d", svc.Name, svc.Run()))
 
 	pm := NewProcessManager(1000)
 	start := svc.Config.StartAction()
@@ -128,7 +128,7 @@ func (m *Manager) startService(ctx context.Context, name string, recovery bool) 
 
 	svc.SetPID(pid)
 	svc.SetStatus(config.StatusRunning)
-	svc.AppendLog(fmt.Sprintf("[Kranz] Started · PID %d", pid))
+	svc.AppendLog(fmt.Sprintf("[Kranz] Started · PID %d · %s#%d", pid, svc.Name, svc.Run()))
 	svc.ResetNewLogCount()
 
 	monitorStop := make(chan struct{})
@@ -181,7 +181,7 @@ func (m *Manager) startDetachedService(ctx context.Context, svc *Service) error 
 	}
 	svc.SetDesiredRunning(true)
 	svc.SetStatus(config.StatusStarting)
-	svc.AppendLog("[Kranz] Starting detached service")
+	svc.AppendLog(fmt.Sprintf("[Kranz] Starting detached service · %s#%d", svc.Name, svc.Run()))
 	id := lifecycleActionID(svc.Name, "start")
 	result, err := m.actions.RunDefinition(ctx, id, *start)
 	m.appendLifecycleResult(svc, "start", result)

--- a/internal/service/manager_stop.go
+++ b/internal/service/manager_stop.go
@@ -64,7 +64,7 @@ func (m *Manager) StopService(name string) error {
 	svc.RecordExit(exitCode, stopErr)
 	svc.SetPID(0)
 	svc.SetStatus(config.StatusStopped)
-	svc.AppendLog("[Kranz] Stopped")
+	svc.AppendLog(fmt.Sprintf("[Kranz] Stopped · %s#%d", svc.Name, svc.Run()))
 	return stopErr
 }
 

--- a/internal/service/run_catalog.go
+++ b/internal/service/run_catalog.go
@@ -75,19 +75,42 @@ type RunSummary struct {
 	Output      RunOutputSummary   `json:"output"`
 }
 
+// RunRetentionBoundary describes the independent catalog and output budgets
+// for one target and the oldest summary still addressable in this session.
+type RunRetentionBoundary struct {
+	Target            RunTarget `json:"target"`
+	MaxRuns           int       `json:"max_runs"`
+	MaxEntries        int       `json:"max_entries"`
+	MaxBytes          uint64    `json:"max_bytes"`
+	OldestRetainedRun uint32    `json:"oldest_retained_run,omitempty"`
+	EvictedRuns       uint64    `json:"evicted_runs"`
+}
+
 // RunCatalog retains a fair, per-target bounded history. A noisy target can
 // evict only its own old summaries, never another service or action's history.
 type RunCatalog struct {
 	mu               sync.RWMutex
 	maxRunsPerTarget int
 	runs             map[RunTarget][]RunSummary
+	boundaries       map[RunTarget]RunRetentionBoundary
 }
 
 func NewRunCatalog(maxRunsPerTarget int) *RunCatalog {
 	if maxRunsPerTarget <= 0 {
 		maxRunsPerTarget = defaultRunCatalogSize
 	}
-	return &RunCatalog{maxRunsPerTarget: maxRunsPerTarget, runs: make(map[RunTarget][]RunSummary)}
+	return &RunCatalog{maxRunsPerTarget: maxRunsPerTarget, runs: make(map[RunTarget][]RunSummary), boundaries: make(map[RunTarget]RunRetentionBoundary)}
+}
+
+func (c *RunCatalog) SetOutputLimits(target RunTarget, maxEntries int, maxBytes uint64) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	boundary := c.boundaries[target]
+	boundary.Target, boundary.MaxRuns, boundary.MaxEntries, boundary.MaxBytes = target, c.maxRunsPerTarget, maxEntries, maxBytes
+	c.boundaries[target] = boundary
+	c.mu.Unlock()
 }
 
 func (c *RunCatalog) Begin(summary RunSummary) {
@@ -110,9 +133,32 @@ func (c *RunCatalog) Begin(summary RunSummary) {
 	}
 	history = append(history, cloneRunSummary(summary))
 	if len(history) > c.maxRunsPerTarget {
+		boundary := c.boundaries[summary.Target]
+		boundary.Target, boundary.MaxRuns = summary.Target, c.maxRunsPerTarget
+		boundary.EvictedRuns += uint64(len(history) - c.maxRunsPerTarget)
+		c.boundaries[summary.Target] = boundary
 		history = append([]RunSummary(nil), history[len(history)-c.maxRunsPerTarget:]...)
 	}
 	c.runs[summary.Target] = history
+}
+
+func (c *RunCatalog) Boundaries() []RunRetentionBoundary {
+	if c == nil {
+		return nil
+	}
+	c.mu.RLock()
+	result := make([]RunRetentionBoundary, 0, len(c.boundaries))
+	for target, boundary := range c.boundaries {
+		boundary.Target = target
+		boundary.MaxRuns = c.maxRunsPerTarget
+		if history := c.runs[target]; len(history) > 0 {
+			boundary.OldestRetainedRun = history[0].Run
+		}
+		result = append(result, boundary)
+	}
+	c.mu.RUnlock()
+	sort.Slice(result, func(i, j int) bool { return runTargetLess(result[i].Target, result[j].Target) })
+	return result
 }
 
 func (c *RunCatalog) Update(target RunTarget, run uint32, status string, pid int, cause *config.StateCause) {

--- a/internal/service/run_catalog_test.go
+++ b/internal/service/run_catalog_test.go
@@ -171,11 +171,49 @@ func TestConfigReloadMarkerStaysInsideContinuingRun(t *testing.T) {
 	manager.RecordConfigReload(2, nil)
 	svc, _ := manager.GetService("api")
 	entries := svc.LogEntries()
-	if len(entries) == 0 || entries[len(entries)-1].Run != 1 || entries[len(entries)-1].Raw != "[Kranz] Config reloaded · generation 2" {
+	if len(entries) == 0 || entries[len(entries)-1].Run != 1 || entries[len(entries)-1].Raw != "[Kranz] Config reloaded · generation 2 · api#1" {
 		t.Fatalf("reload marker entries = %#v", entries)
 	}
 	runs := manager.RunSummaries(ServiceRunTarget("api"))
 	if len(runs) != 1 || runs[0].Run != 1 || runs[0].Surface != "tui" || runs[0].ClientLabel != "dashboard" || runs[0].StartReason != "first_start" {
 		t.Fatalf("continuing run = %#v", runs)
+	}
+}
+
+func TestLogStreamEnforcesByteAndEntryBudgetsIndependently(t *testing.T) {
+	catalog := NewRunCatalog(10)
+	target := ServiceRunTarget("api")
+	stream := newLogStreamWithLimits(10, 5)
+	stream.SetCatalog(catalog, target)
+	run := stream.BeginRun()
+	catalog.Begin(RunSummary{Target: target, Run: run, Status: "running", StartedAt: time.Now()})
+	stream.Append(time.Now(), "stdout", "aaa")
+	stream.Append(time.Now(), "stderr", "bbbb")
+
+	entries := stream.Entries()
+	if len(entries) != 1 || entries[0].Raw != "bbbb" || entries[0].Source != "stderr" {
+		t.Fatalf("retained entries = %#v", entries)
+	}
+	summary := catalog.List(target)[0]
+	if summary.Output.CapturedLines != 2 || summary.Output.CapturedBytes != 7 || summary.Output.RetainedLines != 1 ||
+		summary.Output.RetainedBytes != 4 || summary.Output.MissingLines != 1 || summary.Output.MissingBytes != 3 || summary.Output.State != RunOutputPartial {
+		t.Fatalf("output retention = %+v", summary.Output)
+	}
+	boundary := catalog.Boundaries()[0]
+	if boundary.MaxEntries != 10 || boundary.MaxBytes != 5 || boundary.OldestRetainedRun != 1 {
+		t.Fatalf("boundary = %+v", boundary)
+	}
+}
+
+func TestRunCatalogPublishesOldestBoundaryAfterSummaryEviction(t *testing.T) {
+	catalog := NewRunCatalog(2)
+	target := ServiceRunTarget("api")
+	catalog.SetOutputLimits(target, 100, 1024)
+	for run := uint32(1); run <= 3; run++ {
+		catalog.Begin(RunSummary{Target: target, Run: run, Status: "running", StartedAt: time.Now()})
+	}
+	boundary := catalog.Boundaries()[0]
+	if boundary.OldestRetainedRun != 2 || boundary.EvictedRuns != 1 || boundary.MaxRuns != 2 {
+		t.Fatalf("boundary = %+v", boundary)
 	}
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -35,6 +35,7 @@ const (
 	ModeConfirmThemeSave
 	ModeThemes
 	ModeRunList
+	ModeRunExport
 )
 
 type runViewMode uint8
@@ -137,6 +138,10 @@ type actionResultMsg struct {
 
 type shutdownResultMsg struct{ err error }
 type shellFinishedMsg struct{ err error }
+type runExportResultMsg struct {
+	path string
+	err  error
+}
 type backgroundColorMsg struct {
 	dark bool
 	err  error
@@ -202,6 +207,7 @@ type Model struct {
 	logSearcher      *kranzlog.Searcher
 	pinnedSearcher   *kranzlog.Searcher
 	searchInput      textinput.Model
+	exportInput      textinput.Model
 	searchNudge      time.Time
 	currentMatch     int
 	pinnedMatch      int
@@ -217,6 +223,8 @@ type Model struct {
 	runListCursor    int
 	runStatusFilter  string
 	runViewports     map[runViewportKey]runViewportState
+	exportTarget     app.RunTarget
+	exportRun        uint32
 
 	mode       ViewMode
 	width      int
@@ -366,6 +374,7 @@ func NewModelWithOptions(cfg *config.Config, version string, options ModelOption
 		pinnedSearcher:      kranzlog.NewSearcher(),
 		runViewports:        make(map[runViewportKey]runViewportState),
 		searchInput:         newSearchInput(),
+		exportInput:         newRunExportInput(),
 		themeColorInput:     newThemeColorInput(),
 		currentMatch:        -1,
 		pinnedMatch:         -1,
@@ -455,6 +464,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.searchInput, searchCommand = m.searchInput.Update(msg)
 		} else if m.mode == ModeThemes && m.themeColorEditing {
 			m.themeColorInput, searchCommand = m.themeColorInput.Update(msg)
+		} else if m.mode == ModeRunExport {
+			m.exportInput, searchCommand = m.exportInput.Update(msg)
 		}
 		return m, tea.Batch(m.enableMouseTracking(time.Now()), searchCommand)
 	case tea.KeyMsg:
@@ -489,6 +500,14 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.addNotification("shell", "Returned to Kranz", config.LogInfo)
 		}
 		return m, tea.Batch(tea.ClearScreen, m.probeTerminalBackground(true))
+	case runExportResultMsg:
+		if msg.err != nil {
+			m.addNotification("export", "Run export failed: "+msg.err.Error(), config.LogError)
+		} else {
+			m.addNotification("export", "Run exported to "+msg.path, config.LogInfo)
+		}
+		m.mode = ModeNormal
+		return m, nil
 	case backgroundColorMsg:
 		m.backgroundProbeBusy = false
 		m.lastBackgroundProbe = time.Now()

--- a/internal/ui/model_keys.go
+++ b/internal/ui/model_keys.go
@@ -49,6 +49,8 @@ func (m *Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleThemeKeys(msg)
 	case ModeRunList:
 		return m.handleRunListKeys(msg)
+	case ModeRunExport:
+		return m.handleRunExportKeys(msg)
 	default:
 		if msg.String() == "esc" || msg.String() == "q" {
 			m.mode = ModeNormal
@@ -84,6 +86,12 @@ func (m *Model) handleNormalKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 	if key.Matches(msg, m.keys.Search) {
 		return m, m.openSearchEditor()
+	}
+	if msg.String() == "e" {
+		return m, m.copySelectedRun()
+	}
+	if msg.String() == "E" {
+		return m, m.openRunExport()
 	}
 	if m.handleLogKey(msg) {
 		return m, nil

--- a/internal/ui/run_export.go
+++ b/internal/ui/run_export.go
@@ -1,0 +1,142 @@
+package ui
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/kranz-org/kranz/internal/app"
+	"github.com/kranz-org/kranz/internal/config"
+)
+
+func newRunExportInput() textinput.Model {
+	input := textinput.New()
+	input.Prompt = "Path: "
+	input.CharLimit = 0
+	return input
+}
+
+func (m *Model) selectedRunIdentity() (app.RunTarget, uint32, bool) {
+	if m.panelFocus == panelPinnedLogs {
+		if target, ok := m.pinnedRunTarget(); ok && m.pinnedRun > 0 {
+			return target, m.pinnedRun, true
+		}
+	}
+	if !m.syncRunTarget() {
+		return app.RunTarget{}, 0, false
+	}
+	run := m.selectedRun
+	if m.runMode == runViewCombined || run == 0 {
+		run = latestRun(m.runsForTarget(m.runTarget))
+	}
+	return m.runTarget, run, run > 0
+}
+
+func (m *Model) copySelectedRun() tea.Cmd {
+	target, run, ok := m.selectedRunIdentity()
+	if !ok {
+		m.addNotification("export", "No run is selected", config.LogWarn)
+		return nil
+	}
+	export, err := m.app.ExportRun(target, run)
+	if err != nil {
+		m.addNotification("export", err.Error(), config.LogError)
+		return nil
+	}
+	payload := formatRunExport(export)
+	encoded := base64.StdEncoding.EncodeToString([]byte(payload))
+	m.addNotification("export", fmt.Sprintf("Copied %s#%d to clipboard", runTargetLabel(target), run), config.LogInfo)
+	// OSC 52 is the terminal-native clipboard protocol and works identically
+	// for `up` and `attach`; it writes only after the explicit keypress.
+	return tea.Printf("%s", "\x1b]52;c;"+encoded+"\a")
+}
+
+func (m *Model) openRunExport() tea.Cmd {
+	target, run, ok := m.selectedRunIdentity()
+	if !ok {
+		m.addNotification("export", "No run is selected", config.LogWarn)
+		return nil
+	}
+	m.exportTarget, m.exportRun = target, run
+	name := strings.NewReplacer("/", "-", "\\", "-", " ", "-").Replace(runTargetLabel(target))
+	m.exportInput.SetValue(fmt.Sprintf("kranz-%s-%d.log", name, run))
+	m.exportInput.CursorEnd()
+	m.mode = ModeRunExport
+	return m.exportInput.Focus()
+}
+
+func (m *Model) handleRunExportKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		m.exportInput.Blur()
+		m.mode = ModeNormal
+		return m, nil
+	case "enter":
+		path := strings.TrimSpace(m.exportInput.Value())
+		if path == "" {
+			m.addNotification("export", "Export path cannot be empty", config.LogError)
+			return m, nil
+		}
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(m.workingDirectory, path)
+		}
+		export, err := m.app.ExportRun(m.exportTarget, m.exportRun)
+		if err != nil {
+			m.addNotification("export", err.Error(), config.LogError)
+			return m, nil
+		}
+		payload := []byte(formatRunExport(export))
+		m.exportInput.Blur()
+		return m, func() tea.Msg {
+			err := os.WriteFile(filepath.Clean(path), payload, 0o644)
+			return runExportResultMsg{path: filepath.Clean(path), err: err}
+		}
+	}
+	var command tea.Cmd
+	m.exportInput, command = m.exportInput.Update(msg)
+	return m, command
+}
+
+func (m *Model) renderRunExportView() string {
+	identity := fmt.Sprintf("%s#%d", runTargetLabel(m.exportTarget), m.exportRun)
+	lines := []string{ModalTitleStyle.Render(" Export run "), "", "  " + identity, "", "  " + m.exportInput.View(), "",
+		renderModalShortcuts("  [Enter] Write file  [Esc] Cancel", lipgloss.NewStyle().Foreground(ColorDim))}
+	return m.placeOverlay(renderFlushModal(strings.Join(lines, "\n")))
+}
+
+func formatRunExport(export app.RunExport) string {
+	summary := export.Summary
+	finished := "running"
+	if !summary.FinishedAt.IsZero() {
+		finished = summary.FinishedAt.Format(time.RFC3339Nano)
+	}
+	exit := "-"
+	if summary.ExitCode != nil {
+		exit = fmt.Sprint(*summary.ExitCode)
+	}
+	var output strings.Builder
+	_, _ = fmt.Fprintf(&output, "Kranz run: %s#%d\nStatus: %s\nStarted: %s\nFinished: %s\nExit code: %s\nSurface: %s\nClient: %s\nStart reason: %s\n",
+		runTargetLabel(summary.Target), summary.Run, summary.Status, summary.StartedAt.Format(time.RFC3339Nano), finished, exit,
+		summary.Surface, summary.ClientLabel, summary.StartReason)
+	_, _ = fmt.Fprintf(&output, "Output: %s; captured %d lines/%d bytes; retained %d lines/%d bytes; missing %d lines/%d bytes\n",
+		summary.Output.State, summary.Output.CapturedLines, summary.Output.CapturedBytes, summary.Output.RetainedLines, summary.Output.RetainedBytes,
+		summary.Output.MissingLines, summary.Output.MissingBytes)
+	_, _ = fmt.Fprintf(&output, "Retention: oldest #%d; budgets %d runs/%d entries/%d bytes; evicted %d summaries\n---\n",
+		export.Retention.OldestRetainedRun, export.Retention.MaxRuns, export.Retention.MaxEntries, export.Retention.MaxBytes, export.Retention.EvictedRuns)
+	if summary.Output.MissingLines > 0 || summary.Output.MissingBytes > 0 {
+		_, _ = fmt.Fprintf(&output, "[Kranz] Output truncated · missing %d lines / %d bytes\n", summary.Output.MissingLines, summary.Output.MissingBytes)
+	}
+	for _, entry := range export.Entries {
+		line := strings.TrimRight(strings.ReplaceAll(ansi.Strip(entry.Raw), "\r", ""), "\n")
+		_, _ = fmt.Fprintf(&output, "[%s] [%s] [seq=%d] %s\n", entry.Timestamp.Format(time.RFC3339Nano), entry.Source, entry.Sequence, line)
+	}
+	return output.String()
+}

--- a/internal/ui/run_view.go
+++ b/internal/ui/run_view.go
@@ -372,6 +372,13 @@ func (m *Model) renderRunListView() string {
 		filter = "all"
 	}
 	lines := []string{ModalTitleStyle.Render(" Run history "), "", ContextBarStyle.Render("  Filter: " + filter + " · Tab changes filter"), ""}
+	for _, boundary := range m.app.RunRetention() {
+		if boundary.Target == m.runTarget {
+			lines = append(lines, ContextBarStyle.Render(fmt.Sprintf("  Oldest retained #%d · budgets %d runs / %d entries / %d bytes · evicted %d summaries",
+				boundary.OldestRetainedRun, boundary.MaxRuns, boundary.MaxEntries, boundary.MaxBytes, boundary.EvictedRuns)), "")
+			break
+		}
+	}
 	if len(runs) == 0 {
 		lines = append(lines, "  No runs match this filter")
 	}

--- a/internal/ui/run_view_test.go
+++ b/internal/ui/run_view_test.go
@@ -2,9 +2,12 @@ package ui
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/kranz-org/kranz/internal/config"
 )
@@ -128,6 +131,34 @@ func TestActionOutputDefaultsToSingleLatestRun(t *testing.T) {
 	plain := ansi.Strip(model.renderActionLogPanel(100, 12))
 	if model.runMode != runViewSingle || model.selectedRun != 1 || !strings.Contains(plain, "RUN #1 · LIVE/LATEST") || !strings.Contains(plain, "action-output") {
 		t.Fatalf("action did not open latest single run: mode=%d run=%d\n%s", model.runMode, model.selectedRun, plain)
+	}
+}
+
+func TestRunExportFileIncludesIdentityProvenanceAndTruncationMetadata(t *testing.T) {
+	model := newTestModel()
+	defer model.Shutdown()
+	finishTestServiceRun(t, model, "api", 0, "export me")
+	model.refreshServices()
+	model.selectLatestRun()
+	directory := t.TempDir()
+	model.workingDirectory = directory
+	model.openRunExport()
+	model.exportInput.SetValue("selected.log")
+	_, command := model.handleRunExportKeys(tea.KeyMsg{Type: tea.KeyEnter})
+	if command == nil {
+		t.Fatal("file export returned no command")
+	}
+	message := command()
+	_, _ = model.Update(message)
+	payload, err := os.ReadFile(filepath.Join(directory, "selected.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(payload)
+	for _, expected := range []string{"Kranz run: api#1", "Surface: runtime", "Output: complete", "Retention: oldest #1", "[seq=", "export me"} {
+		if !strings.Contains(text, expected) {
+			t.Fatalf("export missing %q:\n%s", expected, text)
+		}
 	}
 }
 

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -53,6 +53,8 @@ func (m *Model) View() string {
 		content = m.renderThemeView()
 	case ModeRunList:
 		content = m.renderRunListView()
+	case ModeRunExport:
+		content = m.renderRunExportView()
 	default:
 		content = m.renderMainView()
 	}

--- a/internal/ui/view_modals.go
+++ b/internal/ui/view_modals.go
@@ -72,6 +72,7 @@ func helpEntries() []helpEntry {
 		{"x", "Toggle Combined/Single run log view"},
 		{"[ / ]", "Previous/next run; Shift+F finds the previous failed run"},
 		{"v", "Open the run catalog; l returns to latest"},
+		{"e / E", "Export selected run to clipboard / a file path"},
 		{"c", "Clear focused or pinned service logs after confirmation"},
 		{"q", "Quit"},
 		{"?", "Show this help"},


### PR DESCRIPTION
## Summary
- enforce independent per-target run, entry, and byte retention with observable boundaries
- expose exact retention gaps and stable run identities through runtime, CLI, MCP, and TUI
- add explicit selected-run export to terminal clipboard or user-chosen file
- document the run viewer, catalog, and retention contracts

## Validation
- go test ./...
- go test -race ./...
- make lint
- kranz -p kranz-workspace action run development/build --output json

Target: v0.10.0. This PR does not tag or publish a release.