### PR TITLE
docs: prepare v0.10 validation notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 
 ## [Unreleased]
 
+### Added
+
+- Stable absolute `SERVICE#N` and `OWNER/ACTION#N` identities across the TUI,
+  CLI, runtime API, and MCP. Each real start has provenance, start reason,
+  timing, live/final status, PID, exit code, and cause in a bounded per-target
+  run catalog independent from log output and the transition journal.
+- A run-aware TUI log viewer with Combined and Single run modes, previous/next
+  and previous-failed navigation, a status-filterable keyboard/mouse run list,
+  independent scroll/follow/search state, immutable historical pin/split
+  snapshots, newer-run indication, and a quick return to latest.
+- Explicit selected-run export to the terminal clipboard or a user-chosen file,
+  including identity, provenance, canonical capture metadata, and exact
+  truncation information. Run history remains scoped to the live runtime and
+  is never persisted in the background.
+- `kranz runs` and MCP run retention metadata expose the oldest retained run,
+  independent run/entry/byte budgets, evicted summaries, and complete,
+  partial, or unavailable output state.
+
+### Changed
+
+- Stdout, stderr, and lifecycle markers now share one capture-ordered sequence
+  with timestamp and source. Config reloads appear inside the continuing run
+  with their new generation instead of looking like a process restart.
+- Relative log selectors such as `--run -1` resolve against the run catalog,
+  while output always prints the absolute `#N` identity. A retained run whose
+  prefix was evicted reports exact missing lines and bytes before its tail.
+
+### Fixed
+
+- Replacing an in-process runtime can no longer capture the outgoing owner's
+  project directory as its restore point, which could leave an embedded client
+  or test process in a deleted temporary directory after shutdown.
+
 ## [0.9.0] - 2026-08-25
 
 ### Added

--- a/internal/ui/run_view_test.go
+++ b/internal/ui/run_view_test.go
@@ -51,6 +51,35 @@ func TestRunListIncludesRetentionAndProvenanceFields(t *testing.T) {
 	}
 }
 
+func TestRunListFiltersAndSelectsByKeyboardAndMouse(t *testing.T) {
+	model := newTestModel()
+	defer model.Shutdown()
+	model.width, model.height, model.ready = 140, 30, true
+	finishTestServiceRun(t, model, "api", 7, "failed output")
+	finishTestServiceRun(t, model, "api", 0, "successful output")
+	model.refreshServices()
+	model.openRunList()
+
+	for range 3 { // all -> running -> succeeded -> failed
+		_, _ = model.handleRunListKeys(tea.KeyMsg{Type: tea.KeyTab})
+	}
+	filtered := model.filteredRunList()
+	if len(filtered) != 1 || filtered[0].Run != 1 {
+		t.Fatalf("failed filter = %#v", filtered)
+	}
+	_, _ = model.handleRunListKeys(tea.KeyMsg{Type: tea.KeyEnter})
+	if model.mode != ModeNormal || model.runMode != runViewSingle || model.selectedRun != 1 {
+		t.Fatalf("keyboard selection = mode %d view %d run %d", model.mode, model.runMode, model.selectedRun)
+	}
+
+	model.runStatusFilter = "all"
+	model.openRunList()
+	clickRenderedText(t, model, "#2")
+	if model.mode != ModeNormal || model.runMode != runViewSingle || model.selectedRun != 2 {
+		t.Fatalf("mouse selection = mode %d view %d run %d", model.mode, model.runMode, model.selectedRun)
+	}
+}
+
 func TestPinnedHistoricalRunRemainsImmutableAfterNewStart(t *testing.T) {
 	model := newTestModel()
 	defer model.Shutdown()


### PR DESCRIPTION
## Summary
- document the complete v0.10 run-aware history surface in Unreleased
- lock keyboard status filtering and mouse selection into the run-list test suite

## Validation
- make verify
- make lint
- make release-check
- focused run-list test repeated 10 times

This prepares the user-test candidate only. No tag or release is created.