### PR TITLE
feat: make MCP runtime binding discoverable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 - `kranz runs` and MCP run retention metadata expose the oldest retained run,
   independent run/entry/byte budgets, evicted summaries, and complete,
   partial, or unavailable output state.
+- MCP runtime discovery through `kranz://runtimes` and the read-only `runtimes`
+  tool. Results flag the connection's fixed binding; cross-runtime selector
+  misses name matching sessions instead of implying global unavailability.
+- `kranz mcp --attach-only` for agent registrations that must fail rather than
+  silently create a missing runtime. Deliberate owner fallback now reports
+  `owner_reason: created_missing_runtime` and hints about other live sessions.
 
 ### Changed
 
@@ -33,6 +39,8 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 
 ### Fixed
 
+- Config and MCP service views now redact credential-bearing URLs even when
+  their environment variable name is not itself secret-looking.
 - Replacing an in-process runtime can no longer capture the outgoing owner's
   project directory as its restore point, which could leave an embedded client
   or test process in a deleted temporary directory after shutdown.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ of starting a second development stack.
 - **Clear ownership** — disconnecting an attached agent does not stop the stack.
 
 Register the existing binary as a stdio MCP server running
-`kranz mcp -C /path/to/project`.
+`kranz mcp -C /path/to/project --attach-only`. The explicit attach policy keeps
+an agent from silently creating an empty runtime when the intended TUI session
+is not running.
 
 See [Coding agents and one live runtime](https://kranz-org.github.io/kranz/guide/mcp)
 for ownership behavior and examples, and the [MCP reference](https://kranz-org.github.io/kranz/reference/mcp)

--- a/cmd/kranz/config_commands_test.go
+++ b/cmd/kranz/config_commands_test.go
@@ -15,6 +15,7 @@ defaults:
   env:
     LOG_LEVEL: debug
     DATABASE_PASSWORD: hunter2
+    DATABASE_URL: postgresql://app:database-secret@db.example/app
 services:
   zulu:
     command: sleep 60
@@ -40,7 +41,7 @@ func secretsDirectory(t *testing.T) string {
 func TestConfigShowRedactsSecretEnvironmentValues(t *testing.T) {
 	output := runInspection(t, secretsDirectory(t), "config", "show")
 
-	for _, secret := range []string{"hunter2", "abc123"} {
+	for _, secret := range []string{"hunter2", "abc123", "database-secret"} {
 		if strings.Contains(output, secret) {
 			t.Errorf("config show leaked %q:\n%s", secret, output)
 		}

--- a/cmd/kranz/help_options_test.go
+++ b/cmd/kranz/help_options_test.go
@@ -45,6 +45,14 @@ func TestEveryDocumentedOptionIsAcceptedByItsCommand(t *testing.T) {
 		for _, option := range command.Options {
 			for _, spelling := range optionSpellings(option, directory) {
 				t.Run(strings.Join(append(append([]string(nil), path...), spelling...), " "), func(t *testing.T) {
+					if kranzcli.PathString(path) == "mcp" {
+						var stdout, stderr bytes.Buffer
+						_ = execute(append([]string{"-C", directory, "mcp"}, spelling...), &stdout, &stderr)
+						if strings.Contains(stderr.String(), "unknown mcp option") {
+							t.Fatalf("help documents %s, but MCP rejects it: %s", option.Flags, stderr.String())
+						}
+						return
+					}
 					args := append([]string{"-C", directory, "--output=json"}, path...)
 					var stdout, stderr bytes.Buffer
 					if code := execute(append(args, spelling...), &stdout, &stderr); code == 0 {

--- a/cmd/kranz/main.go
+++ b/cmd/kranz/main.go
@@ -73,11 +73,16 @@ func execute(args []string, stdout, stderr io.Writer) int {
 		return writeVersion(stdout, stderr, invocation.Globals.Output)
 	}
 	if invocation.Command() == "mcp" {
-		if len(invocation.Args) != 0 {
-			_, _ = fmt.Fprintln(stderr, "Kranz MCP: mcp does not accept positional arguments")
+		attachOnly := false
+		for _, arg := range invocation.Args {
+			if arg == "--attach-only" {
+				attachOnly = true
+				continue
+			}
+			_, _ = fmt.Fprintf(stderr, "Kranz MCP: unknown mcp option or argument %q\n", arg)
 			return kranzcli.ExitUsage
 		}
-		if err := runMCP(invocation.Globals, stdout, stderr); err != nil {
+		if err := runMCP(invocation.Globals, attachOnly, stdout, stderr); err != nil {
 			_, _ = fmt.Fprintf(stderr, "Kranz MCP: %v\n", err)
 			return 1
 		}

--- a/cmd/kranz/mcp.go
+++ b/cmd/kranz/mcp.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -20,17 +21,21 @@ var mcpStdin io.Reader = os.Stdin
 // runMCP attaches first. Only a proven absence for the current configured
 // runtime permits owner fallback; ambiguous, unreachable, stale-but-locked,
 // and incompatible records are returned without attempting Acquire.
-func runMCP(options kranzcli.GlobalOptions, stdout, stderr io.Writer) error {
+func runMCP(options kranzcli.GlobalOptions, attachOnly bool, stdout, stderr io.Writer) error {
 	if options.Output != kranzcli.OutputText {
 		return errors.New("--output is not valid for MCP stdio; stdout is reserved for JSON-RPC framing")
 	}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
-	return runMCPContext(ctx, options, mcpStdin, stdout, stderr)
+	return runMCPContextOptions(ctx, options, attachOnly, mcpStdin, stdout, stderr)
 }
 
 func runMCPContext(ctx context.Context, options kranzcli.GlobalOptions, stdin io.Reader, stdout, stderr io.Writer) error {
-	client, metadata, mode, owner, err := connectMCP(options)
+	return runMCPContextOptions(ctx, options, false, stdin, stdout, stderr)
+}
+
+func runMCPContextOptions(ctx context.Context, options kranzcli.GlobalOptions, attachOnly bool, stdin io.Reader, stdout, stderr io.Writer) error {
+	client, metadata, mode, owner, err := connectMCP(options, attachOnly)
 	if err != nil {
 		return err
 	}
@@ -68,7 +73,11 @@ func runMCPContext(ctx context.Context, options kranzcli.GlobalOptions, stdin io
 			cancelServe()
 		}
 	}()
-	server := kranzmcp.NewServer(client, kranzmcp.SessionFromMetadata(metadata, mode), stdin, stdout, stderr)
+	identity := kranzmcp.SessionFromMetadata(metadata, mode)
+	if owner != nil {
+		identity.OwnerReason = "created_missing_runtime"
+	}
+	server := kranzmcp.NewServer(client, identity, stdin, stdout, stderr)
 	err = server.Serve(serveCtx)
 	cancelServe()
 	<-watchDone
@@ -78,7 +87,7 @@ func runMCPContext(ctx context.Context, options kranzcli.GlobalOptions, stdin io
 	return errors.Join(err, cleanup())
 }
 
-func connectMCP(options kranzcli.GlobalOptions) (*kranzruntime.Client, kranzruntime.SessionMetadata, string, *runtimeHost, error) {
+func connectMCP(options kranzcli.GlobalOptions, attachOnly ...bool) (*kranzruntime.Client, kranzruntime.SessionMetadata, string, *runtimeHost, error) {
 	reference := options.Project
 	if reference == "" {
 		name, err := runtimeNameFromDirectory(options)
@@ -98,6 +107,9 @@ func connectMCP(options kranzcli.GlobalOptions) (*kranzruntime.Client, kranzrunt
 		return attachMCPRecord(reference, record)
 	}
 	var notFound *kranzruntime.SessionNotFoundError
+	if errors.As(resolveErr, &notFound) && len(attachOnly) > 0 && attachOnly[0] {
+		return nil, kranzruntime.SessionMetadata{}, "", nil, mcpAttachOnlyError(registry, reference)
+	}
 	if !errors.As(resolveErr, &notFound) || options.Project != "" {
 		return nil, kranzruntime.SessionMetadata{}, "", nil, fmt.Errorf("resolve runtime %s: %w", reference, resolveErr)
 	}
@@ -114,6 +126,34 @@ func connectMCP(options kranzcli.GlobalOptions) (*kranzruntime.Client, kranzrunt
 		return nil, kranzruntime.SessionMetadata{}, "", nil, fmt.Errorf("create MCP-owned runtime: %w", err)
 	}
 	return host.client, host.session.Metadata(), "owner", host, nil
+}
+
+func mcpAttachOnlyError(registry *kranzruntime.Registry, reference string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	records, err := registry.List(ctx, version)
+	if err != nil {
+		return fmt.Errorf("runtime %q is not running; refusing to create one (--attach-only); list runtimes: %w", reference, err)
+	}
+	running := make([]string, 0)
+	for _, record := range records {
+		if record.State != kranzruntime.SessionRunning {
+			continue
+		}
+		count := "services unknown"
+		if record.Services != nil {
+			count = fmt.Sprintf("%d services", *record.Services)
+		}
+		id := record.ID
+		if len(id) > 8 {
+			id = id[:8]
+		}
+		running = append(running, fmt.Sprintf("%s (%s, %s)", record.Name, id, count))
+	}
+	if len(running) == 0 {
+		return fmt.Errorf("runtime %q is not running; refusing to create one (--attach-only); no other runtimes are running", reference)
+	}
+	return fmt.Errorf("runtime %q is not running; refusing to create one (--attach-only); running runtimes: %s", reference, strings.Join(running, ", "))
 }
 
 func attachMCPRecord(reference string, record kranzruntime.SessionRecord) (*kranzruntime.Client, kranzruntime.SessionMetadata, string, *runtimeHost, error) {

--- a/cmd/kranz/mcp_test.go
+++ b/cmd/kranz/mcp_test.go
@@ -369,6 +369,33 @@ func TestMCPAttachesToForegroundRuntimeAndLeavesItRunning(t *testing.T) {
 	}
 }
 
+func TestMCPAttachOnlyRefusesPhantomRuntimeAndListsRunningAlternatives(t *testing.T) {
+	runningOptions, runningName := writeMCPProject(t)
+	host, _, err := startRuntime(runningOptions, "foreground")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = host.client.Shutdown(); _ = host.Close() }()
+
+	missingOptions, missingName := writeMCPProject(t)
+	client, _, _, owner, err := connectMCP(missingOptions, true)
+	if client != nil || owner != nil || err == nil {
+		t.Fatalf("client=%v owner=%v err=%v", client, owner, err)
+	}
+	if !strings.Contains(err.Error(), `runtime "`+missingName+`" is not running`) || !strings.Contains(err.Error(), "--attach-only") || !strings.Contains(err.Error(), runningName) {
+		t.Fatalf("attach-only error = %v", err)
+	}
+	registry, registryErr := kranzruntime.DefaultRegistry()
+	if registryErr != nil {
+		t.Fatal(registryErr)
+	}
+	_, resolveErr := registry.ResolveForAttach(context.Background(), missingName, version)
+	var notFound *kranzruntime.SessionNotFoundError
+	if !errors.As(resolveErr, &notFound) {
+		t.Fatalf("attach-only created a phantom runtime: %v", resolveErr)
+	}
+}
+
 func TestMCPExplicitMissingProjectNeverCreatesOwner(t *testing.T) {
 	options, _ := writeMCPProject(t)
 	options.Project = "definitely-missing-mcp-runtime"

--- a/docs/guide/mcp.md
+++ b/docs/guide/mcp.md
@@ -38,14 +38,16 @@ kranz mcp --help
 ```
 
 The bridge uses foreground stdio. Register it in an MCP client with an absolute
-project directory, then let the client start and supervise the command.
+project directory and `--attach-only`, then let the client start and supervise
+the command. This makes a missing TUI/background runtime a loud error rather
+than creating an empty project that looks successfully connected.
 
 ## Register the server
 
 ### Codex
 
 ```bash
-codex mcp add kranz -- kranz mcp -C /path/to/project
+codex mcp add kranz -- kranz mcp -C /path/to/project --attach-only
 codex mcp list
 ```
 
@@ -54,7 +56,7 @@ Codex also supports a project-scoped `.codex/config.toml`:
 ```toml
 [mcp_servers.kranz]
 command = "kranz"
-args = ["mcp", "-C", "/path/to/project"]
+args = ["mcp", "-C", "/path/to/project", "--attach-only"]
 ```
 
 The Codex CLI, IDE extension, and ChatGPT desktop app on the same host share
@@ -67,7 +69,7 @@ for client-side configuration and approval options.
 Run this from the project to keep the registration local to that checkout:
 
 ```bash
-claude mcp add --scope local kranz -- kranz mcp -C /path/to/project
+claude mcp add --scope local kranz -- kranz mcp -C /path/to/project --attach-only
 claude mcp get kranz
 ```
 
@@ -79,7 +81,7 @@ claude mcp get kranz
   "mcp": {
     "kranz": {
       "type": "local",
-      "command": ["kranz", "mcp", "-C", "/path/to/project"],
+      "command": ["kranz", "mcp", "-C", "/path/to/project", "--attach-only"],
       "enabled": true
     }
   }
@@ -116,10 +118,22 @@ the process which owns this runtime is an MCP bridge. Another user's runtime is
 named from that user's selected project configuration, not from their account
 name and not automatically `kranz`.
 
+Each MCP connection has one fixed runtime binding. Use the `runtimes` tool (or
+`kranz://runtimes`) before interpreting an empty status or a missing selector:
+it lists other sessions and marks the current one. A cross-runtime
+`selector_not_found` also reports `available_in` when, for example, `im-core`
+exists in `myclass` while this connection is bound to `harness`.
+
 Global project selection is unchanged. `kranz -C DIR mcp`, `kranz -f FILE mcp`,
 and `kranz -p NAME_OR_ID mcp` use the same config discovery and runtime registry
 as the CLI. Global flags can appear before or after `mcp`.
 Run `kranz mcp --help` for the selected build's project-selection options.
+
+`-C DIR` discovers the project at that directory; without `--attach-only` it
+may create and own the runtime when none exists. `-p NAME|ID` binds by runtime
+identity and never creates one. For an agent that moves between projects, use
+separate named registrations pinned with `-p`, rather than relying on the
+client's startup working directory to follow the conversation.
 
 Try prompts that describe an outcome rather than protocol calls:
 
@@ -137,6 +151,11 @@ keep running. If no runtime exists for the configured project, MCP creates one
 foreground owner runtime; closing that owner performs normal managed-process
 cleanup. Ambiguous, incompatible, stale, or unreachable registry entries fail
 instead of creating a competing supervisor.
+
+An owner fallback is explicit in `kranz://session` as
+`owner_reason: created_missing_runtime`, together with a hint when other
+runtimes were already live. `--attach-only` disables that fallback and prints
+the available runtimes instead.
 
 `kranz down` against an MCP-owned runtime waits until the old session has left
 the registry before reporting `Stopped`. It also disconnects every attached MCP

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -169,14 +169,14 @@ a client of that session and does not add another mode or another `ps` row.
 ### Serving a runtime to a coding agent
 
 ```bash
-kranz mcp                           # stdio MCP server on the selected runtime
+kranz mcp --attach-only             # attach-only stdio MCP server (recommended)
 ```
 
 `mcp` speaks the Model Context Protocol on stdin and stdout, so stdout carries
 JSON-RPC framing and nothing else; `--output` is refused and diagnostics go to
-stderr. It attaches to the runtime the ordinary selection rules pick, and only
-creates one of its own when that project has no runtime at all. See the [MCP
-reference](./mcp.md).
+stderr. One connection stays bound to one runtime. `--attach-only` refuses a
+missing runtime and lists other live sessions; without it, MCP can create and
+own the selected project when none exists. See the [MCP reference](./mcp.md).
 
 ### Logs
 

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -13,14 +13,17 @@ window boundaries.
 ## Command
 
 ```bash
-kranz mcp [-C DIR] [-f FILE] [-p NAME_OR_ID]
+kranz mcp [-C DIR] [-f FILE] [-p NAME_OR_ID] [--attach-only]
 kranz mcp --help
 ```
 
 Install the ordinary Kranz binary, then register this command as a local stdio
-server in the coding-agent client. Use an absolute `-C` path when the client may
-start outside the project. The [MCP guide](../guide/mcp) has ready-to-copy Codex,
-Claude Code, and OpenCode configurations plus a first-connection check.
+server in the coding-agent client. Use `--attach-only` for agent registrations:
+it refuses to create a missing runtime and names the runtimes that are already
+running. Use an absolute `-C` path for a project-scoped client, or `-p NAME|ID`
+to bind a connection to a known live runtime from any directory. The [MCP
+guide](../guide/mcp) has ready-to-copy configurations and a first-connection
+check.
 
 Do not run `kranz mcp` directly in an interactive terminal to test it: stdout
 is the protocol transport, not a human-readable prompt. Use the configured MCP
@@ -31,6 +34,7 @@ client or the repository's [minimal example client](../examples/mcp-shared-runti
 | URI | Contents |
 | --- | --- |
 | `kranz://session` | Runtime/session identity, protocol, ownership, generation |
+| `kranz://runtimes` | Registry sessions, service counts, and the current fixed binding |
 | `kranz://config` | Effective config with shared secret redaction, loader diagnostics, and provenance |
 | `kranz://services` | Definitions, snapshots, and computed `primary_action` |
 | `kranz://actions` | Service/group actions and current state |
@@ -40,7 +44,7 @@ client or the repository's [minimal example client](../examples/mcp-shared-runti
 
 ## Tools
 
-Observation tools are `status`, `changes`, `plan`, `graph`, `ports`,
+Observation tools are `runtimes`, `status`, `changes`, `plan`, `graph`, `ports`,
 `port_inspect`, `logs`, `wait`, `health`, `doctor`, `action_list`,
 `action_info`, and `action_result`. Mutations are explicit: `start`, `stop`,
 `restart`, `action_run`, `action_cancel`, `logs_clear`, and `reload`. There is
@@ -54,6 +58,12 @@ Actions always use `OWNER/ACTION`. `start` defaults
 `include_dependencies` to true; false keeps the resolved exact targets.
 Lifecycle mutations require at least one explicit selector; an omitted or empty
 list cannot turn an agent request into a project-wide start, stop, or restart.
+
+One MCP connection remains bound to one runtime. The `runtimes` tool and
+`kranz://runtimes` resource show every registry session visible to the user and
+flag the current binding. If a service/tag misses here but matches another
+running runtime, `selector_not_found` names that runtime in `available_in`
+instead of letting the caller conclude the service is globally unavailable.
 
 `logs` accepts `tail` (maximum 1000), `since` as RFC3339 or a duration,
 `sources`, `run`, `runs`, `with_actions`, and an opaque cursor. The server
@@ -112,6 +122,12 @@ Stable causal codes include `selector_not_found`, `service_unavailable`,
 `service_unavailable` is the runtime declining to answer for a service the
 configuration still declares — a reload race, or an attached runtime that went
 away mid-call.
+
+`owner_reason: created_missing_runtime` means this MCP process used the
+non-attach fallback because its selected runtime did not exist. The session
+resource also names other runtimes that were already running. Agent
+registrations should normally use `--attach-only`; omit it only when the MCP
+process is deliberately allowed to own and clean up a new stack.
 
 The allow-list cannot reach project-wide down/force-down, `StopAll`, raw force
 start/stop, shutdown, external PID/port release, arbitrary shell execution,

--- a/internal/cli/tree.go
+++ b/internal/cli/tree.go
@@ -143,7 +143,9 @@ func DefaultTree() *Command {
 			{Flags: "--force", Summary: "discard a runtime that no longer answers its socket"},
 		}},
 		{Name: "attach", Summary: "open the TUI for an active runtime"},
-		{Name: "mcp", Summary: "serve the selected runtime over MCP stdio", Usage: "kranz mcp"},
+		{Name: "mcp", Summary: "serve the selected runtime over MCP stdio", Usage: "kranz mcp [--attach-only]", Options: []Option{
+			{Flags: "--attach-only", Summary: "fail instead of creating a missing runtime; recommended for agent clients"},
+		}},
 		{Name: "logs", Summary: "show and clear logs", Default: "show", Children: []*Command{
 			{Name: "show", Summary: "show service and action logs", Usage: "kranz logs [SELECTOR ...] [--tail N | --all] [--since D]\n  [--run N | --runs N] [--source S] [--with-actions]\n  [--plain | --no-timestamps | --no-labels] [--follow]", Options: []Option{
 				{Flags: "--tail N", Summary: "show the last N lines; a service defaults to 50"},

--- a/internal/config/redact.go
+++ b/internal/config/redact.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"net/url"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -8,9 +9,7 @@ import (
 
 var secretKeyFragments = []string{"PASSWORD", "PASSWD", "SECRET", "TOKEN", "APIKEY", "API_KEY", "PRIVATE_KEY", "ACCESS_KEY", "CREDENTIAL", "AUTH", "SESSION_KEY", "SIGNING", "DSN"}
 
-// IsSecretKey is the shared config-show/MCP redaction rule. Redaction is by
-// key because a secret value is indistinguishable from ordinary text once it
-// has left its environment-variable context.
+// IsSecretKey is the shared config-show/MCP environment-key redaction rule.
 func IsSecretKey(name string) bool {
 	upper := strings.ToUpper(name)
 	for _, fragment := range secretKeyFragments {
@@ -19,6 +18,22 @@ func IsSecretKey(name string) bool {
 		}
 	}
 	return false
+}
+
+func isCredentialURL(value string) bool {
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.User == nil {
+		return false
+	}
+	_, hasPassword := parsed.User.Password()
+	return hasPassword
+}
+
+func redactEnvironmentValue(name, value string) (string, bool) {
+	if IsSecretKey(name) || isCredentialURL(value) {
+		return "[redacted]", true
+	}
+	return value, false
 }
 
 // RedactYAMLNode replaces secret-looking environment values anywhere in an
@@ -32,10 +47,11 @@ func RedactYAMLNode(node *yaml.Node) {
 			key, value := node.Content[index], node.Content[index+1]
 			if key.Value == "env" && value.Kind == yaml.MappingNode {
 				for envIndex := 0; envIndex+1 < len(value.Content); envIndex += 2 {
-					if IsSecretKey(value.Content[envIndex].Value) {
-						value.Content[envIndex+1].Value = "[redacted]"
-						value.Content[envIndex+1].Tag = "!!str"
-						value.Content[envIndex+1].Style = 0
+					envValue := value.Content[envIndex+1]
+					if redacted, changed := redactEnvironmentValue(value.Content[envIndex].Value, envValue.Value); changed {
+						envValue.Value = redacted
+						envValue.Tag = "!!str"
+						envValue.Style = 0
 					}
 				}
 				continue

--- a/internal/config/redact_test.go
+++ b/internal/config/redact_test.go
@@ -1,0 +1,28 @@
+package config
+
+import "testing"
+
+func TestRedactEnvironmentValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      string
+		value    string
+		want     string
+		redacted bool
+	}{
+		{name: "secret key", key: "API_TOKEN", value: "secret", want: "[redacted]", redacted: true},
+		{name: "postgres password", key: "DATABASE_URL", value: "postgresql://app:secret@db.example/app", want: "[redacted]", redacted: true},
+		{name: "redis password", key: "CACHE_URL", value: "redis://:secret@cache.example/0", want: "[redacted]", redacted: true},
+		{name: "url without credentials", key: "PUBLIC_URL", value: "https://example.com/app", want: "https://example.com/app"},
+		{name: "database url without password", key: "DATABASE_URL", value: "postgresql://db.example/app", want: "postgresql://db.example/app"},
+		{name: "ordinary at sign", key: "CONTACT", value: "team@example.com", want: "team@example.com"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, redacted := redactEnvironmentValue(test.key, test.value)
+			if got != test.want || redacted != test.redacted {
+				t.Fatalf("redactEnvironmentValue(%q, %q) = (%q, %t), want (%q, %t)", test.key, test.value, got, redacted, test.want, test.redacted)
+			}
+		})
+	}
+}

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -2,15 +2,19 @@ package mcp
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/kranz-org/kranz/internal/app"
 	"github.com/kranz-org/kranz/internal/config"
+	kranzruntime "github.com/kranz-org/kranz/internal/runtime"
 	"gopkg.in/yaml.v3"
 )
 
 func (s *Server) installResources() {
 	definitions := []resourceDefinition{
 		{URI: "kranz://session", Name: "session", Title: "Kranz runtime session", Description: "Runtime identity, ownership mode, protocol, and generation.", MimeType: "application/json", handler: s.sessionResource},
+		{URI: "kranz://runtimes", Name: "runtimes", Title: "Running Kranz runtimes", Description: "Registry sessions visible to this user, with the current MCP binding flagged.", MimeType: "application/json", handler: s.runtimesResource},
 		{URI: "kranz://config", Name: "config", Title: "Redacted effective configuration", Description: "Effective config and provenance paths with secret-like environment values redacted.", MimeType: "application/json", handler: s.configResource},
 		{URI: "kranz://services", Name: "services", Title: "Services", Description: "Declared services and their live runtime snapshots.", MimeType: "application/json", handler: s.servicesResource},
 		{URI: "kranz://actions", Name: "actions", Title: "Actions", Description: "Service and project actions in declaration order.", MimeType: "application/json", handler: s.actionsResource},
@@ -35,12 +39,51 @@ func (s *Server) envelope(data any) ResultEnvelope {
 }
 
 func (s *Server) errorEnvelope(err error) ResultEnvelope {
-	return ResultEnvelope{SchemaVersion: SchemaVersion, Generation: s.api.Project().Generation, Session: s.session, Error: causalError(err)}
+	causal := causalError(err)
+	if causal != nil && causal.Code == "selector_not_found" {
+		selector, _ := causal.Details["selector"].(string)
+		causal.Message = fmt.Sprintf("service or tag %q was not found in runtime %q", selector, s.session.Name)
+		causal.Hint = "This MCP connection is bound to one runtime. Read kranz://runtimes before concluding the service is unavailable."
+		causal.Details["current_runtime"] = s.session.Name
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		matches, discoveryErr := s.selectorMatches(ctx, selector)
+		cancel()
+		if discoveryErr == nil && len(matches) > 0 {
+			causal.Hint = fmt.Sprintf("This selector matches another running runtime. This MCP connection remains bound to %q; register or attach an MCP server with -p for the matching runtime.", s.session.Name)
+			causal.Details["available_in"] = matches
+		}
+	}
+	return ResultEnvelope{SchemaVersion: SchemaVersion, Generation: s.api.Project().Generation, Session: s.session, Error: causal}
 }
 
 func (s *Server) sessionResource(context.Context) ResultEnvelope {
 	project := s.api.Project()
-	return s.envelope(map[string]any{"identity": s.session, "generation": project.Generation, "loaded_at": project.LoadedAt, "last_reload_error": project.LastReloadError})
+	data := map[string]any{"identity": s.session, "generation": project.Generation, "loaded_at": project.LoadedAt, "last_reload_error": project.LastReloadError}
+	if s.session.OwnerReason != "" {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		entries, err := s.runtimeEntries(ctx)
+		cancel()
+		if err == nil {
+			others := make([]RuntimeEntry, 0)
+			for _, entry := range entries {
+				if !entry.Current && entry.State == kranzruntime.SessionRunning {
+					others = append(others, entry)
+				}
+			}
+			if len(others) > 0 {
+				data["owner_hint"] = map[string]any{"message": "MCP created the selected runtime because it was missing; other runtimes were already running.", "other_running_runtimes": others}
+			}
+		}
+	}
+	return s.envelope(data)
+}
+
+func (s *Server) runtimesResource(ctx context.Context) ResultEnvelope {
+	entries, err := s.runtimeEntries(ctx)
+	if err != nil {
+		return s.errorEnvelope(err)
+	}
+	return s.envelope(map[string]any{"runtimes": entries})
 }
 
 func (s *Server) configResource(context.Context) ResultEnvelope {

--- a/internal/mcp/runtime_discovery.go
+++ b/internal/mcp/runtime_discovery.go
@@ -1,0 +1,99 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	kranzruntime "github.com/kranz-org/kranz/internal/runtime"
+)
+
+// RuntimeEntry is the read-only registry view exposed to an MCP client. Current
+// makes the connection's fixed project binding explicit among all sessions.
+type RuntimeEntry struct {
+	ID            string                    `json:"id"`
+	Name          string                    `json:"name"`
+	Project       string                    `json:"project"`
+	Directory     string                    `json:"directory"`
+	Mode          string                    `json:"mode"`
+	State         kranzruntime.SessionState `json:"state"`
+	StartedAt     time.Time                 `json:"started_at"`
+	UptimeSeconds int64                     `json:"uptime_seconds"`
+	Services      *int                      `json:"services"`
+	Running       *int                      `json:"running"`
+	Current       bool                      `json:"current"`
+}
+
+type RuntimeSelectorMatch struct {
+	Runtime string `json:"runtime"`
+	ID      string `json:"id"`
+	Kind    string `json:"kind"`
+	Service string `json:"service,omitempty"`
+	Tag     string `json:"tag,omitempty"`
+}
+
+func (s *Server) runtimeEntries(ctx context.Context) ([]RuntimeEntry, error) {
+	if s.runtimeListOverride != nil {
+		return s.runtimeListOverride(ctx)
+	}
+	registry, err := kranzruntime.DefaultRegistry()
+	if err != nil {
+		return nil, err
+	}
+	records, err := registry.List(ctx, s.session.KranzVersion)
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]RuntimeEntry, 0, len(records))
+	for _, record := range records {
+		entries = append(entries, RuntimeEntry{
+			ID: record.ID, Name: record.Name, Project: record.Project, Directory: record.Directory,
+			Mode: record.Mode, State: record.State, StartedAt: record.StartedAt,
+			UptimeSeconds: max(0, int64(time.Since(record.StartedAt).Seconds())),
+			Services:      record.Services, Running: record.Running, Current: record.ID == s.session.ID,
+		})
+	}
+	return entries, nil
+}
+
+func (s *Server) selectorMatches(ctx context.Context, selector string) ([]RuntimeSelectorMatch, error) {
+	if s.selectorMatchOverride != nil {
+		return s.selectorMatchOverride(ctx, selector)
+	}
+	registry, err := kranzruntime.DefaultRegistry()
+	if err != nil {
+		return nil, err
+	}
+	records, err := registry.List(ctx, s.session.KranzVersion)
+	if err != nil {
+		return nil, err
+	}
+	matches := make([]RuntimeSelectorMatch, 0)
+	for _, record := range records {
+		if record.ID == s.session.ID || record.State != kranzruntime.SessionRunning {
+			continue
+		}
+		client, dialErr := kranzruntime.DialContext(ctx, record.Socket, s.session.KranzVersion)
+		if dialErr != nil {
+			continue
+		}
+		cfg := client.Config()
+		_ = client.Close()
+		if cfg == nil {
+			continue
+		}
+		if _, ok := cfg.Services[selector]; ok {
+			matches = append(matches, RuntimeSelectorMatch{Runtime: record.Name, ID: record.ID, Kind: "service", Service: selector})
+			continue
+		}
+		for _, name := range cfg.ServiceOrder {
+			for _, tag := range cfg.Services[name].Tags {
+				if strings.EqualFold(tag, selector) {
+					matches = append(matches, RuntimeSelectorMatch{Runtime: record.Name, ID: record.ID, Kind: "tag", Service: name, Tag: tag})
+					break
+				}
+			}
+		}
+	}
+	return matches, nil
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -40,6 +40,9 @@ type Server struct {
 	toolOrder     []string
 	resources     map[string]resourceDefinition
 	resourceOrder []string
+
+	runtimeListOverride   func(context.Context) ([]RuntimeEntry, error)
+	selectorMatchOverride func(context.Context, string) ([]RuntimeSelectorMatch, error)
 }
 
 func NewServer(api app.API, session SessionIdentity, stdin io.Reader, stdout, stderr io.Writer) *Server {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/kranz-org/kranz/internal/app"
 	"github.com/kranz-org/kranz/internal/config"
+	kranzruntime "github.com/kranz-org/kranz/internal/runtime"
 )
 
 func testServer(t *testing.T) (*Server, *app.Local) {
@@ -21,7 +22,11 @@ func testServer(t *testing.T) (*Server, *app.Local) {
 	interactive := true
 	confirm := true
 	cfg := &config.Config{Project: "demo", Services: map[string]config.Service{
-		"api": {Command: "exit 0", Tags: []string{"backend"}, Env: map[string]string{"API_TOKEN": "super-secret"}, Actions: map[string]config.Action{
+		"api": {Command: "exit 0", Tags: []string{"backend"}, Env: map[string]string{
+			"API_TOKEN":    "super-secret",
+			"DATABASE_URL": "postgresql://app:database-secret@db.example/app",
+			"PUBLIC_URL":   "https://example.com",
+		}, Actions: map[string]config.Action{
 			"shell":   {Command: "sh", Interactive: &interactive},
 			"migrate": {Command: "printf 'migrated\\n'", Shell: "/bin/sh"},
 			"deploy":  {Command: "exit 0", Shell: "/bin/sh", Confirm: &confirm},
@@ -55,15 +60,18 @@ func TestConfigResourceUsesSharedRedaction(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := string(payload)
-	if strings.Contains(text, "super-secret") {
+	if strings.Contains(text, "super-secret") || strings.Contains(text, "database-secret") {
 		t.Fatalf("config leaked a secret: %s", text)
 	}
-	if !strings.Contains(text, `"API_TOKEN":"[redacted]"`) {
+	if !strings.Contains(text, `"API_TOKEN":"[redacted]"`) || !strings.Contains(text, `"DATABASE_URL":"[redacted]"`) {
 		t.Fatalf("redacted value missing: %s", text)
+	}
+	if !strings.Contains(text, `"PUBLIC_URL":"https://example.com"`) {
+		t.Fatalf("public URL was redacted: %s", text)
 	}
 	services := server.resources["kranz://services"].handler(context.Background())
 	payload, _ = json.Marshal(services)
-	if strings.Contains(string(payload), "super-secret") || !strings.Contains(string(payload), "[redacted]") {
+	if strings.Contains(string(payload), "super-secret") || strings.Contains(string(payload), "database-secret") || !strings.Contains(string(payload), "[redacted]") {
 		t.Fatalf("services redaction = %s", payload)
 	}
 }
@@ -330,8 +338,8 @@ func TestCapabilitySurfaceIsExactAllowList(t *testing.T) {
 			t.Fatalf("unsafe tool %q is reachable", forbidden)
 		}
 	}
-	if got := len(server.resourceOrder); got != 8 {
-		t.Fatalf("resources = %d, want 8", got)
+	if got := len(server.resourceOrder); got != 9 {
+		t.Fatalf("resources = %d, want 9", got)
 	}
 	for _, definition := range server.listTools() {
 		if definition.InputSchema["additionalProperties"] != false {
@@ -342,6 +350,61 @@ func TestCapabilitySurfaceIsExactAllowList(t *testing.T) {
 		t.Fatal("generic/unsafe tool dispatch succeeded")
 	}
 }
+
+func TestRuntimesToolAndResourceFlagCurrentBinding(t *testing.T) {
+	server, _ := testServer(t)
+	entries := []RuntimeEntry{
+		{ID: "session-1", Name: "harness", State: kranzruntime.SessionRunning, Current: true},
+		{ID: "other-1", Name: "myclass", State: kranzruntime.SessionRunning, Services: intPointer(4)},
+	}
+	server.runtimeListOverride = func(context.Context) ([]RuntimeEntry, error) { return entries, nil }
+	for _, result := range []ResultEnvelope{
+		server.tools["runtimes"].handler(context.Background(), json.RawMessage(`{}`)),
+		server.resources["kranz://runtimes"].handler(context.Background()),
+	} {
+		if result.Error != nil {
+			t.Fatalf("runtimes = %#v", result.Error)
+		}
+		payload, _ := json.Marshal(result.Data)
+		if !strings.Contains(string(payload), `"name":"harness"`) || !strings.Contains(string(payload), `"current":true`) || !strings.Contains(string(payload), `"name":"myclass"`) {
+			t.Fatalf("runtimes payload = %s", payload)
+		}
+	}
+}
+
+func TestSelectorNotFoundNamesCurrentAndMatchingRuntime(t *testing.T) {
+	server, _ := testServer(t)
+	server.session.Name = "harness"
+	server.selectorMatchOverride = func(_ context.Context, selector string) ([]RuntimeSelectorMatch, error) {
+		if selector != "im-core" {
+			t.Fatalf("selector = %q", selector)
+		}
+		return []RuntimeSelectorMatch{{Runtime: "myclass", ID: "ec52bcfb", Kind: "service", Service: "im-core"}}, nil
+	}
+	result := server.tools["status"].handler(context.Background(), json.RawMessage(`{"selectors":["im-core"]}`))
+	if result.Error == nil || result.Error.Code != "selector_not_found" || !strings.Contains(result.Error.Message, `runtime "harness"`) || !strings.Contains(result.Error.Hint, "another running runtime") {
+		t.Fatalf("error = %#v", result.Error)
+	}
+	payload, _ := json.Marshal(result.Error.Details)
+	if !strings.Contains(string(payload), `"runtime":"myclass"`) || !strings.Contains(string(payload), `"service":"im-core"`) {
+		t.Fatalf("details = %s", payload)
+	}
+}
+
+func TestOwnerFallbackSessionNamesOtherRunningRuntimes(t *testing.T) {
+	server, _ := testServer(t)
+	server.session.OwnerReason = "created_missing_runtime"
+	server.runtimeListOverride = func(context.Context) ([]RuntimeEntry, error) {
+		return []RuntimeEntry{{ID: "session-1", Name: "harness", Current: true, State: kranzruntime.SessionRunning}, {ID: "other", Name: "myclass", State: kranzruntime.SessionRunning}}, nil
+	}
+	result := server.resources["kranz://session"].handler(context.Background())
+	payload, _ := json.Marshal(result)
+	if !strings.Contains(string(payload), `"owner_reason":"created_missing_runtime"`) || !strings.Contains(string(payload), `"other_running_runtimes"`) || !strings.Contains(string(payload), `"name":"myclass"`) {
+		t.Fatalf("session = %s", payload)
+	}
+}
+
+func intPointer(value int) *int { return &value }
 
 func TestEveryResultCarriesIdentityGenerationAndSchema(t *testing.T) {
 	server, _ := testServer(t)

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -25,7 +25,7 @@ const waitTransportGrace = 5 * time.Second
 // exactly, so a tool cannot appear without being listed here, and a listed
 // name cannot resolve to nothing.
 var toolNames = []string{
-	"status", "runs", "changes", "plan", "graph", "ports", "port_inspect", "logs", "wait", "health",
+	"runtimes", "status", "runs", "changes", "plan", "graph", "ports", "port_inspect", "logs", "wait", "health",
 	"action_list", "action_info", "action_result",
 	"doctor", "start", "stop", "restart", "action_run", "action_cancel", "logs_clear", "reload",
 }
@@ -45,6 +45,7 @@ var (
 
 func (s *Server) installTools() {
 	definitions := []toolDefinition{
+		{Name: "runtimes", Description: "List Kranz runtime sessions visible to this user and flag the runtime this MCP connection is bound to.", InputSchema: objectSchema(map[string]any{}), handler: s.runtimesTool},
 		{Name: "status", Description: "Return live status for selected services, including the structured cause of a state whose reason is not the state itself.", InputSchema: objectSchema(map[string]any{"selectors": selectorsProperty}), handler: s.statusTool},
 		{Name: "runs", Description: "Return the bounded service and action run catalog with provenance and output retention state.", InputSchema: objectSchema(map[string]any{}), handler: s.runsTool},
 		{Name: "changes", Description: "Return what changed in the runtime after a cursor: service and action transitions, detected-port changes, and configuration reloads.", InputSchema: objectSchema(map[string]any{
@@ -90,6 +91,18 @@ func (s *Server) installTools() {
 			panic("MCP tool allow-list names an unimplemented tool: " + name)
 		}
 	}
+}
+
+func (s *Server) runtimesTool(ctx context.Context, raw json.RawMessage) ResultEnvelope {
+	var args struct{}
+	if err := decodeArgs(raw, &args); err != nil {
+		return s.argError(err)
+	}
+	entries, err := s.runtimeEntries(ctx)
+	if err != nil {
+		return s.errorEnvelope(err)
+	}
+	return s.envelope(map[string]any{"runtimes": entries})
 }
 
 func (s *Server) runsTool(_ context.Context, raw json.RawMessage) ResultEnvelope {

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -29,6 +29,7 @@ type SessionIdentity struct {
 	RuntimeMode     string `json:"runtime_mode"`
 	ConnectionMode  string `json:"connection_mode"`
 	OwnerKind       string `json:"owner_kind"`
+	OwnerReason     string `json:"owner_reason,omitempty"`
 	KranzVersion    string `json:"kranz_version"`
 	ProtocolVersion int    `json:"runtime_protocol_version"`
 }


### PR DESCRIPTION
## Summary
- expose running runtimes to MCP and make the current fixed binding explicit
- enrich selector misses with matching services/tags in other live runtimes
- add `--attach-only`, visible owner fallback, and agent registration guidance
- redact credential-bearing URLs from config and MCP service views

## Validation
- `go test -race ./...`
- `make lint`
- `make verify`
- `make release-check`
- Kranz action `development/build`
- read-only live MCP smoke against `myclass` / `im-core`

Target: 0.10.0. No release or tag.