### PR TITLE
fix(tui): clarify run history state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 
 ### Fixed
 
+- Run-view titles now distinguish auto-updating combined output, the latest
+  isolated run, and historical runs without conflating "live" process state
+  with history position. Pinned panels show the `Shift+3` unpin action, which
+  now removes the existing pin from any focused panel.
 - Config and MCP service views now redact credential-bearing URLs even when
   their environment variable name is not itself secret-looking.
 - Replacing an in-process runtime can no longer capture the outgoing owner's

--- a/docs/reference/controls.md
+++ b/docs/reference/controls.md
@@ -13,7 +13,7 @@ modal actions, search controls, and the theme picker.
 | `t`, `←` / `→`, or `1` again | Switch Services and Tags |
 | `Tab` / `Shift+Tab` | Focus next or previous panel |
 | `↑` / `↓`, `j` / `k` | Navigate or scroll |
-| `Shift+3` | Pin or unpin focused service logs |
+| `Shift+3` | Pin the current run, or unpin the existing view from any panel |
 | `Enter` | Expand/collapse tags, services, actions, or action groups |
 
 ## Lifecycle and actions
@@ -54,6 +54,12 @@ directions.
 | `v` | Open the filterable run list |
 | `Shift+3` | Pin the selected `{target, run, view mode}` snapshot |
 | `e` / `Shift+E` | Export selected run to clipboard / chosen file |
+
+The log header names the history position explicitly: `ALL RUNS · INCLUDES NEW`
+keeps accepting new runs, `LATEST RUN · #N` shows the newest run in isolation,
+and `HISTORY · RUN #N` means a newer run exists. A pinned panel is frozen and
+shows `Shift+3 UNPIN` in its title; while any pin exists the footer starts with
+`[Shift+3] unpin`, and the shortcut works from every panel.
 
 ## Application
 

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -103,7 +103,7 @@ func DefaultKeyMap() KeyMap {
 		),
 		PinLogs: key.NewBinding(
 			key.WithKeys("#", "shift+3"),
-			key.WithHelp("Shift+3", "pin/unpin focused logs"),
+			key.WithHelp("Shift+3", "pin current/unpin existing"),
 		),
 		Reload: key.NewBinding(
 			key.WithKeys("ctrl+l"),

--- a/internal/ui/model_logs_test.go
+++ b/internal/ui/model_logs_test.go
@@ -138,7 +138,7 @@ func TestShiftThreePinsLogsAboveFocusedLogs(t *testing.T) {
 
 	rendered := model.renderLogColumn(64, model.height-2)
 	plain := ansi.Strip(rendered)
-	for _, expected := range []string{"PINNED LOGS", "api log remains visible", "[3] LOGS", "worker", "WORKER matched line"} {
+	for _, expected := range []string{"PINNED [Shift+3 UNPIN]", "api log remains visible", "[3] LOGS", "worker", "WORKER matched line"} {
 		if !strings.Contains(plain, expected) {
 			t.Errorf("split logs do not contain %q:\n%s", expected, plain)
 		}
@@ -180,7 +180,7 @@ func TestThreeSwitchesAndScrollsPinnedLogsIndependently(t *testing.T) {
 		t.Fatalf("pinned/current viewports = %d/%v and %d/%v", model.pinnedOffset, model.pinnedFollow, model.logOffset, model.followMode)
 	}
 	plain := ansi.Strip(model.renderLogColumn(64, model.height-2))
-	if !strings.Contains(plain, "PINNED LOGS") || !strings.Contains(plain, "BROWSING") {
+	if !strings.Contains(plain, "PINNED [Shift+3 UNPIN]") || !strings.Contains(plain, "BROWSING") {
 		t.Fatalf("focused pinned viewport does not expose its browsing state:\n%s", plain)
 	}
 	pressKey(model, '3')
@@ -200,18 +200,18 @@ func TestThreeSwitchesAndScrollsPinnedLogsIndependently(t *testing.T) {
 	}
 }
 
-func TestShiftThreeReplacesAndUnpinsPinnedService(t *testing.T) {
+func TestShiftThreeUnpinsFromAnyPanelThenPinsCurrentService(t *testing.T) {
 	model := newTestModel()
 	defer model.Shutdown()
 	pressKey(model, '#')
 	model.moveFocus(1)
 	pressKey(model, '#')
-	if model.pinnedLog != "worker" {
-		t.Fatalf("replacement pinned service = %q", model.pinnedLog)
+	if model.pinnedLog != "" || model.PinnedService() != nil {
+		t.Fatalf("pinned service was not cleared from current panel: %q", model.pinnedLog)
 	}
 	pressKey(model, '#')
-	if model.pinnedLog != "" || model.PinnedService() != nil {
-		t.Fatalf("pinned service was not cleared: %q", model.pinnedLog)
+	if model.pinnedLog != "worker" {
+		t.Fatalf("current service was not pinned after unpin: %q", model.pinnedLog)
 	}
 }
 

--- a/internal/ui/model_selection.go
+++ b/internal/ui/model_selection.go
@@ -118,6 +118,10 @@ func (m *Model) toggleAllSelection() {
 }
 
 func (m *Model) togglePinnedLog() {
+	if m.hasPinnedRunView() {
+		m.unpinRunView()
+		return
+	}
 	if m.focusedActionGroup != "" {
 		return
 	}
@@ -132,18 +136,6 @@ func (m *Model) togglePinnedLog() {
 	if m.runMode == runViewSingle && m.selectedRun > 0 {
 		run = m.selectedRun
 	}
-	if m.pinnedTarget == target && m.pinnedRunMode == m.runMode && m.pinnedRun == run ||
-		m.pinnedTarget.Kind == "" && target.Kind == app.RunKindService && m.pinnedLog == target.Name {
-		m.pinnedLog = ""
-		m.pinnedTarget = app.RunTarget{}
-		m.pinnedRun = 0
-		m.pinnedOffset, m.pinnedAnchor, m.pinnedFollow = 0, 0, true
-		if m.panelFocus == panelPinnedLogs {
-			m.panelFocus = panelLogs
-		}
-		m.addNotification("logs", "Pinned log closed", config.LogInfo)
-		return
-	}
 	m.pinnedTarget, m.pinnedRunMode, m.pinnedRun = target, m.runMode, run
 	m.pinnedLog = ""
 	if target.Kind == app.RunKindService {
@@ -154,6 +146,17 @@ func (m *Model) togglePinnedLog() {
 	}
 	m.pinnedOffset, m.pinnedAnchor, m.pinnedFollow = 0, 0, true
 	m.addNotification("logs", fmt.Sprintf("Pinned logs: %s#%d", runTargetLabel(target), run), config.LogInfo)
+}
+
+func (m *Model) unpinRunView() {
+	m.pinnedLog = ""
+	m.pinnedTarget = app.RunTarget{}
+	m.pinnedRun = 0
+	m.pinnedOffset, m.pinnedAnchor, m.pinnedFollow = 0, 0, true
+	if m.panelFocus == panelPinnedLogs {
+		m.panelFocus = panelLogs
+	}
+	m.addNotification("logs", "Pinned run closed", config.LogInfo)
 }
 
 func (m *Model) toggleListMode() {

--- a/internal/ui/run_view.go
+++ b/internal/ui/run_view.go
@@ -209,16 +209,19 @@ func (m *Model) runSummary(target app.RunTarget, run uint32) (app.RunSummary, bo
 
 func (m *Model) runViewLabel() string {
 	if !m.syncRunTarget() || m.runMode == runViewCombined {
-		return "ALL"
+		return "ALL RUNS · INCLUDES NEW"
 	}
 	latest := latestRun(m.runsForTarget(m.runTarget))
-	label := fmt.Sprintf("RUN #%d", m.selectedRun)
-	if m.selectedRun == latest {
-		label += " · LIVE/LATEST"
-	} else if latest > m.selectedRun {
-		label += fmt.Sprintf(" · %d NEWER", latest-m.selectedRun)
+	if latest == 0 {
+		return "NO RUNS YET"
 	}
-	return label
+	if m.selectedRun == latest {
+		return fmt.Sprintf("LATEST RUN · #%d", m.selectedRun)
+	}
+	if latest > m.selectedRun {
+		return fmt.Sprintf("HISTORY · RUN #%d · %d NEWER · [L] LATEST", m.selectedRun, latest-m.selectedRun)
+	}
+	return fmt.Sprintf("HISTORY · RUN #%d", m.selectedRun)
 }
 
 func runTargetLabel(target app.RunTarget) string {
@@ -230,9 +233,9 @@ func runTargetLabel(target app.RunTarget) string {
 
 func (m *Model) pinnedRunViewLabel() string {
 	if m.pinnedRunMode == runViewSingle {
-		return fmt.Sprintf("RUN #%d · SNAPSHOT", m.pinnedRun)
+		return fmt.Sprintf("FROZEN · RUN #%d", m.pinnedRun)
 	}
-	return fmt.Sprintf("ALL ≤ #%d · SNAPSHOT", m.pinnedRun)
+	return fmt.Sprintf("FROZEN · RUNS THROUGH #%d", m.pinnedRun)
 }
 
 func (m *Model) pinnedEntries(target app.RunTarget) []config.LogEntry {
@@ -254,7 +257,7 @@ func (m *Model) pinnedEntries(target app.RunTarget) []config.LogEntry {
 
 func (m *Model) renderPinnedActionRunPanel(target app.RunTarget, width, height int) string {
 	contentWidth, contentHeight := max(1, width-2), max(1, height-2)
-	title := "[3] PINNED ACTION" + ContextBarStyle.Render(" │ ") + ServiceNameStyle.Render(runTargetLabel(target)) +
+	title := "[3] PINNED ACTION [Shift+3 UNPIN]" + ContextBarStyle.Render(" │ ") + ServiceNameStyle.Render(runTargetLabel(target)) +
 		" " + RunningBadgeStyle.Render(m.pinnedRunViewLabel())
 	entries := m.pinnedEntries(target)
 	if len(entries) == 0 {

--- a/internal/ui/run_view_test.go
+++ b/internal/ui/run_view_test.go
@@ -31,8 +31,34 @@ func TestSingleRunViewerNavigatesStableServiceRuns(t *testing.T) {
 	if !strings.Contains(plain, "first failed output") || strings.Contains(plain, "second successful output") {
 		t.Fatalf("single run leaked another run:\n%s", plain)
 	}
-	if !strings.Contains(plain, "1 NEWER") {
+	if !strings.Contains(plain, "HISTORY · RUN #1 · 1 NEWER · [L] LATEST") {
 		t.Fatalf("historical run has no newer-runs indicator:\n%s", plain)
+	}
+}
+
+func TestRunLabelsSeparateAutoUpdatingLatestAndHistoryViews(t *testing.T) {
+	model := newTestModel()
+	defer model.Shutdown()
+
+	finishTestServiceRun(t, model, "api", 0, "run one")
+	finishTestServiceRun(t, model, "api", 0, "run two")
+	model.refreshServices()
+	if got := model.runViewLabel(); got != "ALL RUNS · INCLUDES NEW" {
+		t.Fatalf("combined label = %q", got)
+	}
+	model.selectLatestRun()
+	if got := model.runViewLabel(); got != "LATEST RUN · #2" {
+		t.Fatalf("latest label = %q", got)
+	}
+
+	finishTestServiceRun(t, model, "api", 0, "run three")
+	model.refreshServices()
+	if got := model.runViewLabel(); got != "HISTORY · RUN #2 · 1 NEWER · [L] LATEST" {
+		t.Fatalf("history label = %q", got)
+	}
+	model.selectLatestRun()
+	if got := model.runViewLabel(); got != "LATEST RUN · #3" {
+		t.Fatalf("returned latest label = %q", got)
 	}
 }
 
@@ -96,8 +122,33 @@ func TestPinnedHistoricalRunRemainsImmutableAfterNewStart(t *testing.T) {
 	if !strings.Contains(plain, "run one snapshot") || strings.Contains(plain, "run two output") || strings.Contains(plain, "run three output") {
 		t.Fatalf("pinned run changed after newer starts:\n%s", plain)
 	}
-	if !strings.Contains(plain, "RUN #1 · SNAPSHOT") {
+	if !strings.Contains(plain, "FROZEN · RUN #1") || !strings.Contains(plain, "Shift+3 UNPIN") {
 		t.Fatalf("pin identity is not explicit:\n%s", plain)
+	}
+}
+
+func TestFocusedPinnedPanelCanAlwaysBeUnpinned(t *testing.T) {
+	model := newTestModel()
+	defer model.Shutdown()
+	model.width, model.height, model.ready = 100, 28, true
+	finishTestServiceRun(t, model, "api", 0, "pinned history")
+	model.refreshServices()
+	model.selectLatestRun()
+	model.togglePinnedLog()
+	model.moveFocus(1) // The current panel now points at another service.
+	model.panelFocus = panelPinnedLogs
+	model.notifMu.Lock()
+	model.toastMessage = ""
+	model.notifMu.Unlock()
+
+	panel := ansi.Strip(model.renderLogColumn(80, model.height-2))
+	footer := ansi.Strip(model.contextMessage())
+	if !strings.Contains(panel, "Shift+3 UNPIN") || !strings.Contains(footer, "[Shift+3] unpin") {
+		t.Fatalf("unpin control is not visible:\npanel=%s\nfooter=%s", panel, footer)
+	}
+	pressKey(model, '#')
+	if model.hasPinnedRunView() || model.panelFocus != panelLogs {
+		t.Fatalf("focused pinned panel was not closed: pinned=%v focus=%v", model.hasPinnedRunView(), model.panelFocus)
 	}
 }
 
@@ -158,7 +209,7 @@ func TestActionOutputDefaultsToSingleLatestRun(t *testing.T) {
 	}
 	model.focusedAction = &id
 	plain := ansi.Strip(model.renderActionLogPanel(100, 12))
-	if model.runMode != runViewSingle || model.selectedRun != 1 || !strings.Contains(plain, "RUN #1 · LIVE/LATEST") || !strings.Contains(plain, "action-output") {
+	if model.runMode != runViewSingle || model.selectedRun != 1 || !strings.Contains(plain, "LATEST RUN · #1") || !strings.Contains(plain, "action-output") {
 		t.Fatalf("action did not open latest single run: mode=%d run=%d\n%s", model.runMode, model.selectedRun, plain)
 	}
 }

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -340,11 +340,20 @@ func (m *Model) contextMessage() string {
 	if toast != "" {
 		return toast + " "
 	}
-	if svc := m.FocusedService(); svc != nil {
-		mode := "filter"
-		if m.searchMode == searchHighlight {
-			mode = "highlight"
+	mode := "filter"
+	if m.activeSearchMode() == searchHighlight {
+		mode = "highlight"
+	}
+	if target, ok := m.pinnedRunTarget(); ok {
+		searchTarget := runTargetLabel(target)
+		if m.panelFocus != panelPinnedLogs {
+			if svc := m.FocusedService(); svc != nil {
+				searchTarget = svc.Name
+			}
 		}
+		return fmt.Sprintf("[Shift+3] unpin %s · [/] regex %s · %s ", runTargetLabel(target), mode, searchTarget)
+	}
+	if svc := m.FocusedService(); svc != nil {
 		return fmt.Sprintf("[/] regex %s · %s ", mode, svc.Name)
 	}
 	return "[?] help "

--- a/internal/ui/view_logs.go
+++ b/internal/ui/view_logs.go
@@ -28,7 +28,7 @@ func (m *Model) renderLogColumn(width, height int) string {
 	topHeight, bottomHeight := m.logColumnLayout(height)
 	top := m.renderPinnedRunPanel(pinnedTarget, width, topHeight)
 	if topHeight == collapsedPanelHeight {
-		top = renderCollapsedPanel("[3] PINNED LOGS │ "+runTargetLabel(pinnedTarget), width)
+		top = renderCollapsedPanel("[3] PINNED [Shift+3 UNPIN] │ "+runTargetLabel(pinnedTarget), width)
 	}
 	focused := m.FocusedService()
 	bottom := m.renderLogPanel(focused, width, bottomHeight)
@@ -213,7 +213,7 @@ func (m *Model) renderLogPanelMode(svc *app.ServiceSnapshot, width, height int, 
 	if pinned {
 		panelStyle = m.panelStyle(panelPinnedLogs)
 		titleStyle = m.panelTitleStyle(panelPinnedLogs)
-		titlePrefix = "[3] PINNED LOGS"
+		titlePrefix = "[3] PINNED [Shift+3 UNPIN]"
 		followMode, logOffset, logAnchor, logPaused = m.pinnedFollow, m.pinnedOffset, m.pinnedAnchor, false
 	}
 	if svc == nil {
@@ -236,10 +236,9 @@ func (m *Model) renderLogPanelMode(svc *app.ServiceSnapshot, width, height int, 
 	if m.showLogTime {
 		title += " " + RunningBadgeStyle.Render("TIME")
 	}
+	runLabel := m.pinnedRunViewLabel()
 	if !pinned {
-		title += " " + RunningBadgeStyle.Render(m.runViewLabel())
-	} else {
-		title += " " + RunningBadgeStyle.Render(m.pinnedRunViewLabel())
+		runLabel = m.runViewLabel()
 	}
 
 	sourceEntries := m.app.Logs(svc.Name)
@@ -264,6 +263,7 @@ func (m *Model) renderLogPanelMode(svc *app.ServiceSnapshot, width, height int, 
 		}
 		title += SearchInputStyle.Render(fmt.Sprintf("  %s /%s/ · %d", modeLabel, searcher.Pattern(), len(searchMatches)))
 	}
+	title += " " + RunningBadgeStyle.Render(runLabel)
 	matchSet := make(map[int]bool, len(searchMatches))
 	for _, idx := range searchMatches {
 		matchSet[idx] = true

--- a/internal/ui/view_modals.go
+++ b/internal/ui/view_modals.go
@@ -42,8 +42,8 @@ func (m *Model) renderHelpView() string {
 func helpEntries() []helpEntry {
 	return []helpEntry{
 		{"1 / 2 / 3", "Focus panels; 1 switches Services/Tags when the list is focused"},
-		{"Shift+3", "Pin focused service logs above the active log panel"},
-		{"3 again", "Switch focus between pinned and current logs"},
+		{"Shift+3", "Pin the current run; if a pin exists, unpin it from any panel"},
+		{"3", "Switch focus between pinned and current logs"},
 		{"Tab / Shift+Tab", "Focus the next or previous panel, including pinned logs"},
 		{"↑/↓ j/k", "Navigate or scroll focused panel"},
 		{"←/→", "Cycle Services/Tags while the list panel is focused"},


### PR DESCRIPTION
## Summary
- replace ambiguous LIVE/LATEST/SNAPSHOT labels with explicit all-runs, latest-run, history, and frozen states
- show the shortcut for returning from history to latest
- make Shift+3 unpin the existing frozen view from any panel and surface that control in the title/footer/help

## Validation
- `go test ./internal/ui`
- `make verify`
- `make lint`
- `make release-check`
- Kranz action `development/build`

Target: 0.10.0. No release or tag.