### PR TITLE
fix(tui): keep latest runs and scroll full history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 
 ### Fixed
 
+- The isolated latest-run view now follows subsequent starts until the user
+  explicitly enters history. Combined action output scrolls across all retained
+  runs instead of using the latest result as its viewport boundary, and the
+  shortcut reference is a sectioned single-column list.
 - Run-view titles now distinguish auto-updating combined output, the latest
   isolated run, and historical runs without conflating "live" process state
   with history position. Pinned panels show the `Shift+3` unpin action, which

--- a/docs/reference/controls.md
+++ b/docs/reference/controls.md
@@ -61,6 +61,15 @@ and `HISTORY · RUN #N` means a newer run exists. A pinned panel is frozen and
 shows `Shift+3 UNPIN` in its title; while any pin exists the footer starts with
 `[Shift+3] unpin`, and the shortcut works from every panel.
 
+`LATEST RUN` follows future starts automatically. Choosing an older run with
+`[`, the catalog, or previous-failed navigation enters `HISTORY`; that explicit
+selection remains stable until `l` returns to the latest run. The all-runs view
+scrolls across the complete retained output of service and action runs.
+
+The in-app `?` reference is a single scrollable column split into Navigation,
+Services & Actions, Logs & Run History, Log Search, Appearance, and Application
+sections.
+
 ## Application
 
 | Key | Action |

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -220,6 +220,7 @@ type Model struct {
 	runTarget        app.RunTarget
 	runMode          runViewMode
 	selectedRun      uint32
+	runFollowsLatest bool
 	runListCursor    int
 	runStatusFilter  string
 	runViewports     map[runViewportKey]runViewportState

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -785,10 +785,10 @@ func TestHelpWrapsDescriptionsAndScrollsWithoutTruncatingThem(t *testing.T) {
 	model.width, model.height, model.ready = 80, 24, true
 	body := ansi.Strip(strings.Join(model.helpBodyLines(), "\n"))
 	for _, description := range []string{
-		"Focus panels; 1 switches Services/Tags when the list is focused",
-		"Pin focused service logs above the active log panel",
-		"Regex filter; Tab switches to highlight",
-		"Choose and apply a theme",
+		"Focus Services, Details, or Logs; 1 toggles Services/Tags when already focused",
+		"Pin the current run; if a pin exists, unpin it from any panel",
+		"Open regex search; Tab switches filter/highlight",
+		"Open the theme and appearance picker",
 	} {
 		if rebuilt := strings.Join(wrapHelpText(description, 24), " "); rebuilt != description {
 			t.Errorf("wrapped help rebuilt %q as %q", description, rebuilt)
@@ -808,6 +808,14 @@ func TestHelpWrapsDescriptionsAndScrollsWithoutTruncatingThem(t *testing.T) {
 	if widest <= 66 {
 		t.Fatalf("help did not become materially wider: widest line = %d", widest)
 	}
+	lastSection := -1
+	for _, section := range []string{"NAVIGATION", "SERVICES & ACTIONS", "LOGS & RUN HISTORY", "LOG SEARCH", "APPEARANCE", "APPLICATION"} {
+		index := strings.Index(body, section)
+		if index <= lastSection {
+			t.Fatalf("help section %q missing or out of order:\n%s", section, body)
+		}
+		lastSection = index
+	}
 
 	model.mode = ModeHelp
 	initial := ansi.Strip(model.renderHelpView())
@@ -822,7 +830,7 @@ func TestHelpWrapsDescriptionsAndScrollsWithoutTruncatingThem(t *testing.T) {
 	}
 }
 
-func TestHelpUsesTheWiderLimitAndRespectsTerminalBackground(t *testing.T) {
+func TestHelpUsesOneWideColumnAndRespectsTerminalBackground(t *testing.T) {
 	defer func() { _, _ = ApplyTheme(DefaultTheme, "") }()
 	dark := true
 	model := NewModelWithOptions(&config.Config{
@@ -835,6 +843,10 @@ func TestHelpUsesTheWiderLimitAndRespectsTerminalBackground(t *testing.T) {
 	widest := 0
 	for _, line := range model.helpBodyLines() {
 		widest = max(widest, lipgloss.Width(line))
+		plain := ansi.Strip(line)
+		if strings.Contains(plain, "1 / 2 / 3") && strings.Contains(plain, "Ctrl+T") {
+			t.Fatalf("help still renders two shortcut columns: %q", plain)
+		}
 	}
 	if widest <= 100 || widest > 105 {
 		t.Fatalf("help body width = %d, want the new 101–105 cell range", widest)

--- a/internal/ui/mouse.go
+++ b/internal/ui/mouse.go
@@ -306,6 +306,7 @@ func (m *Model) handleOverlayMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 				m.runListCursor = index
 				m.saveRunViewport()
 				m.selectedRun, m.runMode, m.mode = run.Run, runViewSingle, ModeNormal
+				m.runFollowsLatest = run.Run == latestRun(m.runsForTarget(m.runTarget))
 				m.restoreRunViewport()
 				return m, nil
 			}

--- a/internal/ui/run_view.go
+++ b/internal/ui/run_view.go
@@ -38,8 +38,10 @@ func (m *Model) syncRunTarget() bool {
 		m.runTarget = target
 		m.selectedRun = 0
 		m.runMode = runViewCombined
+		m.runFollowsLatest = false
 		if target.Kind == app.RunKindAction {
 			m.runMode = runViewSingle
+			m.runFollowsLatest = true
 		}
 		if !initial {
 			key := m.runViewportKey()
@@ -49,8 +51,15 @@ func (m *Model) syncRunTarget() bool {
 			m.restoreRunViewport()
 		}
 	}
-	if m.runMode == runViewSingle && m.selectedRun == 0 {
-		m.selectedRun = latestRun(m.runsForTarget(target))
+	if m.runMode == runViewSingle && (m.selectedRun == 0 || m.runFollowsLatest) {
+		latest := latestRun(m.runsForTarget(target))
+		if latest != m.selectedRun {
+			if m.selectedRun > 0 {
+				m.saveRunViewport()
+			}
+			m.selectedRun = latest
+			m.restoreRunViewport()
+		}
 	}
 	return true
 }
@@ -81,8 +90,10 @@ func (m *Model) toggleRunView() {
 	if m.runMode == runViewCombined {
 		m.runMode = runViewSingle
 		m.selectedRun = latestRun(m.runsForTarget(m.runTarget))
+		m.runFollowsLatest = true
 	} else {
 		m.runMode = runViewCombined
+		m.runFollowsLatest = false
 	}
 	m.restoreRunViewport()
 }
@@ -94,6 +105,7 @@ func (m *Model) selectLatestRun() {
 	m.saveRunViewport()
 	m.runMode = runViewSingle
 	m.selectedRun = latestRun(m.runsForTarget(m.runTarget))
+	m.runFollowsLatest = true
 	m.restoreRunViewport()
 }
 
@@ -120,6 +132,7 @@ func (m *Model) moveRun(direction int, failedOnly bool) {
 		if !failedOnly || runFailed(runs[next]) {
 			m.saveRunViewport()
 			m.runMode, m.selectedRun = runViewSingle, runs[next].Run
+			m.runFollowsLatest = runs[next].Run == latestRun(runs)
 			m.restoreRunViewport()
 			return
 		}
@@ -359,6 +372,7 @@ func (m *Model) handleRunListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if len(runs) > 0 {
 			m.saveRunViewport()
 			m.selectedRun, m.runMode = runs[m.runListCursor].Run, runViewSingle
+			m.runFollowsLatest = m.selectedRun == latestRun(m.runsForTarget(m.runTarget))
 			m.restoreRunViewport()
 		}
 		m.mode = ModeNormal

--- a/internal/ui/run_view_test.go
+++ b/internal/ui/run_view_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +10,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/kranz-org/kranz/internal/app"
 	"github.com/kranz-org/kranz/internal/config"
 )
 
@@ -53,12 +55,62 @@ func TestRunLabelsSeparateAutoUpdatingLatestAndHistoryViews(t *testing.T) {
 
 	finishTestServiceRun(t, model, "api", 0, "run three")
 	model.refreshServices()
+	if got := model.runViewLabel(); got != "LATEST RUN · #3" || model.selectedRun != 3 {
+		t.Fatalf("latest view did not follow the new run: label=%q run=%d", got, model.selectedRun)
+	}
+	model.moveRun(-1, false)
 	if got := model.runViewLabel(); got != "HISTORY · RUN #2 · 1 NEWER · [L] LATEST" {
-		t.Fatalf("history label = %q", got)
+		t.Fatalf("explicit history label = %q", got)
+	}
+	finishTestServiceRun(t, model, "api", 0, "run four")
+	model.refreshServices()
+	if got := model.runViewLabel(); got != "HISTORY · RUN #2 · 2 NEWER · [L] LATEST" || model.selectedRun != 2 {
+		t.Fatalf("history view followed a new run: label=%q run=%d", got, model.selectedRun)
 	}
 	model.selectLatestRun()
-	if got := model.runViewLabel(); got != "LATEST RUN · #3" {
+	if got := model.runViewLabel(); got != "LATEST RUN · #4" {
 		t.Fatalf("returned latest label = %q", got)
+	}
+}
+
+func TestCombinedActionOutputScrollsAcrossAllRetainedRuns(t *testing.T) {
+	id := config.ActionID{OwnerKind: config.ActionOwnerGroup, Owner: "ops", Name: "history"}
+	values := make([]string, 18)
+	for index := range values {
+		values[index] = fmt.Sprint(index + 1)
+	}
+	command := "for value in " + strings.Join(values, " ") + "; do echo line-$value; done"
+	model := NewModel(&config.Config{Project: "actions", ActionGroups: map[string]config.ActionGroup{
+		"ops": {Actions: map[string]config.Action{"history": {Command: command}}},
+	}}, "test")
+	defer model.Shutdown()
+	for range 2 {
+		if _, err := model.app.RunAction(context.Background(), id); err != nil {
+			t.Fatal(err)
+		}
+	}
+	model.focusedAction = &id
+	model.width, model.height, model.ready = 100, 14, true
+	model.panelFocus = panelLogs
+	model.syncRunTarget()
+	model.toggleRunView()
+	if model.runMode != runViewCombined {
+		t.Fatalf("action view mode = %v, want combined", model.runMode)
+	}
+
+	target := app.ActionRunTarget(id)
+	latestEntries := len(model.entriesForRun(target, 2))
+	allEntries := len(model.entriesForRun(target, 0))
+	displayedRows := model.displayedLogLineCount()
+	if allEntries <= latestEntries || displayedRows <= latestEntries {
+		t.Fatalf("combined rows = %d from %d entries, latest has %d", displayedRows, allEntries, latestEntries)
+	}
+	for range displayedRows + 10 {
+		model.scrollLogs(-1)
+	}
+	wantOffset := max(0, displayedRows-(model.currentLogPanelHeight()-2))
+	if model.logOffset != wantOffset || model.logOffset <= latestEntries {
+		t.Fatalf("combined scroll stopped at %d, want %d across older runs (latest entries %d)", model.logOffset, wantOffset, latestEntries)
 	}
 }
 

--- a/internal/ui/view_logs.go
+++ b/internal/ui/view_logs.go
@@ -61,43 +61,12 @@ func (m *Model) renderActionLogPanel(width, height int) string {
 	if !exists {
 		return renderTitledPanel(m.panelStyle(panelLogs), m.panelTitleStyle(panelLogs), contentWidth, contentHeight, "[3] ACTION OUTPUT", []string{"", "Select an action"})
 	}
-	m.syncRunTarget()
-	selectedRun := state.Run
-	if m.runMode == runViewSingle && m.selectedRun > 0 {
-		selectedRun = m.selectedRun
-		if summary, ok := m.runSummary(app.ActionRunTarget(id), selectedRun); ok {
-			state.Run = summary.Run
-			state.StartedAt, state.FinishedAt = summary.StartedAt, summary.FinishedAt
-			state.Status = actionStatusFromRun(summary.Status)
-			if summary.ExitCode != nil {
-				state.ExitCode = *summary.ExitCode
-			}
-		}
-	}
+	selectedRun, state, lines := m.actionLogContent(id, action, state)
 	name := actionRunName(id.Name, selectedRun)
 	title := "[3] ACTION OUTPUT" + ContextBarStyle.Render(" │ ") + actionStatusIndicator(state.Status) + " " + ServiceNameStyle.Render(name) + ContextBarStyle.Render(" · "+state.Status.String())
 	title += " " + RunningBadgeStyle.Render(m.runViewLabel())
 	if state.Status == app.ActionRunning {
 		title += StartingBadgeStyle.Render(" RUNNING")
-	}
-	entries := m.entriesForRun(app.ActionRunTarget(id), 0)
-	if m.runMode == runViewSingle {
-		entries = m.entriesForRun(app.ActionRunTarget(id), selectedRun)
-	}
-	outputLines := make([]string, 0, len(entries))
-	for _, entry := range entries {
-		prefix := ""
-		if entry.Source == "stderr" {
-			prefix = "[stderr] "
-		}
-		outputLines = appendSafeActionOutput(outputLines, entry.Raw, prefix)
-	}
-	lines := outputLines
-	if state.Status != app.ActionReady {
-		lines = append(appendSafeActionOutput(nil, action.Command, "$ "), lines...)
-	}
-	if state.Status == app.ActionRunning && len(outputLines) == 0 {
-		lines = append(lines, "Running · press s to stop")
 	}
 	if len(lines) == 0 {
 		return renderTitledPanel(m.panelStyle(panelLogs), m.panelTitleStyle(panelLogs), contentWidth, contentHeight, title, []string{"", ContextBarStyle.Render("Press s to run this action")})
@@ -121,6 +90,42 @@ func (m *Model) renderActionLogPanel(width, height int) string {
 		title += ContextBarStyle.Render(fmt.Sprintf("  %d–%d/%d  ↑/↓", start+1, end, len(rows)))
 	}
 	return renderTitledPanel(m.panelStyle(panelLogs), m.panelTitleStyle(panelLogs), contentWidth, contentHeight, title, rows[start:end])
+}
+
+func (m *Model) actionLogContent(id config.ActionID, action config.Action, state app.ActionResult) (uint32, app.ActionResult, []string) {
+	m.syncRunTarget()
+	selectedRun := state.Run
+	if m.runMode == runViewSingle && m.selectedRun > 0 {
+		selectedRun = m.selectedRun
+		if summary, ok := m.runSummary(app.ActionRunTarget(id), selectedRun); ok {
+			state.Run = summary.Run
+			state.StartedAt, state.FinishedAt = summary.StartedAt, summary.FinishedAt
+			state.Status = actionStatusFromRun(summary.Status)
+			if summary.ExitCode != nil {
+				state.ExitCode = *summary.ExitCode
+			}
+		}
+	}
+	entries := m.entriesForRun(app.ActionRunTarget(id), 0)
+	if m.runMode == runViewSingle {
+		entries = m.entriesForRun(app.ActionRunTarget(id), selectedRun)
+	}
+	outputLines := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		prefix := ""
+		if entry.Source == "stderr" {
+			prefix = "[stderr] "
+		}
+		outputLines = appendSafeActionOutput(outputLines, entry.Raw, prefix)
+	}
+	lines := outputLines
+	if state.Status != app.ActionReady {
+		lines = append(appendSafeActionOutput(nil, action.Command, "$ "), lines...)
+	}
+	if state.Status == app.ActionRunning && len(outputLines) == 0 {
+		lines = append(lines, "Running · press s to stop")
+	}
+	return selectedRun, state, lines
 }
 
 func actionStatusFromRun(status string) app.ActionStatus {
@@ -406,14 +411,18 @@ func (m *Model) displayedPinnedLogLineCount() int {
 }
 
 func (m *Model) displayedLogLineCount() int {
-	if _, _, state, exists := m.focusedActionDefinition(); exists {
-		return visualLogRowCount(actionOutputLines(state), m.currentLogContentWidth(), m.wrapLogs)
+	if id, action, state, exists := m.focusedActionDefinition(); exists {
+		_, _, lines := m.actionLogContent(id, action, state)
+		return visualLogRowCount(lines, m.currentLogContentWidth(), m.wrapLogs)
 	}
 	svc := m.FocusedService()
 	if svc == nil {
 		return 0
 	}
 	entries := m.app.Logs(svc.Name)
+	if m.syncRunTarget() && m.runMode == runViewSingle {
+		entries = m.entriesForRun(app.ServiceRunTarget(svc.Name), m.selectedRun)
+	}
 	lines := logEntryLines(entries)
 	indices := make([]int, len(lines))
 	for index := range indices {

--- a/internal/ui/view_modals.go
+++ b/internal/ui/view_modals.go
@@ -39,83 +39,77 @@ func (m *Model) renderHelpView() string {
 	return m.placeOverlay(content)
 }
 
-func helpEntries() []helpEntry {
-	return []helpEntry{
-		{"1 / 2 / 3", "Focus panels; 1 switches Services/Tags when the list is focused"},
-		{"Shift+3", "Pin the current run; if a pin exists, unpin it from any panel"},
-		{"3", "Switch focus between pinned and current logs"},
-		{"Tab / Shift+Tab", "Focus the next or previous panel, including pinned logs"},
-		{"↑/↓ j/k", "Navigate or scroll focused panel"},
-		{"←/→", "Cycle Services/Tags while the list panel is focused"},
-		{"t", "Toggle Services/Tags from any panel"},
-		{"Enter", "Expand or collapse service actions, action groups, or a tag"},
-		{"Space", "Select/unselect service or tag"},
-		{"s", "Start/stop service targets or run the focused action"},
-		{"Shift+S", "Start or stop only targets, ignoring dependency expansion"},
-		{"a", "Select/clear all services"},
-		{"A", "Stop all services"},
-		{"r", "Restart selected service"},
-		{"R", "Restart running services"},
-		{"T", "Clear selected tags"},
-		{"h", "Health check history"},
-		{"n", "Notification center"},
-		{"/", "Open the regex log search; Tab switches filter/highlight"},
-		{"Enter in search", "Apply the query and keep editing it"},
-		{"Ctrl+U in search", "Erase the query being edited"},
-		{"Ctrl+V in search", "Paste clipboard text at the caret"},
-		{"Esc in search", "Close the editor, keeping the last applied filter"},
-		{"Esc", "Clear the active log filter"},
-		{"n/N", "Next/previous highlighted match"},
-		{"w", "Toggle log line wrapping"},
-		{"i", "Show/hide captured-at time in logs"},
-		{"f", "Pause/resume logs"},
-		{"x", "Toggle Combined/Single run log view"},
-		{"[ / ]", "Previous/next run; Shift+F finds the previous failed run"},
-		{"v", "Open the run catalog; l returns to latest"},
-		{"e / E", "Export selected run to clipboard / a file path"},
-		{"c", "Clear focused or pinned service logs after confirmation"},
-		{"q", "Quit"},
-		{"?", "Show this help"},
-		{"Ctrl+T", "Choose and apply a theme"},
-		{"p / m", "In Themes: toggle theme or cycle Auto/Dark/Light mode"},
-		{"a / b", "In Themes: cycle the accent or canvas sources, including a custom color once one is set"},
-		{"Shift+A/B", "In Themes: edit the six hex digits of the accent or the canvas"},
-		{"Enter / r", "In Themes: apply for this session or reload saved appearance from configuration"},
-		{"g / c", "In Themes: save appearance globally or to the project config"},
-		{"Ctrl+L", "Reload configuration and detect terminal appearance"},
-		{"Ctrl+O", "Open command shell; Ctrl+O returns to Kranz"},
+type helpSection struct {
+	title   string
+	entries []helpEntry
+}
+
+func helpSections() []helpSection {
+	return []helpSection{
+		{title: "NAVIGATION", entries: []helpEntry{
+			{"1 / 2 / 3", "Focus Services, Details, or Logs; 1 toggles Services/Tags when already focused"},
+			{"Tab / Shift+Tab", "Focus the next or previous panel, including pinned logs"},
+			{"↑/↓ j/k", "Navigate or scroll the focused panel"},
+			{"←/→", "Cycle Services/Tags while the list panel is focused"},
+			{"t", "Toggle Services/Tags from any panel"},
+			{"Enter", "Expand or collapse a service, action group, or tag"},
+		}},
+		{title: "SERVICES & ACTIONS", entries: []helpEntry{
+			{"Space", "Select or unselect a service or tag"},
+			{"s", "Start/stop service targets or run the focused action"},
+			{"Shift+S", "Start or stop only targets, ignoring dependency expansion"},
+			{"a / Shift+A", "Select/clear all services or stop all services"},
+			{"r / Shift+R", "Restart the selected service or all running services"},
+			{"Shift+T", "Clear selected tags"},
+			{"h / n", "Open health history or the notification center"},
+		}},
+		{title: "LOGS & RUN HISTORY", entries: []helpEntry{
+			{"3", "Switch focus between pinned and current logs"},
+			{"Shift+3", "Pin the current run; if a pin exists, unpin it from any panel"},
+			{"w / i", "Toggle line wrapping or captured-at timestamps"},
+			{"f", "Pause or resume following logs"},
+			{"x", "Toggle all-runs and single-run views"},
+			{"[ / ]", "Open the previous or next run"},
+			{"Shift+F / l", "Open the previous failed run or return to the latest run"},
+			{"v", "Open the filterable run catalog"},
+			{"e / Shift+E", "Export the selected run to clipboard or a file"},
+			{"c", "Clear focused or pinned service logs after confirmation"},
+		}},
+		{title: "LOG SEARCH", entries: []helpEntry{
+			{"/", "Open regex search; Tab switches filter/highlight"},
+			{"Enter", "Apply the query and keep editing it"},
+			{"Ctrl+U / Ctrl+V", "Erase the query or paste clipboard text"},
+			{"Esc", "Close the editor, then clear the active filter"},
+			{"n / Shift+N", "Open the next or previous highlighted match"},
+		}},
+		{title: "APPEARANCE", entries: []helpEntry{
+			{"Ctrl+T", "Open the theme and appearance picker"},
+			{"p / m", "Toggle theme or cycle Auto/Dark/Light mode"},
+			{"a / b", "Cycle accent or canvas sources, including a custom color"},
+			{"Shift+A/B", "Edit the six hex digits of the accent or canvas"},
+			{"Enter / r", "Apply for this session or reload saved appearance"},
+			{"g / c", "Save appearance globally or to the project config"},
+		}},
+		{title: "APPLICATION", entries: []helpEntry{
+			{"Ctrl+L", "Reload configuration and detect terminal appearance"},
+			{"Ctrl+O", "Open command shell; Ctrl+O returns to Kranz"},
+			{"?", "Show this help"},
+			{"q", "Quit"},
+		}},
 	}
 }
 
 func (m *Model) helpBodyLines() []string {
-	helpPairs := helpEntries()
 	availableWidth := max(20, min(105, m.width-6))
-	if availableWidth < 86 {
-		lines := make([]string, 0, len(helpPairs))
-		for _, entry := range helpPairs {
+	sections := helpSections()
+	lines := make([]string, 0, 64)
+	for sectionIndex, section := range sections {
+		if sectionIndex > 0 {
+			lines = append(lines, "")
+		}
+		lines = append(lines, HelpKeyStyle.Bold(true).Render(section.title))
+		for _, entry := range section.entries {
 			lines = append(lines, renderHelpCell(entry.key, entry.desc, availableWidth)...)
-		}
-		return lines
-	}
-	cellWidth := (availableWidth - 3) / 2
-	rows := (len(helpPairs) + 1) / 2
-	lines := make([]string, 0, rows)
-	for row := 0; row < rows; row++ {
-		left := renderHelpCell(helpPairs[row].key, helpPairs[row].desc, cellWidth)
-		right := []string(nil)
-		if rightIndex := row + rows; rightIndex < len(helpPairs) {
-			right = renderHelpCell(helpPairs[rightIndex].key, helpPairs[rightIndex].desc, cellWidth)
-		}
-		rowHeight := max(len(left), len(right))
-		for line := 0; line < rowHeight; line++ {
-			leftLine, rightLine := strings.Repeat(" ", cellWidth), ""
-			if line < len(left) {
-				leftLine = left[line]
-			}
-			if line < len(right) {
-				rightLine = right[line]
-			}
-			lines = append(lines, leftLine+"   "+rightLine)
 		}
 	}
 	return lines


### PR DESCRIPTION
## Summary
- keep the isolated latest-run view attached to newly started runs until the user explicitly enters history
- calculate log viewport bounds from the exact retained service/action content being rendered
- replace the dense two-column shortcut reference with six logical single-column sections

## Validation
- make verify
- make lint
- make release-check
- git diff --check

Target release: 0.10.0. No release or tag is part of this PR.