### PR TITLE
fix(tui): tighten run history presentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 
 ### Fixed
 
+- Run labels and action status separators are visually cleaner, the run catalog
+  has an explicit column header, and the shortcut reference is narrower,
+  shorter, and gives section headings a distinct neutral hierarchy.
 - The isolated latest-run view now follows subsequent starts until the user
   explicitly enters history. Combined action output scrolls across all retained
   runs instead of using the latest result as its viewport boundary, and the

--- a/docs/reference/controls.md
+++ b/docs/reference/controls.md
@@ -56,7 +56,7 @@ directions.
 | `e` / `Shift+E` | Export selected run to clipboard / chosen file |
 
 The log header names the history position explicitly: `ALL RUNS · INCLUDES NEW`
-keeps accepting new runs, `LATEST RUN · #N` shows the newest run in isolation,
+keeps accepting new runs, `LATEST RUN #N` shows the newest run in isolation,
 and `HISTORY · RUN #N` means a newer run exists. A pinned panel is frozen and
 shows `Shift+3 UNPIN` in its title; while any pin exists the footer starts with
 `[Shift+3] unpin`, and the shortcut works from every panel.
@@ -66,9 +66,10 @@ shows `Shift+3 UNPIN` in its title; while any pin exists the footer starts with
 selection remains stable until `l` returns to the latest run. The all-runs view
 scrolls across the complete retained output of service and action runs.
 
-The in-app `?` reference is a single scrollable column split into Navigation,
-Services & Actions, Logs & Run History, Log Search, Appearance, and Application
-sections.
+The in-app `?` reference is a compact, scrollable single column split into
+Navigation, Services & Actions, Logs & Run History, Log Search, Appearance, and
+Application sections. Neutral section headings are visually distinct from the
+accent-coloured shortcuts.
 
 ## Application
 

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -801,12 +801,12 @@ func TestHelpWrapsDescriptionsAndScrollsWithoutTruncatingThem(t *testing.T) {
 	for _, line := range model.helpBodyLines() {
 		width := lipgloss.Width(line)
 		widest = max(widest, width)
-		if width > 74 {
-			t.Fatalf("help line width = %d, want at most 74: %q", width, ansi.Strip(line))
+		if width > 64 {
+			t.Fatalf("help line width = %d, want at most 64: %q", width, ansi.Strip(line))
 		}
 	}
-	if widest <= 66 {
-		t.Fatalf("help did not become materially wider: widest line = %d", widest)
+	if widest < 60 {
+		t.Fatalf("help became unnecessarily narrow: widest line = %d", widest)
 	}
 	lastSection := -1
 	for _, section := range []string{"NAVIGATION", "SERVICES & ACTIONS", "LOGS & RUN HISTORY", "LOG SEARCH", "APPEARANCE", "APPLICATION"} {
@@ -821,6 +821,9 @@ func TestHelpWrapsDescriptionsAndScrollsWithoutTruncatingThem(t *testing.T) {
 	initial := ansi.Strip(model.renderHelpView())
 	if !strings.Contains(initial, "[↑/k] Up") || !strings.Contains(initial, "[↓/j] Down") || lipgloss.Height(model.renderHelpView()) != model.height {
 		t.Fatalf("scrollable help layout is invalid:\n%s", initial)
+	}
+	if got := model.helpVisibleBodyHeight(); got != 8 {
+		t.Fatalf("help visible body height = %d, want compact 8 rows at terminal height 24", got)
 	}
 	for range model.maxHelpOffset() {
 		_, _ = model.handleKeyMsg(tea.KeyMsg{Type: tea.KeyDown})
@@ -848,8 +851,14 @@ func TestHelpUsesOneWideColumnAndRespectsTerminalBackground(t *testing.T) {
 			t.Fatalf("help still renders two shortcut columns: %q", plain)
 		}
 	}
-	if widest <= 100 || widest > 105 {
-		t.Fatalf("help body width = %d, want the new 101–105 cell range", widest)
+	if widest < 74 || widest > 78 {
+		t.Fatalf("help body width = %d, want compact 74–78 cell range", widest)
+	}
+	if got := model.helpVisibleBodyHeight(); got != 16 {
+		t.Fatalf("help visible body height = %d, want 16 at terminal height 32", got)
+	}
+	if reflect.DeepEqual(HelpSectionStyle.GetForeground(), HelpKeyStyle.GetForeground()) {
+		t.Fatal("help section headers still use the shortcut accent color")
 	}
 	if !reflect.DeepEqual(ModalStyle.GetBackground(), lipgloss.Color(model.activeTheme.SurfaceAlt)) {
 		t.Fatalf("terminal-owned help background = %#v, want modal surface %s", ModalStyle.GetBackground(), model.activeTheme.SurfaceAlt)

--- a/internal/ui/run_view.go
+++ b/internal/ui/run_view.go
@@ -229,7 +229,7 @@ func (m *Model) runViewLabel() string {
 		return "NO RUNS YET"
 	}
 	if m.selectedRun == latest {
-		return fmt.Sprintf("LATEST RUN · #%d", m.selectedRun)
+		return fmt.Sprintf("LATEST RUN #%d", m.selectedRun)
 	}
 	if latest > m.selectedRun {
 		return fmt.Sprintf("HISTORY · RUN #%d · %d NEWER · [L] LATEST", m.selectedRun, latest-m.selectedRun)
@@ -398,6 +398,9 @@ func (m *Model) renderRunListView() string {
 	}
 	if len(runs) == 0 {
 		lines = append(lines, "  No runs match this filter")
+	} else {
+		lines = append(lines, DetailLabelStyle.Render(fmt.Sprintf("  %-5s %-10s  %-8s  %8s  %-8s  %-18s  %-18s  %s",
+			"RUN", "STATUS", "START", "DURATION", "EXIT", "REASON", "INITIATOR", "OUTPUT")))
 	}
 	for index, run := range runs {
 		exit := "-"
@@ -412,7 +415,7 @@ func (m *Model) renderRunListView() string {
 		if run.ClientLabel != "" {
 			initiator += ":" + run.ClientLabel
 		}
-		line := fmt.Sprintf("  #%d  %-10s  %s  %8s  exit %-3s  %-18s  %-18s  %s", run.Run, run.Status,
+		line := fmt.Sprintf("  %-5s %-10s  %-8s  %8s  %-8s  %-18s  %-18s  %s", fmt.Sprintf("#%d", run.Run), run.Status,
 			run.StartedAt.Local().Format("15:04:05"), duration.Round(time.Millisecond), exit, run.StartReason, initiator, run.Output.State)
 		if index == m.runListCursor {
 			line = SelectionStyle.Render(line)

--- a/internal/ui/run_view_test.go
+++ b/internal/ui/run_view_test.go
@@ -49,13 +49,13 @@ func TestRunLabelsSeparateAutoUpdatingLatestAndHistoryViews(t *testing.T) {
 		t.Fatalf("combined label = %q", got)
 	}
 	model.selectLatestRun()
-	if got := model.runViewLabel(); got != "LATEST RUN · #2" {
+	if got := model.runViewLabel(); got != "LATEST RUN #2" {
 		t.Fatalf("latest label = %q", got)
 	}
 
 	finishTestServiceRun(t, model, "api", 0, "run three")
 	model.refreshServices()
-	if got := model.runViewLabel(); got != "LATEST RUN · #3" || model.selectedRun != 3 {
+	if got := model.runViewLabel(); got != "LATEST RUN #3" || model.selectedRun != 3 {
 		t.Fatalf("latest view did not follow the new run: label=%q run=%d", got, model.selectedRun)
 	}
 	model.moveRun(-1, false)
@@ -68,7 +68,7 @@ func TestRunLabelsSeparateAutoUpdatingLatestAndHistoryViews(t *testing.T) {
 		t.Fatalf("history view followed a new run: label=%q run=%d", got, model.selectedRun)
 	}
 	model.selectLatestRun()
-	if got := model.runViewLabel(); got != "LATEST RUN · #4" {
+	if got := model.runViewLabel(); got != "LATEST RUN #4" {
 		t.Fatalf("returned latest label = %q", got)
 	}
 }
@@ -122,7 +122,7 @@ func TestRunListIncludesRetentionAndProvenanceFields(t *testing.T) {
 	model.refreshServices()
 	model.openRunList()
 	plain := ansi.Strip(model.renderRunListView())
-	for _, expected := range []string{"#1", "exit 7", "runtime", "complete", "Filter: all"} {
+	for _, expected := range []string{"RUN", "STATUS", "START", "DURATION", "EXIT", "REASON", "INITIATOR", "OUTPUT", "#1", "7", "runtime", "complete", "Filter: all"} {
 		if !strings.Contains(plain, expected) {
 			t.Fatalf("run list missing %q:\n%s", expected, plain)
 		}
@@ -261,7 +261,7 @@ func TestActionOutputDefaultsToSingleLatestRun(t *testing.T) {
 	}
 	model.focusedAction = &id
 	plain := ansi.Strip(model.renderActionLogPanel(100, 12))
-	if model.runMode != runViewSingle || model.selectedRun != 1 || !strings.Contains(plain, "LATEST RUN · #1") || !strings.Contains(plain, "action-output") {
+	if model.runMode != runViewSingle || model.selectedRun != 1 || !strings.Contains(plain, "succeeded · LATEST RUN #1") || !strings.Contains(plain, "action-output") {
 		t.Fatalf("action did not open latest single run: mode=%d run=%d\n%s", model.runMode, model.selectedRun, plain)
 	}
 }

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -45,6 +45,7 @@ var (
 	LogTimestampStyle     lipgloss.Style
 	LogSourceStyle        lipgloss.Style
 	HelpKeyStyle          lipgloss.Style
+	HelpSectionStyle      lipgloss.Style
 	ModalStyle            lipgloss.Style
 	NewLogIndicatorStyle  lipgloss.Style
 	SearchHighlightStyle  lipgloss.Style
@@ -130,6 +131,7 @@ func applyPalette(theme Theme) {
 	LogTimestampStyle = lipgloss.NewStyle().Foreground(ColorDim)
 	LogSourceStyle = lipgloss.NewStyle().Foreground(ColorDim)
 	HelpKeyStyle = lipgloss.NewStyle().Foreground(ColorInfo).Bold(true)
+	HelpSectionStyle = lipgloss.NewStyle().Foreground(ColorGrey).Bold(true)
 	ModalStyle = lipgloss.NewStyle().Foreground(ColorGrey).Background(ColorSurfaceAlt).Padding(2, 4)
 	ModalTitleStyle = ModalTitleStyle.Background(ColorSurfaceAlt)
 	NewLogIndicatorStyle = lipgloss.NewStyle().Foreground(ColorYellow).Bold(true)

--- a/internal/ui/view_logs.go
+++ b/internal/ui/view_logs.go
@@ -64,7 +64,7 @@ func (m *Model) renderActionLogPanel(width, height int) string {
 	selectedRun, state, lines := m.actionLogContent(id, action, state)
 	name := actionRunName(id.Name, selectedRun)
 	title := "[3] ACTION OUTPUT" + ContextBarStyle.Render(" │ ") + actionStatusIndicator(state.Status) + " " + ServiceNameStyle.Render(name) + ContextBarStyle.Render(" · "+state.Status.String())
-	title += " " + RunningBadgeStyle.Render(m.runViewLabel())
+	title += ContextBarStyle.Render(" · ") + RunningBadgeStyle.Render(m.runViewLabel())
 	if state.Status == app.ActionRunning {
 		title += StartingBadgeStyle.Render(" RUNNING")
 	}
@@ -268,7 +268,7 @@ func (m *Model) renderLogPanelMode(svc *app.ServiceSnapshot, width, height int, 
 		}
 		title += SearchInputStyle.Render(fmt.Sprintf("  %s /%s/ · %d", modeLabel, searcher.Pattern(), len(searchMatches)))
 	}
-	title += " " + RunningBadgeStyle.Render(runLabel)
+	title += ContextBarStyle.Render(" · ") + RunningBadgeStyle.Render(runLabel)
 	matchSet := make(map[int]bool, len(searchMatches))
 	for _, idx := range searchMatches {
 		matchSet[idx] = true

--- a/internal/ui/view_modals.go
+++ b/internal/ui/view_modals.go
@@ -100,14 +100,14 @@ func helpSections() []helpSection {
 }
 
 func (m *Model) helpBodyLines() []string {
-	availableWidth := max(20, min(105, m.width-6))
+	availableWidth := max(20, min(78, m.width-16))
 	sections := helpSections()
 	lines := make([]string, 0, 64)
 	for sectionIndex, section := range sections {
 		if sectionIndex > 0 {
 			lines = append(lines, "")
 		}
-		lines = append(lines, HelpKeyStyle.Bold(true).Render(section.title))
+		lines = append(lines, HelpSectionStyle.Render(section.title))
 		for _, entry := range section.entries {
 			lines = append(lines, renderHelpCell(entry.key, entry.desc, availableWidth)...)
 		}
@@ -116,7 +116,7 @@ func (m *Model) helpBodyLines() []string {
 }
 
 func (m *Model) helpVisibleBodyHeight() int {
-	return max(1, m.height-10)
+	return min(24, max(1, m.height-16))
 }
 
 func (m *Model) maxHelpOffset() int {


### PR DESCRIPTION
## Summary
- render latest labels as `LATEST RUN #N` and separate them from action/service status
- add an aligned column header to the run history catalog
- constrain help width and visible height while styling section headers separately from shortcuts

## Validation
- make verify
- make lint
- make release-check
- git diff --check

Target: 0.10.0. No release or tag.