### PR TITLE
feat(runs): delete retained runs explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
   including identity, provenance, canonical capture metadata, and exact
   truncation information. Run history remains scoped to the live runtime and
   is never persisted in the background.
+- Completed runs can be removed from Run history with `d`, from the CLI with
+  `kranz runs delete TARGET#N --confirm`, or through the MCP `run_delete` tool
+  with `confirm: true`. Active runs are protected and run numbers are not reused.
 - `kranz runs` and MCP run retention metadata expose the oldest retained run,
   independent run/entry/byte budgets, evicted summaries, and complete,
   partial, or unavailable output state.

--- a/cmd/kranz/main.go
+++ b/cmd/kranz/main.go
@@ -136,8 +136,13 @@ func execute(args []string, stdout, stderr io.Writer) int {
 			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
 		}
 		return 0
-	case "runs":
+	case "runs list":
 		if err := runRuns(invocation.Globals, invocation.Args, stdout); err != nil {
+			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
+		}
+		return 0
+	case "runs delete":
+		if err := runRunsDelete(invocation.Globals, invocation.Args, stdout); err != nil {
 			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
 		}
 		return 0

--- a/cmd/kranz/runs.go
+++ b/cmd/kranz/runs.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -10,6 +12,78 @@ import (
 	"github.com/kranz-org/kranz/internal/app"
 	kranzcli "github.com/kranz-org/kranz/internal/cli"
 )
+
+func runRunsDelete(options kranzcli.GlobalOptions, args []string, stdout io.Writer) error {
+	confirmed := false
+	identities := make([]string, 0, 1)
+	for _, arg := range args {
+		switch {
+		case arg == "--confirm":
+			confirmed = true
+		case strings.HasPrefix(arg, "-"):
+			return &kranzcli.Error{Code: "unknown_option", Message: fmt.Sprintf("unknown runs delete option %q", arg), Hint: "runs delete accepts one TARGET#N and --confirm.", ExitCode: kranzcli.ExitUsage}
+		default:
+			identities = append(identities, arg)
+		}
+	}
+	if len(identities) != 1 {
+		return &kranzcli.Error{Code: "missing_run_identity", Message: "runs delete requires exactly one TARGET#N", Hint: "Use kranz runs to inspect absolute run identities.", ExitCode: kranzcli.ExitUsage}
+	}
+	if !confirmed {
+		return &kranzcli.Error{Code: "confirmation_required", Message: "deleting a retained run requires --confirm", Hint: "Review the absolute TARGET#N, then repeat with --confirm.", ExitCode: kranzcli.ExitUsage}
+	}
+	targetName, run, err := parseRunIdentity(identities[0])
+	if err != nil {
+		return err
+	}
+	client, closeClient, err := dialProjectRuntime(options)
+	if err != nil {
+		return err
+	}
+	defer closeClient()
+	var target *app.RunTarget
+	for _, candidate := range client.Runs() {
+		if candidate.Run == run && strings.EqualFold(runTargetName(candidate.Target), targetName) {
+			copy := candidate.Target
+			target = &copy
+			break
+		}
+	}
+	if target == nil {
+		return &kranzcli.Error{Code: "run_not_found", Message: fmt.Sprintf("%s#%d is not retained", targetName, run), Hint: "Use kranz runs to inspect retained absolute run identities.", ExitCode: kranzcli.ExitNotFound}
+	}
+	deleted, err := client.DeleteRun(*target, run)
+	if err != nil {
+		var deleteErr *app.RunDeleteError
+		if errors.As(err, &deleteErr) {
+			exit := kranzcli.ExitConflict
+			if deleteErr.Code == "run_not_found" {
+				exit = kranzcli.ExitNotFound
+			}
+			return &kranzcli.Error{Code: deleteErr.Code, Message: deleteErr.Error(), ExitCode: exit}
+		}
+		return err
+	}
+	if options.Output == kranzcli.OutputJSON {
+		return kranzcli.WriteJSON(stdout, struct {
+			Deleted app.RunSummary `json:"deleted"`
+		}{Deleted: deleted})
+	}
+	_, err = fmt.Fprintf(stdout, "Deleted %s#%d from retained history.\n", runTargetName(deleted.Target), deleted.Run)
+	return err
+}
+
+func parseRunIdentity(value string) (string, uint32, error) {
+	separator := strings.LastIndex(value, "#")
+	if separator <= 0 || separator == len(value)-1 {
+		return "", 0, &kranzcli.Error{Code: "invalid_run_identity", Message: fmt.Sprintf("%q is not an absolute TARGET#N run identity", value), Hint: "Use kranz runs to inspect retained absolute run identities.", ExitCode: kranzcli.ExitUsage}
+	}
+	number, err := strconv.ParseUint(value[separator+1:], 10, 32)
+	if err != nil || number == 0 {
+		return "", 0, &kranzcli.Error{Code: "invalid_run_identity", Message: fmt.Sprintf("%q is not an absolute TARGET#N run identity", value), Hint: "Run numbers are positive integers.", ExitCode: kranzcli.ExitUsage}
+	}
+	return value[:separator], uint32(number), nil
+}
 
 func runRuns(options kranzcli.GlobalOptions, targets []string, stdout io.Writer) error {
 	client, closeClient, err := dialProjectRuntime(options)

--- a/cmd/kranz/runs_test.go
+++ b/cmd/kranz/runs_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	kranzcli "github.com/kranz-org/kranz/internal/cli"
+)
+
+func TestParseRunIdentityRequiresAbsolutePositiveNumber(t *testing.T) {
+	target, run, err := parseRunIdentity("analytics/stats#42")
+	if err != nil || target != "analytics/stats" || run != 42 {
+		t.Fatalf("parseRunIdentity = %q, %d, %v", target, run, err)
+	}
+	for _, invalid := range []string{"api", "#1", "api#0", "api#latest"} {
+		if _, _, err := parseRunIdentity(invalid); err == nil {
+			t.Errorf("parseRunIdentity(%q) unexpectedly succeeded", invalid)
+		}
+	}
+}
+
+func TestRunsDeleteRequiresExplicitConfirmationBeforeRuntimeAccess(t *testing.T) {
+	err := runRunsDelete(kranzcli.GlobalOptions{}, []string{"api#1"}, nil)
+	var commandErr *kranzcli.Error
+	if !errors.As(err, &commandErr) || commandErr.Code != "confirmation_required" {
+		t.Fatalf("runRunsDelete error = %#v", err)
+	}
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -217,6 +217,7 @@ kranz logs analytics/stats --runs 3       # the last three runs
 kranz logs api --run -1                   # only the newest start of a service
 kranz runs                                # bounded catalog and retention limits
 kranz runs api analytics/stats            # narrow catalog by target
+kranz runs delete api#4 --confirm         # delete one completed run and retained output
 ```
 
 Every line carries its stable absolute identity (`api#7` or

--- a/docs/reference/controls.md
+++ b/docs/reference/controls.md
@@ -14,6 +14,7 @@ modal actions, search controls, and the theme picker.
 | `Tab` / `Shift+Tab` | Focus next or previous panel |
 | `↑` / `↓`, `j` / `k` | Navigate or scroll |
 | `Shift+3` | Pin the current run, or unpin the existing view from any panel |
+| `d` | Delete the selected completed run from Run history after confirmation |
 | `Enter` | Expand/collapse tags, services, actions, or action groups |
 
 ## Lifecycle and actions

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -47,7 +47,9 @@ client or the repository's [minimal example client](../examples/mcp-shared-runti
 Observation tools are `runtimes`, `status`, `changes`, `plan`, `graph`, `ports`,
 `port_inspect`, `logs`, `wait`, `health`, `doctor`, `action_list`,
 `action_info`, and `action_result`. Mutations are explicit: `start`, `stop`,
-`restart`, `action_run`, `action_cancel`, `logs_clear`, and `reload`. There is
+`restart`, `action_run`, `action_cancel`, `run_delete`, `logs_clear`, and `reload`. `run_delete`
+accepts one absolute target and run number, refuses active runs, and requires
+`confirm: true` before removing the completed summary and retained output. There is
 no toggle or generic application-method dispatcher.
 
 Every tool declares an `outputSchema` for the result envelope, and returns the
@@ -115,6 +117,7 @@ Stable causal codes include `selector_not_found`, `service_unavailable`,
 `interactive_action`, `confirmation_required`, `confirmation_expired`,
 `confirmation_plan_changed`, `action_busy`, `action_failed`,
 `action_timed_out`, `action_cancelled`, `wait_timeout`, `wait_cancelled`,
+`run_not_found`, `run_active`,
 `dependency_blocked`, `terminal_failure`, `port_conflict`, `prerequisite_failed`,
 `no_run_streams`,
 `invalid_cursor`, `invalid_change_query`, and `invalid_change_kind`.

--- a/internal/app/api.go
+++ b/internal/app/api.go
@@ -135,6 +135,7 @@ type API interface {
 	Runs() []RunSummary
 	RunRetention() []RunRetentionBoundary
 	ExportRun(target RunTarget, run uint32) (RunExport, error)
+	DeleteRun(target RunTarget, run uint32) (RunSummary, error)
 
 	// Logs returns the current buffered log entries for a service.
 	Logs(name string) []config.LogEntry

--- a/internal/app/runs.go
+++ b/internal/app/runs.go
@@ -1,10 +1,43 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/kranz-org/kranz/internal/config"
+	"github.com/kranz-org/kranz/internal/service"
 )
+
+// RunDeleteError is stable across local and runtime-backed APIs so delivery
+// adapters can give the same causal response for an invalid destructive call.
+type RunDeleteError struct {
+	Code    string
+	Target  RunTarget
+	Run     uint32
+	Message string
+}
+
+func (e *RunDeleteError) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	return fmt.Sprintf("cannot delete %s#%d", runTargetName(e.Target), e.Run)
+}
+
+func (l *Local) DeleteRun(target RunTarget, run uint32) (RunSummary, error) {
+	deleted, err := l.manager.DeleteRun(target, run)
+	if err == nil {
+		return deleted, nil
+	}
+	code, message := "run_delete_failed", fmt.Sprintf("cannot delete %s#%d", runTargetName(target), run)
+	switch {
+	case errors.Is(err, service.ErrRunActive):
+		code, message = "run_active", fmt.Sprintf("%s#%d is still running", runTargetName(target), run)
+	case errors.Is(err, service.ErrRunNotFound):
+		code, message = "run_not_found", fmt.Sprintf("%s#%d is not retained", runTargetName(target), run)
+	}
+	return RunSummary{}, &RunDeleteError{Code: code, Target: target, Run: run, Message: message}
+}
 
 func (l *Local) ExportRun(target RunTarget, run uint32) (RunExport, error) {
 	var summary RunSummary

--- a/internal/cli/tree.go
+++ b/internal/cli/tree.go
@@ -122,7 +122,12 @@ func DefaultTree() *Command {
 		{Name: "list", Summary: "list services, actions, or tags", Usage: "kranz list [services|actions|tags]"},
 		{Name: "info", Summary: "show project or service details", Usage: "kranz info [SERVICE]"},
 		{Name: "status", Summary: "show runtime status", Usage: "kranz status [SELECTOR ...]"},
-		{Name: "runs", Summary: "list retained service and action runs", Usage: "kranz runs [TARGET ...]"},
+		{Name: "runs", Summary: "inspect and delete retained runs", Default: "list", Children: []*Command{
+			{Name: "list", Summary: "list retained service and action runs", Usage: "kranz runs [TARGET ...]"},
+			{Name: "delete", Summary: "delete one completed run", Usage: "kranz runs delete TARGET#N --confirm", Options: []Option{
+				{Flags: "--confirm", Summary: "confirm permanent removal of the run and its retained output"},
+			}},
+		}},
 		{Name: "plan", Summary: "show the resolved start plan", Usage: "kranz plan [SELECTOR ...]"},
 		{Name: "graph", Summary: "print the dependency graph", Usage: "kranz graph [--format text|json|dot]", Options: []Option{
 			{Flags: "--format FORMAT", Summary: "text, json, or dot; defaults to text", Values: []string{"text", "json", "dot"}},

--- a/internal/mcp/errors.go
+++ b/internal/mcp/errors.go
@@ -17,6 +17,14 @@ func causalError(err error) *CausalError {
 	if errors.As(err, &logErr) {
 		return &CausalError{Code: logErr.Code, Message: logErr.Message, Hint: logErr.Hint, Details: map[string]any{"selector": logErr.Selector}}
 	}
+	var runDelete *app.RunDeleteError
+	if errors.As(err, &runDelete) {
+		hint := "Use runs to inspect retained absolute run identities."
+		if runDelete.Code == "confirmation_required" {
+			hint = "Repeat the same call with confirm set to true."
+		}
+		return &CausalError{Code: runDelete.Code, Message: runDelete.Error(), Hint: hint, Details: map[string]any{"target": runTargetName(runDelete.Target), "run": runDelete.Run}}
+	}
 	var confirmationRequired *app.ConfirmationRequiredError
 	if errors.As(err, &confirmationRequired) {
 		return &CausalError{Code: "confirmation_required", Message: confirmationRequired.Error(), Hint: "Review the resolved plan, then repeat the same tool call with its confirmation_token.", Details: map[string]any{"plan": confirmationRequired.Plan, "confirmation_token": confirmationRequired.Plan.ConfirmationToken}}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -311,6 +311,27 @@ func TestMCPUsesSameSelectorsPlansAndLogsAsApplication(t *testing.T) {
 	}
 }
 
+func TestRunDeleteToolRequiresConfirmationAndDeletesExactRun(t *testing.T) {
+	server, local := testServer(t)
+	local.SetServiceStatusForTest("api", config.StatusStarting)
+	local.AppendLogForTest("api", "retained")
+	snapshot, _ := local.Service("api")
+	completed := snapshot.State
+	completed.Completed = true
+	completed.ExitCode = 0
+	local.SetServiceStateForTest("api", completed)
+	local.SetServiceStatusForTest("api", config.StatusStopped)
+
+	result := server.tools["run_delete"].handler(context.Background(), json.RawMessage(`{"target":"api","run":1}`))
+	if result.Error == nil || result.Error.Code != "confirmation_required" || len(local.Runs()) != 1 {
+		t.Fatalf("unconfirmed delete = %#v, runs=%#v", result, local.Runs())
+	}
+	result = server.tools["run_delete"].handler(context.Background(), json.RawMessage(`{"target":"api","run":1,"confirm":true}`))
+	if result.Error != nil || len(local.Runs()) != 0 || len(local.Logs("api")) != 0 {
+		t.Fatalf("confirmed delete = %#v, runs=%#v logs=%#v", result, local.Runs(), local.Logs("api"))
+	}
+}
+
 func TestCapabilitySurfaceIsExactAllowList(t *testing.T) {
 	server, _ := testServer(t)
 	// toolOrder is built from toolNames, so comparing the two proves nothing.

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/kranz-org/kranz/internal/app"
@@ -25,7 +26,7 @@ const waitTransportGrace = 5 * time.Second
 // exactly, so a tool cannot appear without being listed here, and a listed
 // name cannot resolve to nothing.
 var toolNames = []string{
-	"runtimes", "status", "runs", "changes", "plan", "graph", "ports", "port_inspect", "logs", "wait", "health",
+	"runtimes", "status", "runs", "run_delete", "changes", "plan", "graph", "ports", "port_inspect", "logs", "wait", "health",
 	"action_list", "action_info", "action_result",
 	"doctor", "start", "stop", "restart", "action_run", "action_cancel", "logs_clear", "reload",
 }
@@ -48,6 +49,11 @@ func (s *Server) installTools() {
 		{Name: "runtimes", Description: "List Kranz runtime sessions visible to this user and flag the runtime this MCP connection is bound to.", InputSchema: objectSchema(map[string]any{}), handler: s.runtimesTool},
 		{Name: "status", Description: "Return live status for selected services, including the structured cause of a state whose reason is not the state itself.", InputSchema: objectSchema(map[string]any{"selectors": selectorsProperty}), handler: s.statusTool},
 		{Name: "runs", Description: "Return the bounded service and action run catalog with provenance and output retention state.", InputSchema: objectSchema(map[string]any{}), handler: s.runsTool},
+		{Name: "run_delete", Description: "Delete one completed absolute service or action run and its retained output after explicit confirmation.", InputSchema: objectSchema(map[string]any{
+			"target":  map[string]any{"type": "string", "description": "Exact service name or OWNER/ACTION target from runs."},
+			"run":     map[string]any{"type": "integer", "minimum": 1, "description": "Absolute run number from runs."},
+			"confirm": map[string]any{"type": "boolean", "description": "Must be true after reviewing the exact target and run."},
+		}, "target", "run"), handler: s.runDeleteTool},
 		{Name: "changes", Description: "Return what changed in the runtime after a cursor: service and action transitions, detected-port changes, and configuration reloads.", InputSchema: objectSchema(map[string]any{
 			"since":            map[string]any{"type": "integer", "minimum": 0, "description": "Cursor from a previous changes or wait result. Zero reads the whole retained journal."},
 			"since_generation": map[string]any{"type": "integer", "minimum": 0, "description": "Alternative anchor: read everything after the reload that produced this configuration generation."},
@@ -111,6 +117,43 @@ func (s *Server) runsTool(_ context.Context, raw json.RawMessage) ResultEnvelope
 		return s.argError(err)
 	}
 	return s.envelope(map[string]any{"runs": s.api.Runs(), "retention": s.api.RunRetention()})
+}
+
+func (s *Server) runDeleteTool(_ context.Context, raw json.RawMessage) ResultEnvelope {
+	var args struct {
+		Target  string `json:"target"`
+		Run     uint32 `json:"run"`
+		Confirm bool   `json:"confirm"`
+	}
+	if err := decodeArgs(raw, &args); err != nil {
+		return s.argError(err)
+	}
+	var target *app.RunTarget
+	for _, candidate := range s.api.Runs() {
+		if candidate.Run == args.Run && strings.EqualFold(runTargetName(candidate.Target), args.Target) {
+			copy := candidate.Target
+			target = &copy
+			break
+		}
+	}
+	if target == nil {
+		return s.errorEnvelope(&app.RunDeleteError{Code: "run_not_found", Run: args.Run, Message: fmt.Sprintf("%s#%d is not retained", args.Target, args.Run)})
+	}
+	if !args.Confirm {
+		return s.errorEnvelope(&app.RunDeleteError{Code: "confirmation_required", Target: *target, Run: args.Run, Message: fmt.Sprintf("deleting %s#%d requires explicit confirmation", runTargetName(*target), args.Run)})
+	}
+	deleted, err := s.api.DeleteRun(*target, args.Run)
+	if err != nil {
+		return s.errorEnvelope(err)
+	}
+	return s.envelope(map[string]any{"deleted": deleted})
+}
+
+func runTargetName(target app.RunTarget) string {
+	if target.Kind == app.RunKindService {
+		return target.Name
+	}
+	return target.Action.Owner + "/" + target.Action.Name
 }
 
 func mutationSchema(includeDependencies bool) map[string]any {

--- a/internal/runtime/client.go
+++ b/internal/runtime/client.go
@@ -456,6 +456,10 @@ func (c *Client) ExportRun(target app.RunTarget, run uint32) (app.RunExport, err
 	return call[exportRunRequest, app.RunExport](c, context.Background(), methodExportRun, exportRunRequest{Target: target, Run: run})
 }
 
+func (c *Client) DeleteRun(target app.RunTarget, run uint32) (app.RunSummary, error) {
+	return call[exportRunRequest, app.RunSummary](c, context.Background(), methodDeleteRun, exportRunRequest{Target: target, Run: run})
+}
+
 func (c *Client) Logs(name string) []config.LogEntry {
 	resp, _ := call[nameRequest, logsResponse](c, context.Background(), methodLogs, nameRequest{Name: name})
 	return resp.Entries

--- a/internal/runtime/envelope.go
+++ b/internal/runtime/envelope.go
@@ -79,6 +79,7 @@ const (
 	errorActionTimedOut       errorKind = "action_timed_out"
 	errorActionCancelled      errorKind = "action_cancelled"
 	errorPrerequisite         errorKind = "prerequisite_failed"
+	errorRunDelete            errorKind = "run_delete"
 )
 
 // errorPayload is the body of a messageError envelope.
@@ -114,6 +115,7 @@ type errorPayload struct {
 	RunningActionOwner string                 `json:"running_action_owner,omitempty"`
 	RunningActionName  string                 `json:"running_action_name,omitempty"`
 	ActionExitCode     int                    `json:"action_exit_code,omitempty"`
+	RunTarget          *app.RunTarget         `json:"run_target,omitempty"`
 	PrerequisiteLabel  string                 `json:"prerequisite_label,omitempty"`
 	PrerequisiteCause  string                 `json:"prerequisite_cause,omitempty"`
 }

--- a/internal/runtime/errors.go
+++ b/internal/runtime/errors.go
@@ -32,6 +32,11 @@ func (e *VersionMismatchError) Error() string {
 // port-conflict modal (see internal/ui/model_lifecycle.go), so it is the one
 // error kind that carries structured fields instead of just text.
 func encodeError(err error) errorPayload {
+	var runDelete *app.RunDeleteError
+	if errors.As(err, &runDelete) {
+		target := runDelete.Target
+		return errorPayload{Kind: errorRunDelete, Code: runDelete.Code, Message: runDelete.Error(), RunTarget: &target, Run: runDelete.Run}
+	}
 	var required *app.ConfirmationRequiredError
 	if errors.As(err, &required) {
 		return errorPayload{Kind: errorConfirmationRequired, Code: "confirmation_required", Message: required.Error(), Plan: &required.Plan}
@@ -112,6 +117,12 @@ func decodeError(payload errorPayload) error {
 		return &VersionMismatchError{
 			Message: payload.Message, ServerProtocol: payload.ServerProtocol, ServerVersion: payload.ServerVersion,
 		}
+	case errorRunDelete:
+		var target app.RunTarget
+		if payload.RunTarget != nil {
+			target = *payload.RunTarget
+		}
+		return &app.RunDeleteError{Code: payload.Code, Message: payload.Message, Target: target, Run: payload.Run}
 	case errorPortConflict:
 		return &app.PortConflictError{
 			Service:      payload.Service,

--- a/internal/runtime/handlers.go
+++ b/internal/runtime/handlers.go
@@ -163,6 +163,9 @@ var handlers = map[string]handlerFunc{
 	methodExportRun: handler(func(_ context.Context, l *app.Local, req exportRunRequest) (app.RunExport, error) {
 		return l.ExportRun(req.Target, req.Run)
 	}),
+	methodDeleteRun: handler(func(_ context.Context, l *app.Local, req exportRunRequest) (app.RunSummary, error) {
+		return l.DeleteRun(req.Target, req.Run)
+	}),
 	methodActionLogs: handler(func(_ context.Context, l *app.Local, req actionIDRequest) (logsResponse, error) {
 		return logsResponse{Entries: l.ActionLogs(req.ID)}, nil
 	}),

--- a/internal/runtime/integration_test.go
+++ b/internal/runtime/integration_test.go
@@ -259,6 +259,28 @@ func TestRunCatalogPreservesConnectionProvenanceAcrossRPC(t *testing.T) {
 	}
 }
 
+func TestDeleteRunCrossesRPCWithTypedErrors(t *testing.T) {
+	cfg := &config.Config{Project: "RPC delete", ActionGroups: map[string]config.ActionGroup{
+		"ops": {Actions: map[string]config.Action{"ping": {Command: "echo pong", Shell: "/bin/sh"}}},
+	}}
+	client, cleanup := startTestSupervisor(t, cfg, nil)
+	defer cleanup()
+	id := config.ActionID{OwnerKind: config.ActionOwnerGroup, Owner: "ops", Name: "ping"}
+	if _, err := client.RunAction(context.Background(), id); err != nil {
+		t.Fatal(err)
+	}
+	target := app.ActionRunTarget(id)
+	deleted, err := client.DeleteRun(target, 1)
+	if err != nil || deleted.Run != 1 || len(client.Runs()) != 0 || len(client.ActionLogs(id)) != 0 {
+		t.Fatalf("DeleteRun = %+v, %v; runs=%#v logs=%#v", deleted, err, client.Runs(), client.ActionLogs(id))
+	}
+	_, err = client.DeleteRun(target, 1)
+	var deleteErr *app.RunDeleteError
+	if !errors.As(err, &deleteErr) || deleteErr.Code != "run_not_found" || deleteErr.Target != target || deleteErr.Run != 1 {
+		t.Fatalf("typed delete error = %#v (%v)", deleteErr, err)
+	}
+}
+
 func TestExecutePlanPreservesFailedActionRunAcrossIPC(t *testing.T) {
 	cfg := &config.Config{Project: "RPC Failed Action", ActionGroups: map[string]config.ActionGroup{
 		"ops": {Actions: map[string]config.Action{"fail": {Command: "exit 7", Shell: "/bin/sh"}}},

--- a/internal/runtime/messages.go
+++ b/internal/runtime/messages.go
@@ -53,6 +53,7 @@ const (
 	methodRuns                            = "runs"
 	methodRunRetention                    = "runRetention"
 	methodExportRun                       = "exportRun"
+	methodDeleteRun                       = "deleteRun"
 	methodActionLogs                      = "actionLogs"
 	methodQueryLogs                       = "queryLogs"
 	methodClearLogStreams                 = "clearLogStreams"

--- a/internal/service/action.go
+++ b/internal/service/action.go
@@ -436,11 +436,18 @@ func (r *ActionRunner) Result(id config.ActionID, requested int) (ActionResult, 
 	}
 	var wanted uint32
 	if requested < 0 {
-		offset := uint32(-requested) - 1
-		if offset >= latest {
+		available := make([]uint32, 0, len(r.history[id])+1)
+		for _, result := range r.history[id] {
+			available = append(available, result.Run)
+		}
+		if state, ok := r.states[id]; ok && state.Status == ActionRunning {
+			available = append(available, state.Run)
+		}
+		offset := -requested
+		if offset > len(available) {
 			return ActionResult{}, fmt.Errorf("%w: %s/%s run offset %d", ErrActionRunNotFound, id.Owner, id.Name, requested)
 		}
-		wanted = latest - offset
+		wanted = available[len(available)-offset]
 	} else {
 		wanted = uint32(requested)
 		if wanted > latest {
@@ -631,6 +638,38 @@ func (r *ActionRunner) ClearActionLogs(id config.ActionID) {
 	}
 	r.mu.Lock()
 	delete(r.history, id)
+	r.mu.Unlock()
+}
+
+// DeleteRun removes one completed action result and its retained output while
+// leaving nextRun untouched so a deleted address can never be reused.
+func (r *ActionRunner) DeleteRun(id config.ActionID, run uint32) {
+	r.logsMu.RLock()
+	stream := r.logs[id]
+	r.logsMu.RUnlock()
+	if stream != nil {
+		stream.DeleteRun(run)
+	}
+	r.mu.Lock()
+	history := r.history[id]
+	for index := range history {
+		if history[index].Run == run {
+			history = append(history[:index:index], history[index+1:]...)
+			break
+		}
+	}
+	if len(history) == 0 {
+		delete(r.history, id)
+	} else {
+		r.history[id] = history
+	}
+	if state, ok := r.states[id]; ok && state.Run == run {
+		if len(history) == 0 {
+			delete(r.states, id)
+		} else {
+			r.states[id] = cloneActionResult(history[len(history)-1])
+		}
+	}
 	r.mu.Unlock()
 }
 

--- a/internal/service/logstream.go
+++ b/internal/service/logstream.go
@@ -221,6 +221,41 @@ func (s *logStream) Clear() {
 	catalog.ClearOutput(target)
 }
 
+// DeleteRun atomically removes only entries belonging to one run while
+// preserving chronological order, sequence numbers, and the monotonic run
+// counter. The catalog summary is removed separately by Manager.DeleteRun.
+func (s *logStream) DeleteRun(run uint32) {
+	if run == 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	kept := make([]config.LogEntry, 0, s.count)
+	keptBytes := make([]uint64, 0, s.count)
+	for index := range s.count {
+		position := (s.write - s.count + index + len(s.lines)) % len(s.lines)
+		if s.runs[position] == run {
+			continue
+		}
+		kept = append(kept, config.LogEntry{Sequence: s.sequences[position], Timestamp: s.times[position], Source: s.sources[position], Run: s.runs[position], Raw: s.lines[position]})
+		keptBytes = append(keptBytes, s.lineBytes[position])
+	}
+	clear(s.lines)
+	clear(s.times)
+	clear(s.sources)
+	clear(s.sequences)
+	clear(s.runs)
+	clear(s.lineBytes)
+	s.retainedBytes = 0
+	for index, entry := range kept {
+		s.lines[index], s.times[index], s.sources[index] = entry.Raw, entry.Timestamp, entry.Source
+		s.sequences[index], s.runs[index], s.lineBytes[index] = entry.Sequence, entry.Run, keptBytes[index]
+		s.retainedBytes += keptBytes[index]
+	}
+	s.count = len(kept)
+	s.write = s.count % len(s.lines)
+}
+
 // CopyFrom preserves a logical stream across a hot reload.
 func (s *logStream) CopyFrom(previous *logStream) {
 	previous.mu.RLock()

--- a/internal/service/manager.go
+++ b/internal/service/manager.go
@@ -53,6 +53,21 @@ func (m *Manager) AllRunSummaries() []RunSummary { return m.runs.All() }
 
 func (m *Manager) RunRetentionBoundaries() []RunRetentionBoundary { return m.runs.Boundaries() }
 
+// DeleteRun removes one completed catalog record and the retained data owned
+// by its producer. The transition journal remains an immutable audit trail.
+func (m *Manager) DeleteRun(target RunTarget, run uint32) (RunSummary, error) {
+	deleted, err := m.runs.Delete(target, run)
+	if err != nil {
+		return RunSummary{}, err
+	}
+	if target.Kind == RunKindAction {
+		m.actions.DeleteRun(target.Action, run)
+	} else if svc, ok := m.GetService(target.Name); ok {
+		svc.DeleteRunLogs(run)
+	}
+	return deleted, nil
+}
+
 // RecordConfigReload marks a new configuration generation inside every
 // continuing service run. Services restarted by ApplyConfig get a new run and
 // therefore do not receive a marker that would imply process continuity.

--- a/internal/service/run_catalog.go
+++ b/internal/service/run_catalog.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"sort"
 	"sync"
 	"time"
@@ -9,6 +10,11 @@ import (
 )
 
 const defaultRunCatalogSize = 100
+
+var (
+	ErrRunNotFound = errors.New("run not found")
+	ErrRunActive   = errors.New("active run cannot be deleted")
+)
 
 // RunKind identifies the runtime subject that owns a numbered execution.
 type RunKind string
@@ -281,6 +287,35 @@ func (c *RunCatalog) All() []RunSummary {
 		return result[i].StartedAt.Before(result[j].StartedAt)
 	})
 	return result
+}
+
+// Delete removes one completed summary. Run numbers and automatic-retention
+// counters are deliberately untouched: a manually deleted address must never
+// be reused or reported as an automatic eviction.
+func (c *RunCatalog) Delete(target RunTarget, run uint32) (RunSummary, error) {
+	if c == nil || run == 0 {
+		return RunSummary{}, ErrRunNotFound
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	history := c.runs[target]
+	for index := range history {
+		if history[index].Run != run {
+			continue
+		}
+		if history[index].Live {
+			return RunSummary{}, ErrRunActive
+		}
+		deleted := cloneRunSummary(history[index])
+		history = append(history[:index:index], history[index+1:]...)
+		if len(history) == 0 {
+			delete(c.runs, target)
+		} else {
+			c.runs[target] = history
+		}
+		return deleted, nil
+	}
+	return RunSummary{}, ErrRunNotFound
 }
 
 func runTargetLess(left, right RunTarget) bool {

--- a/internal/service/run_catalog_test.go
+++ b/internal/service/run_catalog_test.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"errors"
+	"slices"
 	"testing"
 	"time"
 
@@ -215,5 +217,53 @@ func TestRunCatalogPublishesOldestBoundaryAfterSummaryEviction(t *testing.T) {
 	boundary := catalog.Boundaries()[0]
 	if boundary.OldestRetainedRun != 2 || boundary.EvictedRuns != 1 || boundary.MaxRuns != 2 {
 		t.Fatalf("boundary = %+v", boundary)
+	}
+}
+
+func TestManagerDeletesCompletedActionRunAndNeverReusesItsNumber(t *testing.T) {
+	id := config.ActionID{OwnerKind: config.ActionOwnerService, Owner: "api", Name: "check"}
+	manager := NewManager(&config.Config{Services: map[string]config.Service{
+		"api": {Command: "true", Actions: map[string]config.Action{"check": {Command: "printf first", Shell: "/bin/sh"}}},
+	}})
+	for range 2 {
+		if _, err := manager.RunAction(t.Context(), id); err != nil {
+			t.Fatal(err)
+		}
+	}
+	target := ActionRunTarget(id)
+	deleted, err := manager.DeleteRun(target, 2)
+	if err != nil || deleted.Run != 2 {
+		t.Fatalf("DeleteRun = %+v, %v", deleted, err)
+	}
+	if runs := manager.RunSummaries(target); len(runs) != 1 || runs[0].Run != 1 {
+		t.Fatalf("remaining runs = %#v", runs)
+	}
+	if entries := manager.ActionLogs(id); slices.ContainsFunc(entries, func(entry config.LogEntry) bool { return entry.Run == 2 }) {
+		t.Fatalf("deleted output remains: %#v", entries)
+	}
+	latest, err := manager.ActionResult(id, -1)
+	if err != nil || latest.Run != 1 {
+		t.Fatalf("latest retained result = %+v, %v", latest, err)
+	}
+	result, err := manager.RunAction(t.Context(), id)
+	if err != nil || result.Run != 3 {
+		t.Fatalf("next result = %+v, %v; deleted number was reused", result, err)
+	}
+}
+
+func TestManagerRefusesToDeleteLiveRun(t *testing.T) {
+	manager := NewManager(&config.Config{Services: map[string]config.Service{"api": {
+		Supervision: config.SupervisionDetached,
+		Lifecycle:   config.LifecycleConfig{Start: &config.Action{Command: "true", Shell: "/bin/sh"}, Stop: &config.Action{Command: "true", Shell: "/bin/sh"}},
+	}}})
+	t.Cleanup(func() { _ = manager.Shutdown() })
+	if err := manager.StartService("api"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.DeleteRun(ServiceRunTarget("api"), 1); !errors.Is(err, ErrRunActive) {
+		t.Fatalf("DeleteRun live error = %v", err)
+	}
+	if runs := manager.RunSummaries(ServiceRunTarget("api")); len(runs) != 1 || !runs[0].Live {
+		t.Fatalf("live run changed after refusal: %#v", runs)
 	}
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -421,6 +421,9 @@ func (s *Service) CopyLogHistoryFrom(previous *Service) { s.stream.CopyFrom(prev
 // ClearLogs discards this service's buffered logs and their metadata.
 func (s *Service) ClearLogs() { s.stream.Clear() }
 
+// DeleteRunLogs removes retained output for one completed execution.
+func (s *Service) DeleteRunLogs(run uint32) { s.stream.DeleteRun(run) }
+
 // SetState replaces the complete mutable state.
 func (s *Service) SetState(state config.ServiceState) {
 	s.stateMu.Lock()

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -36,6 +36,7 @@ const (
 	ModeThemes
 	ModeRunList
 	ModeRunExport
+	ModeConfirmDeleteRun
 )
 
 type runViewMode uint8
@@ -226,6 +227,8 @@ type Model struct {
 	runViewports     map[runViewportKey]runViewportState
 	exportTarget     app.RunTarget
 	exportRun        uint32
+	deleteTarget     app.RunTarget
+	deleteRun        uint32
 
 	mode       ViewMode
 	width      int

--- a/internal/ui/model_keys.go
+++ b/internal/ui/model_keys.go
@@ -51,6 +51,8 @@ func (m *Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleRunListKeys(msg)
 	case ModeRunExport:
 		return m.handleRunExportKeys(msg)
+	case ModeConfirmDeleteRun:
+		return m.handleConfirmDeleteRunKeys(msg)
 	default:
 		if msg.String() == "esc" || msg.String() == "q" {
 			m.mode = ModeNormal

--- a/internal/ui/mouse.go
+++ b/internal/ui/mouse.go
@@ -314,6 +314,9 @@ func (m *Model) handleOverlayMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		if renderedTextHit(rendered, msg.X, msg.Y, "[Tab] Filter") {
 			return m.handleRunListKeys(tea.KeyMsg{Type: tea.KeyTab})
 		}
+		if renderedTextHit(rendered, msg.X, msg.Y, "[d] Delete") {
+			return m.handleRunListKeys(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+		}
 		return m.closeOverlayOnClick(rendered, msg)
 	case ModeThemes:
 		return m.handleThemeMouseClick(rendered, msg)
@@ -363,6 +366,13 @@ func (m *Model) handleOverlayMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 			m.clearTarget = ""
 			m.clearPinned = false
 			m.mode = ModeNormal
+		}
+	case ModeConfirmDeleteRun:
+		if renderedTextHit(rendered, msg.X, msg.Y, "[Enter] Delete") {
+			m.confirmDeleteRun()
+		}
+		if renderedTextHit(rendered, msg.X, msg.Y, "[Esc] Cancel") {
+			m.cancelDeleteRun()
 		}
 	case ModeConfirmAction:
 		if renderedTextHit(rendered, msg.X, msg.Y, "[Enter/y] Run") || renderedTextHit(rendered, msg.X, msg.Y, "[Enter/y] Stop") {

--- a/internal/ui/run_view.go
+++ b/internal/ui/run_view.go
@@ -376,6 +376,15 @@ func (m *Model) handleRunListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.restoreRunViewport()
 		}
 		m.mode = ModeNormal
+	case msg.String() == "d":
+		if len(runs) > 0 {
+			run := runs[min(m.runListCursor, len(runs)-1)]
+			if run.Live {
+				m.addNotification(runTargetLabel(run.Target), fmt.Sprintf("Run #%d is still active and cannot be deleted", run.Run), config.LogError)
+			} else {
+				m.deleteTarget, m.deleteRun, m.mode = run.Target, run.Run, ModeConfirmDeleteRun
+			}
+		}
 	case msg.String() == "esc", msg.String() == "q", msg.String() == "v":
 		m.mode = ModeNormal
 	}
@@ -422,6 +431,55 @@ func (m *Model) renderRunListView() string {
 		}
 		lines = append(lines, line)
 	}
-	lines = append(lines, "", renderModalShortcuts("  [↑/↓] Select  [Enter] Open run  [Tab] Filter  [Esc] Close", lipgloss.NewStyle().Foreground(ColorDim)))
+	lines = append(lines, "", renderModalShortcuts("  [↑/↓] Select  [Enter] Open run  [d] Delete  [Tab] Filter  [Esc] Close", lipgloss.NewStyle().Foreground(ColorDim)))
 	return m.placeOverlay(renderFlushModal(strings.Join(lines, "\n")))
+}
+
+func (m *Model) renderConfirmDeleteRunView() string {
+	identity := fmt.Sprintf("%s#%d", runTargetLabel(m.deleteTarget), m.deleteRun)
+	return m.placeOverlay(renderConfirmationModal(
+		fmt.Sprintf("Delete %s from run history?", identity),
+		[]string{"This removes the retained summary and output.", "The transition journal is kept. This cannot be undone."},
+		"[Enter] Delete  [Esc] Cancel",
+	))
+}
+
+func (m *Model) handleConfirmDeleteRunKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "enter", "y":
+		m.confirmDeleteRun()
+	case "esc", "n", "q":
+		m.cancelDeleteRun()
+	}
+	return m, nil
+}
+
+func (m *Model) cancelDeleteRun() {
+	m.deleteTarget, m.deleteRun, m.mode = app.RunTarget{}, 0, ModeRunList
+}
+
+func (m *Model) confirmDeleteRun() {
+	target, run := m.deleteTarget, m.deleteRun
+	if _, err := m.app.DeleteRun(target, run); err != nil {
+		m.addNotification(runTargetLabel(target), err.Error(), config.LogError)
+		m.cancelDeleteRun()
+		return
+	}
+	for key := range m.runViewports {
+		if key.Target == target && key.Run == run {
+			delete(m.runViewports, key)
+		}
+	}
+	if m.pinnedTarget == target && m.pinnedRun == run {
+		m.pinnedLog, m.pinnedTarget, m.pinnedRun = "", app.RunTarget{}, 0
+		m.pinnedRunMode, m.pinnedOffset, m.pinnedAnchor, m.pinnedMatch = runViewCombined, 0, 0, -1
+	}
+	if m.runTarget == target && m.selectedRun == run {
+		m.selectedRun = latestRun(m.runsForTarget(target))
+		m.runFollowsLatest = true
+	}
+	runs := m.filteredRunList()
+	m.runListCursor = min(m.runListCursor, max(0, len(runs)-1))
+	m.addNotification(runTargetLabel(target), fmt.Sprintf("Run #%d deleted", run), config.LogInfo)
+	m.deleteTarget, m.deleteRun, m.mode = app.RunTarget{}, 0, ModeRunList
 }

--- a/internal/ui/run_view_test.go
+++ b/internal/ui/run_view_test.go
@@ -158,6 +158,51 @@ func TestRunListFiltersAndSelectsByKeyboardAndMouse(t *testing.T) {
 	}
 }
 
+func TestRunListDeletesCompletedRunOnlyAfterConfirmation(t *testing.T) {
+	model := newTestModel()
+	defer model.Shutdown()
+	finishTestServiceRun(t, model, "api", 0, "delete me")
+	finishTestServiceRun(t, model, "api", 0, "keep me")
+	model.refreshServices()
+	model.selectLatestRun()
+	model.moveRun(-1, false)
+	model.togglePinnedLog()
+	model.openRunList()
+	_, _ = model.handleRunListKeys(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	if model.mode != ModeConfirmDeleteRun || model.deleteRun != 1 {
+		t.Fatalf("delete confirmation = mode %d run %d", model.mode, model.deleteRun)
+	}
+	_, _ = model.handleConfirmDeleteRunKeys(tea.KeyMsg{Type: tea.KeyEsc})
+	if len(model.app.Runs()) != 2 || model.mode != ModeRunList {
+		t.Fatalf("cancel changed runs or mode: %d, %d", len(model.app.Runs()), model.mode)
+	}
+	_, _ = model.handleRunListKeys(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	_, _ = model.handleConfirmDeleteRunKeys(tea.KeyMsg{Type: tea.KeyEnter})
+	if runs := model.app.Runs(); len(runs) != 1 || runs[0].Run != 2 {
+		t.Fatalf("remaining runs = %#v", runs)
+	}
+	if model.pinnedTarget.Kind != "" || model.pinnedRun != 0 {
+		t.Fatalf("deleted pin remains: %+v #%d", model.pinnedTarget, model.pinnedRun)
+	}
+	for _, entry := range model.app.Logs("api") {
+		if entry.Run == 1 {
+			t.Fatalf("deleted output remains: %#v", model.app.Logs("api"))
+		}
+	}
+}
+
+func TestRunListRefusesToDeleteActiveRun(t *testing.T) {
+	model := newTestModel()
+	defer model.Shutdown()
+	model.app.SetServiceStatusForTest("api", config.StatusStarting)
+	model.refreshServices()
+	model.openRunList()
+	_, _ = model.handleRunListKeys(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	if model.mode != ModeRunList || len(model.app.Runs()) != 1 || !model.app.Runs()[0].Live {
+		t.Fatalf("active delete changed mode or run: mode=%d runs=%#v", model.mode, model.app.Runs())
+	}
+}
+
 func TestPinnedHistoricalRunRemainsImmutableAfterNewStart(t *testing.T) {
 	model := newTestModel()
 	defer model.Shutdown()

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -55,6 +55,8 @@ func (m *Model) View() string {
 		content = m.renderRunListView()
 	case ModeRunExport:
 		content = m.renderRunExportView()
+	case ModeConfirmDeleteRun:
+		content = m.renderConfirmDeleteRunView()
 	default:
 		content = m.renderMainView()
 	}

--- a/internal/ui/view_modals.go
+++ b/internal/ui/view_modals.go
@@ -72,6 +72,7 @@ func helpSections() []helpSection {
 			{"[ / ]", "Open the previous or next run"},
 			{"Shift+F / l", "Open the previous failed run or return to the latest run"},
 			{"v", "Open the filterable run catalog"},
+			{"d", "Delete the selected completed run after confirmation"},
 			{"e / Shift+E", "Export the selected run to clipboard or a file"},
 			{"c", "Clear focused or pinned service logs after confirmation"},
 		}},


### PR DESCRIPTION
## Summary
- delete one completed absolute run and its retained output through the shared app/runtime contract
- add confirmed TUI `d`, CLI `runs delete TARGET#N --confirm`, and MCP `run_delete` surfaces
- protect active runs, preserve the transition journal and monotonic run numbering

## Validation
- `make verify`
- `make lint` (0 issues)
- `make release-check`
- `git diff --check`

Target: v0.10.0. This PR does not tag or publish a release.