### PR TITLE
chore: release Kranz 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-08-28
+
 ### Added
 
 - Stable absolute `SERVICE#N` and `OWNER/ACTION#N` identities across the TUI,
@@ -40,8 +42,42 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
   while output always prints the absolute `#N` identity. A retained run whose
   prefix was evicted reports exact missing lines and bytes before its tail.
 
+- Run view labels are a fraction instead of a phrase: `ALL RUNS`, `RUN #3/3`,
+  and `RUN #2/3 · [L] LATEST` replace `ALL RUNS · INCLUDES NEW`,
+  `LATEST RUN #3`, and `HISTORY · RUN #2 · 1 NEWER · [L] LATEST`. The words
+  LATEST, HISTORY, and "N NEWER" each restated what the fraction already says.
+- The action output title no longer repeats the run number in the target name,
+  which in combined mode named a single run while the panel showed all of them,
+  and no longer prints "succeeded" beside the `✓` that already means it. A word
+  appears only where the indicator cannot carry the outcome: `×` covers both
+  failed and timed out. That word now trails the run label instead of preceding
+  it, so starting and finishing a run no longer slides the run position
+  sideways under the cursor.
+- The run list's filter moved into the `[Tab]` shortcut and is offered only
+  when a filter would divide the list, and retention budgets appear only
+  alongside a gap they explain, in readable units. On an intact history both
+  lines only reported that nothing had been lost.
+
 ### Fixed
 
+- The TUI run list now windows itself to the terminal height and shows a
+  `position/total` indicator. A target retains up to a hundred runs, and the
+  unwindowed modal grew past the screen, so the overlay clipped the selection
+  and the shortcut footer while the cursor kept moving invisibly.
+- Clicking a run in the run list now selects that run rather than one whose
+  number is a prefix of it, so `#12` is no longer read as `#1`.
+- The run list's `Tab` cycle now offers only the filters the focused target's
+  history can satisfy. Services and actions use disjoint status vocabularies —
+  a service that exits cleanly is `stopped` and never `succeeded` — so the
+  fixed cycle always contained options that could match nothing.
+- `logs --run N` for a run that is not retained now fails with
+  `run_not_retained` and names the range each selected stream can answer for.
+  Returning an empty success made a typo, a deleted run, and a run that
+  produced no output indistinguishable.
+- `kranz runs` prints retention and run summaries as two separate tables. They
+  share no columns, and one tabwriter stretched the run table's `DURATION`
+  column to fit a retention budget string. A target with no retained runs now
+  shows `-` instead of `#0`.
 - Run labels and action status separators are visually cleaner, the run catalog
   has an explicit column header, and the shortcut reference is narrower,
   shorter, and gives section headings a distinct neutral hierarchy.

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ changes immediately in the open TUI; none of these views starts a second stack.
 ### Coding agents join your live session
 
 Kranz MCP gives a coding agent the same services, actions, readiness, ports,
-and bounded logs visible in the TUI. It attaches to the existing runtime instead
-of starting a second development stack.
+bounded logs, and numbered run history visible in the TUI. It attaches to the
+existing runtime instead of starting a second development stack.
 
 - **One runtime** — TUI, CLI, and MCP use the same supervisor.
 - **One view of the project** — the same selectors, action runs, and logs.
@@ -98,6 +98,8 @@ kranz config check
 kranz up -d
 kranz status
 kranz logs api --tail 20
+kranz runs api
+kranz logs api --run -1
 kranz restart api
 kranz down
 ```
@@ -118,6 +120,8 @@ for every command, option, output contract, and exit code.
 - Prerequisites that must succeed before a service starts
 - Runtime port discovery and ownership-aware conflict handling
 - Searchable, pinnable, timestamped logs in a keyboard and mouse TUI
+- Bounded per-service and per-action run history with provenance, exact output
+  retention state, navigation, deletion, and export
 - Procfile, native YAML, and conservative Process Compose loading
 - Live configuration reload with last-known-good fallback
 

--- a/cmd/kranz/logs.go
+++ b/cmd/kranz/logs.go
@@ -164,7 +164,10 @@ func classifyLogQueryError(err error) error {
 	var queryErr *app.LogQueryError
 	if errors.As(err, &queryErr) {
 		exit := kranzcli.ExitUsage
-		if queryErr.Code == "selector_not_found" || queryErr.Code == "action_not_found" || queryErr.Code == "group_has_no_stream" {
+		// run_not_retained is an address that resolved to nothing, the same
+		// class of failure as naming a service that does not exist.
+		if queryErr.Code == "selector_not_found" || queryErr.Code == "action_not_found" ||
+			queryErr.Code == "group_has_no_stream" || queryErr.Code == "run_not_retained" {
 			exit = kranzcli.ExitNotFound
 		}
 		return &kranzcli.Error{Code: queryErr.Code, Message: queryErr.Message, Hint: queryErr.Hint, ExitCode: exit}

--- a/cmd/kranz/runs.go
+++ b/cmd/kranz/runs.go
@@ -99,11 +99,28 @@ func runRuns(options kranzcli.GlobalOptions, targets []string, stdout io.Writer)
 			Retention []app.RunRetentionBoundary `json:"retention"`
 		}{Runs: runs, Retention: retention})
 	}
-	w := tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
-	for _, boundary := range retention {
-		_, _ = fmt.Fprintf(w, "RETENTION\t%s\toldest #%d\t%d runs / %d entries / %d bytes\tevicted %d runs\n",
-			runTargetName(boundary.Target), boundary.OldestRetainedRun, boundary.MaxRuns, boundary.MaxEntries, boundary.MaxBytes, boundary.EvictedRuns)
+	// The two tables describe different things and share no columns. One
+	// tabwriter aligned them against each other, so a long budget string
+	// stretched the run table's DURATION column across half the terminal.
+	if len(retention) > 0 {
+		rw := tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
+		_, _ = fmt.Fprintln(rw, "TARGET\tOLDEST\tBUDGETS\tEVICTED")
+		for _, boundary := range retention {
+			oldest := "-"
+			if boundary.OldestRetainedRun > 0 {
+				oldest = fmt.Sprintf("#%d", boundary.OldestRetainedRun)
+			}
+			_, _ = fmt.Fprintf(rw, "%s\t%s\t%d runs / %d entries / %s\t%d runs\n",
+				runTargetName(boundary.Target), oldest, boundary.MaxRuns, boundary.MaxEntries, formatRunBytes(boundary.MaxBytes), boundary.EvictedRuns)
+		}
+		if err := rw.Flush(); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(stdout); err != nil {
+			return err
+		}
 	}
+	w := tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
 	_, _ = fmt.Fprintln(w, "RUN\tSTATUS\tSTARTED\tDURATION\tEXIT\tREASON\tINITIATOR\tOUTPUT")
 	for _, run := range runs {
 		exit := "-"
@@ -136,6 +153,20 @@ func filterRunRetention(boundaries []app.RunRetentionBoundary, targets []string)
 		}
 	}
 	return result
+}
+
+// formatRunBytes keeps a budget readable in the text table. JSON output keeps
+// the exact byte count, which is what a machine reader needs.
+func formatRunBytes(bytes uint64) string {
+	switch {
+	case bytes >= 1<<30:
+		return fmt.Sprintf("%.3g GB", float64(bytes)/(1<<30))
+	case bytes >= 1<<20:
+		return fmt.Sprintf("%.3g MB", float64(bytes)/(1<<20))
+	case bytes >= 1<<10:
+		return fmt.Sprintf("%.3g KB", float64(bytes)/(1<<10))
+	}
+	return fmt.Sprintf("%d B", bytes)
 }
 
 func runTargetName(target app.RunTarget) string {

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -42,7 +42,7 @@ workflow; generated binaries are never checked into the repository.
    make verify
    make lint
    make release-check
-   make snapshot RELEASE_VERSION=0.8.0 # use the release being prepared
+   make snapshot RELEASE_VERSION=0.10.0 # use the release being prepared
    ./dist/kranz_darwin_arm64_v8.0/kranz --version # choose the local platform build
    make packages-verify
    PACKAGE_ARCH=arm64 make packages-verify
@@ -57,9 +57,9 @@ workflow; generated binaries are never checked into the repository.
 4. Create an annotated tag without pushing it automatically:
 
    ```bash
-   make tag RELEASE_VERSION=0.8.0 # use the release being published
-   git show v0.8.0
-   git push origin v0.8.0
+   make tag RELEASE_VERSION=0.10.0 # use the release being published
+   git show v0.10.0
+   git push origin v0.10.0
    ```
 
 ## Verify the published release
@@ -71,8 +71,8 @@ replaces generated commit notes with the matching version section from
 the release before announcing it:
 
 ```bash
-gh release view v0.8.0
-gh release download v0.8.0 \
+gh release view v0.10.0
+gh release download v0.10.0 \
   --pattern 'checksums.txt' \
   --pattern '*.tar.gz' \
   --pattern '*.deb' \

--- a/docs/guide/logs-and-ports.md
+++ b/docs/guide/logs-and-ports.md
@@ -21,6 +21,60 @@ The log panels support:
 - pause/follow mode and unread counters;
 - a pinned service above the currently focused log panel.
 
+## Run history
+
+Every start of a service and every invocation of an action is a numbered *run*.
+Run numbers are assigned once and never reused, so `api#4` keeps addressing the
+same execution after later runs age out of the buffer.
+
+Kranz retains a bounded catalog of run summaries per target, independently of
+the log buffer. A noisy service can only evict its own history, never another
+target's.
+
+```bash
+kranz runs                          # every retained run, with retention budgets
+kranz runs api analytics/stats      # narrow to one or more targets
+kranz logs api --run 4              # only run #4
+kranz logs api --run -1             # the newest run
+kranz logs api --runs 3             # the last three runs
+```
+
+A run summary records how the run ended and who started it: exit code,
+duration, the structured cause of a state, the surface that initiated it
+(`tui`, `cli`, `mcp`, or `runtime`), and why (`first_start`, `manual_start`,
+`invoked`, and so on). Client labels are short product names, never socket,
+process, or user identifiers.
+
+Addressing a run that is not retained is an error rather than empty output, and
+the message names the range each selected stream can still answer for:
+
+```
+$ kranz logs api --run 99
+Kranz: run #99 is not retained by anything this query selected.
+Retained runs: api #7-#12.
+```
+
+The catalog and the log buffer have separate budgets, so a run's summary can
+outlive its output. When that happens the run reports `partial` or
+`unavailable` output with exactly how many lines and bytes are missing, instead
+of presenting a shortened log as if it were complete.
+
+In the TUI, `v` opens the run history for the focused service or action. `x`
+switches between all runs and a single run, `[` and `]` step through history,
+`Shift+F` jumps to the previous failed run, and `l` returns to the latest.
+`Shift+3` pins a run so it stays frozen while the live panel keeps moving.
+See [Controls](../reference/controls) for the complete list.
+
+Retention is per session. A run summary and its output can also be dropped
+explicitly:
+
+```bash
+kranz runs delete api#4 --confirm
+```
+
+Deleting a run never reuses its number and never touches the transition
+journal, so history stays honest about what happened.
+
 ## Declared ports
 
 ```yaml

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -233,6 +233,11 @@ run, catalog/output budgets, evicted summary count, provenance, and output
 state (`complete`, `partial`, or `unavailable`). The catalog belongs to the
 live runtime session and is not restored after `down`.
 
+An explicit `--run` that nothing retains exits `4` with `run_not_retained` and
+names the range each selected stream can answer for, so a typo, a deleted run,
+and a run that produced no output stay distinguishable. `--runs N` is a window
+rather than an address and stays silent when it overlaps the start of history.
+
 ### Actions
 
 ```bash
@@ -317,7 +322,7 @@ not successful booleans.
 | `1` | Internal error, or an action that ran and failed |
 | `2` | Usage error — unknown command, missing or malformed argument |
 | `3` | Configuration error, including a failed `doctor` |
-| `4` | Not found — no such runtime, service, action, or selector |
+| `4` | Not found — no such runtime, service, action, selector, or retained run |
 | `5` | Conflict — a runtime with that name is already active, or a file exists |
 | `6` | Runtime unavailable — unreachable, incompatible, or a refused force-down |
 

--- a/docs/reference/controls.md
+++ b/docs/reference/controls.md
@@ -56,16 +56,37 @@ directions.
 | `Shift+3` | Pin the selected `{target, run, view mode}` snapshot |
 | `e` / `Shift+E` | Export selected run to clipboard / chosen file |
 
-The log header names the history position explicitly: `ALL RUNS · INCLUDES NEW`
-keeps accepting new runs, `LATEST RUN #N` shows the newest run in isolation,
-and `HISTORY · RUN #N` means a newer run exists. A pinned panel is frozen and
-shows `Shift+3 UNPIN` in its title; while any pin exists the footer starts with
-`[Shift+3] unpin`, and the shortcut works from every panel.
+The log header names the history position as a fraction. `ALL RUNS` accepts new
+output, `RUN #3/3` is the newest run in isolation, and `RUN #2/3 · [L] LATEST`
+is an older one — the numerator is the run's absolute identity and the
+denominator is the newest run, so the position, the distance from the end, and
+the existence of newer runs are one reading rather than three phrases. The
+panel title names the target once; it does not repeat the run number the label
+already carries. A pinned panel is frozen and shows `Shift+3 UNPIN` in its
+title; while any pin exists the footer starts with `[Shift+3] unpin`, and the
+shortcut works from every panel.
 
-`LATEST RUN` follows future starts automatically. Choosing an older run with
-`[`, the catalog, or previous-failed navigation enters `HISTORY`; that explicit
-selection remains stable until `l` returns to the latest run. The all-runs view
-scrolls across the complete retained output of service and action runs.
+An action's outcome is the status indicator. The word appears after the run
+label, and only where the glyph cannot carry the difference: `×` covers both
+`FAILED` and `TIMED_OUT`, while `✓` and "succeeded" would say the same thing
+twice. Keeping the word behind the label matters because it exists only while a
+run is live — in front of the label it moved the run position on every start
+and every finish.
+
+The run list windows itself to the terminal and shows a `position/total`
+indicator when the history is longer than the window, so the selected row and
+the shortcut footer stay visible however far back the selection is. Its
+`[Tab]` shortcut carries the active filter and appears only when a filter would
+actually divide the list: a candidate is offered only if it selects some but
+not all retained runs, so three successful actions have nothing to filter and
+one failure among them makes `failed` worth offering. Retention budgets are
+shown only alongside a gap they explain — dropped summaries, or runs whose
+output the buffer no longer holds.
+
+`RUN #N/N` follows future starts automatically. Choosing an older run with `[`,
+the catalog, or previous-failed navigation pins the selection; it remains
+stable until `l` returns to the latest run. The all-runs view scrolls across
+the complete retained output of service and action runs.
 
 The in-app `?` reference is a compact, scrollable single column split into
 Navigation, Services & Actions, Logs & Run History, Log Search, Appearance, and

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -117,7 +117,7 @@ Stable causal codes include `selector_not_found`, `service_unavailable`,
 `interactive_action`, `confirmation_required`, `confirmation_expired`,
 `confirmation_plan_changed`, `action_busy`, `action_failed`,
 `action_timed_out`, `action_cancelled`, `wait_timeout`, `wait_cancelled`,
-`run_not_found`, `run_active`,
+`run_not_found`, `run_active`, `run_not_retained`,
 `dependency_blocked`, `terminal_failure`, `port_conflict`, `prerequisite_failed`,
 `no_run_streams`,
 `invalid_cursor`, `invalid_change_query`, and `invalid_change_kind`.

--- a/internal/app/logs.go
+++ b/internal/app/logs.go
@@ -125,6 +125,10 @@ func queryLogs(local *Local, query LogQuery) (LogResult, error) {
 	if err != nil {
 		return result, err
 	}
+	// An explicit --run is a claim about a specific execution and must fail when
+	// nothing answers it. The implicit -1 below is only a default window, so it
+	// has to stay silent for a target that has simply never run.
+	explicitRun := query.Run
 	if query.DefaultTail > 0 && query.Tail == 0 && query.Since.IsZero() && query.Run == 0 && query.Runs == 0 {
 		allActions := len(targets) > 0 && !slices.ContainsFunc(targets, func(target logTarget) bool { return !target.isAction() })
 		if allActions {
@@ -148,6 +152,11 @@ func queryLogs(local *Local, query LogQuery) (LogResult, error) {
 
 	events := make([]LogEvent, 0)
 	windows := make([]LogStreamWindow, 0, len(targets))
+	// An exact --run address either resolves somewhere or it does not. Reporting
+	// success with no events left a typo, a deleted run, and a run that produced
+	// no output looking identical, which no other selector in this API does.
+	runAddressed := explicitRun == 0
+	retained := make([]string, 0, len(targets))
 	for _, target := range targets {
 		entries := local.Logs(target.service)
 		if target.isAction() {
@@ -156,6 +165,12 @@ func queryLogs(local *Local, query LogQuery) (LogResult, error) {
 		runTarget := serviceRunTargetForLogTarget(target)
 		summaries := local.manager.RunSummaries(runTarget)
 		low, high, selected := selectedRunRange(summaries, query.Run, query.Runs)
+		if explicitRun != 0 {
+			if selected && slices.ContainsFunc(summaries, func(summary RunSummary) bool { return summary.Run == low }) {
+				runAddressed = true
+			}
+			retained = append(retained, describeRetainedRuns(target.address, summaries))
+		}
 		if query.Run != 0 || query.Runs != 0 {
 			entries = filterEntriesByRange(entries, low, high, selected)
 			for _, summary := range summaries {
@@ -198,6 +213,13 @@ func queryLogs(local *Local, query LogQuery) (LogResult, error) {
 				continue
 			}
 			events = append(events, normalizedEvents(target, entry)...)
+		}
+	}
+	if !runAddressed {
+		return LogResult{Generation: project.Generation, Events: []LogEvent{}}, &LogQueryError{
+			Code:    "run_not_retained",
+			Message: fmt.Sprintf("run %s is not retained by anything this query selected", formatRunAddress(explicitRun)),
+			Hint:    "Retained runs: " + strings.Join(retained, "; ") + ".",
 		}
 	}
 	sort.SliceStable(events, func(i, j int) bool {
@@ -328,6 +350,32 @@ func serviceRunTargetForLogTarget(target logTarget) RunTarget {
 		return ActionRunTarget(target.action)
 	}
 	return ServiceRunTarget(target.service)
+}
+
+// formatRunAddress spells a --run value the way the user wrote it, so a
+// negative offset is not silently reported as the absolute number it resolved
+// to — or failed to resolve to.
+func formatRunAddress(run int) string {
+	if run < 0 {
+		return fmt.Sprintf("offset %d", run)
+	}
+	return fmt.Sprintf("#%d", run)
+}
+
+// describeRetainedRuns names what one stream can still answer for, so the error
+// tells the user where to aim next instead of only that they missed.
+func describeRetainedRuns(address string, summaries []RunSummary) string {
+	if len(summaries) == 0 {
+		return address + " has no retained runs"
+	}
+	low, high := summaries[0].Run, summaries[0].Run
+	for _, summary := range summaries {
+		low, high = min(low, summary.Run), max(high, summary.Run)
+	}
+	if low == high {
+		return fmt.Sprintf("%s #%d", address, low)
+	}
+	return fmt.Sprintf("%s #%d-#%d", address, low, high)
 }
 
 func selectedRunRange(summaries []RunSummary, run, runs int) (low, high uint32, ok bool) {

--- a/internal/app/logs_test.go
+++ b/internal/app/logs_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -205,5 +206,40 @@ func TestQueryLogsResolvesLatestFromCatalogAndReportsExactRetentionGap(t *testin
 		if event.Run != 1 {
 			t.Fatalf("latest catalog run returned #%d", event.Run)
 		}
+	}
+}
+
+func TestQueryLogsFailsOnAnUnaddressableExplicitRun(t *testing.T) {
+	local := logQueryTestLocal(t)
+	id, _ := findActionID(local.Config(), "api/migrate")
+	if _, err := local.RunAction(context.Background(), id); err != nil {
+		t.Fatal(err)
+	}
+
+	// A run that was never assigned, and an offset past the retained history,
+	// must both be reported. Returning an empty success made a typo, a deleted
+	// run, and a silent run indistinguishable.
+	for _, run := range []int{99, -9} {
+		result, err := local.QueryLogs(LogQuery{Selectors: []string{"api/migrate"}, Run: run})
+		var queryErr *LogQueryError
+		if !errors.As(err, &queryErr) || queryErr.Code != "run_not_retained" {
+			t.Fatalf("run %d = %#v, %v; want a run_not_retained error", run, result, err)
+		}
+		if !strings.Contains(queryErr.Hint, "api/migrate #1") {
+			t.Fatalf("run %d hint = %q, want the retained range", run, queryErr.Hint)
+		}
+	}
+
+	// A target that has simply never run keeps the implicit action default
+	// silent: only an explicit address is a claim that has to resolve.
+	quiet, err := local.QueryLogs(LogQuery{Selectors: []string{"analytics/stats"}, DefaultTail: 200})
+	if err != nil || len(quiet.Events) != 0 {
+		t.Fatalf("action default without runs = %#v, %v", quiet, err)
+	}
+
+	// One retained target is enough for a multi-target address to succeed.
+	both, err := local.QueryLogs(LogQuery{Selectors: []string{"api/migrate", "analytics/stats"}, Run: 1})
+	if err != nil || len(both.Events) == 0 {
+		t.Fatalf("run 1 across a retained and an unrun target = %#v, %v", both, err)
 	}
 }

--- a/internal/service/run_catalog.go
+++ b/internal/service/run_catalog.go
@@ -350,8 +350,15 @@ func (c *RunCatalog) update(target RunTarget, run uint32, update func(*RunSummar
 	}
 }
 
+// cloneRunSummary detaches every pointer a summary carries. A caller that
+// holds a summary returned by List or All must not be able to reach back into
+// catalog state that is only safe to touch under the mutex.
 func cloneRunSummary(summary RunSummary) RunSummary {
 	summary.Cause = cloneStateCause(summary.Cause)
+	if summary.ExitCode != nil {
+		exit := *summary.ExitCode
+		summary.ExitCode = &exit
+	}
 	return summary
 }
 

--- a/internal/ui/mouse.go
+++ b/internal/ui/mouse.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -301,7 +302,17 @@ func (m *Model) handleOverlayMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	switch m.mode {
 	case ModeRunList:
 		runs := m.filteredRunList()
-		for index, run := range runs {
+		// "#1" is a prefix of "#12", and renderedTextHit matches any occurrence
+		// covering the clicked cell. Ascending order therefore let run #1 claim
+		// a click on run #12 as soon as a target had ten runs. Testing the
+		// longest label first makes the most specific row win its own cells.
+		order := make([]int, len(runs))
+		for index := range order {
+			order[index] = index
+		}
+		sort.SliceStable(order, func(i, j int) bool { return runs[order[i]].Run > runs[order[j]].Run })
+		for _, index := range order {
+			run := runs[index]
 			if renderedTextHit(rendered, msg.X, msg.Y, fmt.Sprintf("#%d", run.Run)) {
 				m.runListCursor = index
 				m.saveRunViewport()

--- a/internal/ui/run_view.go
+++ b/internal/ui/run_view.go
@@ -2,6 +2,8 @@ package ui
 
 import (
 	"fmt"
+	"slices"
+	"sort"
 	"strings"
 	"time"
 
@@ -220,21 +222,26 @@ func (m *Model) runSummary(target app.RunTarget, run uint32) (app.RunSummary, bo
 	return app.RunSummary{}, false
 }
 
+// runViewLabel names the history position. "RUN #2/3" carries the identity,
+// the distance from the newest run, and the fact that a newer one exists, so
+// the words LATEST, HISTORY, and "N NEWER" that used to spell those out are
+// three restatements of one fraction.
 func (m *Model) runViewLabel() string {
 	if !m.syncRunTarget() || m.runMode == runViewCombined {
-		return "ALL RUNS · INCLUDES NEW"
+		return "ALL RUNS"
 	}
 	latest := latestRun(m.runsForTarget(m.runTarget))
-	if latest == 0 {
+	switch {
+	case latest == 0:
 		return "NO RUNS YET"
+	case m.selectedRun > latest:
+		// Defensive: a fraction whose numerator exceeds its denominator would
+		// read as a bug rather than as a position.
+		return fmt.Sprintf("RUN #%d", m.selectedRun)
+	case m.selectedRun == latest:
+		return fmt.Sprintf("RUN #%d/%d", m.selectedRun, latest)
 	}
-	if m.selectedRun == latest {
-		return fmt.Sprintf("LATEST RUN #%d", m.selectedRun)
-	}
-	if latest > m.selectedRun {
-		return fmt.Sprintf("HISTORY · RUN #%d · %d NEWER · [L] LATEST", m.selectedRun, latest-m.selectedRun)
-	}
-	return fmt.Sprintf("HISTORY · RUN #%d", m.selectedRun)
+	return fmt.Sprintf("RUN #%d/%d · [L] LATEST", m.selectedRun, latest)
 }
 
 func runTargetLabel(target app.RunTarget) string {
@@ -248,7 +255,7 @@ func (m *Model) pinnedRunViewLabel() string {
 	if m.pinnedRunMode == runViewSingle {
 		return fmt.Sprintf("FROZEN · RUN #%d", m.pinnedRun)
 	}
-	return fmt.Sprintf("FROZEN · RUNS THROUGH #%d", m.pinnedRun)
+	return fmt.Sprintf("FROZEN · RUNS ≤ #%d", m.pinnedRun)
 }
 
 func (m *Model) pinnedEntries(target app.RunTarget) []config.LogEntry {
@@ -324,9 +331,10 @@ func (m *Model) renderPinnedActionRunPanel(target app.RunTarget, width, height i
 }
 
 func (m *Model) openRunList() {
-	if !m.syncRunTarget() || len(m.filteredRunList()) == 0 {
+	if !m.syncRunTarget() || len(m.runsForTarget(m.runTarget)) == 0 {
 		return
 	}
+	m.normalizeRunStatusFilter()
 	m.runListCursor = 0
 	runs := m.filteredRunList()
 	for index := range runs {
@@ -339,16 +347,75 @@ func (m *Model) openRunList() {
 
 func (m *Model) filteredRunList() []app.RunSummary {
 	runs := m.runsForTarget(m.runTarget)
-	if m.runStatusFilter == "" || m.runStatusFilter == "all" {
+	if m.runStatusFilter == "" || m.runStatusFilter == runFilterAll {
 		return runs
 	}
 	filtered := make([]app.RunSummary, 0)
 	for _, run := range runs {
-		if m.runStatusFilter == "failed" && runFailed(run) || strings.EqualFold(run.Status, m.runStatusFilter) {
+		if m.runStatusFilter == runFilterFailed && runFailed(run) || strings.EqualFold(run.Status, m.runStatusFilter) {
 			filtered = append(filtered, run)
 		}
 	}
 	return filtered
+}
+
+const (
+	runFilterAll    = "all"
+	runFilterFailed = "failed"
+)
+
+// runStatusFilters lists only the filters that actually divide the focused
+// target's history. Two things made the old fixed cycle useless. Services and
+// actions use disjoint status vocabularies — a service that exits cleanly is
+// "stopped" and never "succeeded" — so half the cycle was dead on whichever
+// kind was focused. And a filter every run matches narrows nothing: on three
+// successful actions, "succeeded" showed the same three rows as "all".
+// A filter earns its place only by selecting a proper, non-empty subset.
+func (m *Model) runStatusFilters() []string {
+	runs := m.runsForTarget(m.runTarget)
+	candidates := make([]string, 0, 5)
+	if slices.ContainsFunc(runs, runFailed) {
+		candidates = append(candidates, runFilterFailed)
+	}
+	statuses := make([]string, 0, 4)
+	seen := map[string]bool{}
+	for _, run := range runs {
+		status := strings.ToLower(strings.TrimSpace(run.Status))
+		if status == "" || status == runFilterFailed || seen[status] {
+			continue
+		}
+		seen[status] = true
+		statuses = append(statuses, status)
+	}
+	sort.Strings(statuses)
+	candidates = append(candidates, statuses...)
+
+	filters := []string{runFilterAll}
+	for _, candidate := range candidates {
+		if matched := m.runsMatchingFilter(runs, candidate); matched > 0 && matched < len(runs) {
+			filters = append(filters, candidate)
+		}
+	}
+	return filters
+}
+
+func (m *Model) runsMatchingFilter(runs []app.RunSummary, filter string) int {
+	matched := 0
+	for _, run := range runs {
+		if filter == runFilterFailed && runFailed(run) || strings.EqualFold(run.Status, filter) {
+			matched++
+		}
+	}
+	return matched
+}
+
+// normalizeRunStatusFilter drops a filter that the current history can no
+// longer offer, so reopening the list after the runs changed never lands on a
+// filter whose only possible result is "No runs match this filter".
+func (m *Model) normalizeRunStatusFilter() {
+	if !slices.Contains(m.runStatusFilters(), m.runStatusFilter) {
+		m.runStatusFilter = runFilterAll
+	}
 }
 
 func (m *Model) handleRunListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -359,13 +426,8 @@ func (m *Model) handleRunListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, m.keys.Down):
 		m.runListCursor = min(max(0, len(runs)-1), m.runListCursor+1)
 	case msg.String() == "tab":
-		filters := []string{"all", "running", "succeeded", "failed", "stopped"}
-		index := 0
-		for i := range filters {
-			if filters[i] == m.runStatusFilter {
-				index = i
-			}
-		}
+		filters := m.runStatusFilters()
+		index := max(0, slices.Index(filters, m.runStatusFilter))
 		m.runStatusFilter = filters[(index+1)%len(filters)]
 		m.runListCursor = 0
 	case msg.String() == "enter":
@@ -393,17 +455,12 @@ func (m *Model) handleRunListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m *Model) renderRunListView() string {
 	runs := m.filteredRunList()
-	filter := m.runStatusFilter
-	if filter == "" {
-		filter = "all"
-	}
-	lines := []string{ModalTitleStyle.Render(" Run history "), "", ContextBarStyle.Render("  Filter: " + filter + " · Tab changes filter"), ""}
-	for _, boundary := range m.app.RunRetention() {
-		if boundary.Target == m.runTarget {
-			lines = append(lines, ContextBarStyle.Render(fmt.Sprintf("  Oldest retained #%d · budgets %d runs / %d entries / %d bytes · evicted %d summaries",
-				boundary.OldestRetainedRun, boundary.MaxRuns, boundary.MaxEntries, boundary.MaxBytes, boundary.EvictedRuns)), "")
-			break
-		}
+	lines := []string{ModalTitleStyle.Render(" Run history · " + runTargetLabel(m.runTarget)), ""}
+	// Retention is an exception report, not a permanent header. While nothing
+	// has been lost, the budgets only told the user that nothing had been lost,
+	// in ninety characters. They appear when they explain a gap.
+	if notice := m.runRetentionNotice(); notice != "" {
+		lines = append(lines, ContextBarStyle.Render("  "+notice), "")
 	}
 	if len(runs) == 0 {
 		lines = append(lines, "  No runs match this filter")
@@ -411,7 +468,13 @@ func (m *Model) renderRunListView() string {
 		lines = append(lines, DetailLabelStyle.Render(fmt.Sprintf("  %-5s %-10s  %-8s  %8s  %-8s  %-18s  %-18s  %s",
 			"RUN", "STATUS", "START", "DURATION", "EXIT", "REASON", "INITIATOR", "OUTPUT")))
 	}
-	for index, run := range runs {
+	// A target retains up to RunRetention().MaxRuns summaries, far more than any
+	// terminal can show. Without a window the modal grew past m.height, the
+	// overlay clipped the bottom, and the cursor and the shortcut footer both
+	// vanished — the list looked frozen while the selection kept moving.
+	start, visible, windowed := runListWindow(len(runs), m.runListCursor, m.runListCapacity(len(lines)))
+	for index := start; index < start+visible; index++ {
+		run := runs[index]
 		exit := "-"
 		if run.ExitCode != nil {
 			exit = fmt.Sprint(*run.ExitCode)
@@ -431,8 +494,93 @@ func (m *Model) renderRunListView() string {
 		}
 		lines = append(lines, line)
 	}
-	lines = append(lines, "", renderModalShortcuts("  [↑/↓] Select  [Enter] Open run  [d] Delete  [Tab] Filter  [Esc] Close", lipgloss.NewStyle().Foreground(ColorDim)))
+	if windowed {
+		lines = append(lines, "  "+ContextBarStyle.Render(fmt.Sprintf("%d/%d", m.runListCursor+1, len(runs))))
+	}
+	// The filter belongs with the key that changes it. As its own header line it
+	// spent a row restating "all" on the common path where nothing is filtered.
+	shortcuts := "  [↑/↓] Select  [Enter] Open run  [d] Delete"
+	if filters := m.runStatusFilters(); len(filters) > 1 {
+		filter := m.runStatusFilter
+		if filter == "" {
+			filter = runFilterAll
+		}
+		shortcuts += "  [Tab] " + filter
+	}
+	lines = append(lines, "", renderModalShortcuts(shortcuts+"  [Esc] Close", lipgloss.NewStyle().Foreground(ColorDim)))
 	return m.placeOverlay(renderFlushModal(strings.Join(lines, "\n")))
+}
+
+// runRetentionNotice describes what this target has already lost, and returns
+// empty while it has lost nothing. The budgets are named only alongside a real
+// gap, where they are the explanation for it rather than trivia.
+func (m *Model) runRetentionNotice() string {
+	var boundary app.RunRetentionBoundary
+	for _, candidate := range m.app.RunRetention() {
+		if candidate.Target == m.runTarget {
+			boundary = candidate
+			break
+		}
+	}
+	parts := make([]string, 0, 2)
+	if boundary.EvictedRuns > 0 {
+		parts = append(parts, fmt.Sprintf("%d older %s dropped · oldest kept #%d of %d",
+			boundary.EvictedRuns, pluralRuns(boundary.EvictedRuns), boundary.OldestRetainedRun, boundary.MaxRuns))
+	}
+	var missingLines uint64
+	incomplete := 0
+	for _, run := range m.runsForTarget(m.runTarget) {
+		if run.Output.MissingLines > 0 {
+			incomplete++
+			missingLines += run.Output.MissingLines
+		}
+	}
+	if incomplete > 0 {
+		parts = append(parts, fmt.Sprintf("%d %s missing output · %d lines lost to the %s buffer",
+			incomplete, pluralRuns(uint64(incomplete)), missingLines, formatBytes(boundary.MaxBytes)))
+	}
+	return strings.Join(parts, "   ")
+}
+
+func pluralRuns(count uint64) string {
+	if count == 1 {
+		return "run"
+	}
+	return "runs"
+}
+
+// formatBytes keeps a budget readable: "4 MB" is a size, "4194304 bytes" is a
+// number the reader has to divide before it means anything.
+func formatBytes(bytes uint64) string {
+	switch {
+	case bytes >= 1<<30:
+		return fmt.Sprintf("%.3g GB", float64(bytes)/(1<<30))
+	case bytes >= 1<<20:
+		return fmt.Sprintf("%.3g MB", float64(bytes)/(1<<20))
+	case bytes >= 1<<10:
+		return fmt.Sprintf("%.3g KB", float64(bytes)/(1<<10))
+	}
+	return fmt.Sprintf("%d B", bytes)
+}
+
+// runListCapacity is the number of run rows the modal can show once the header
+// rows already collected, the trailing blank and shortcut rows, and the modal's
+// own vertical padding are subtracted from the terminal height.
+func (m *Model) runListCapacity(headerLines int) int {
+	const trailingRows = 2 // the blank separator and the shortcut footer
+	return max(1, m.height-modalVerticalChrome-headerLines-trailingRows)
+}
+
+// runListWindow centres a capacity-sized window on the cursor and reports
+// whether the list had to be windowed at all. When it did, one row is given
+// back to the position indicator so the footer keeps its place.
+func runListWindow(total, cursor, capacity int) (start, visible int, windowed bool) {
+	if total <= capacity {
+		return 0, total, false
+	}
+	visible = max(1, capacity-1) // the position indicator row
+	start = max(0, min(cursor-visible/2, total-visible))
+	return start, visible, true
 }
 
 func (m *Model) renderConfirmDeleteRunView() string {

--- a/internal/ui/run_view_test.go
+++ b/internal/ui/run_view_test.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/kranz-org/kranz/internal/app"
 	"github.com/kranz-org/kranz/internal/config"
@@ -33,7 +35,7 @@ func TestSingleRunViewerNavigatesStableServiceRuns(t *testing.T) {
 	if !strings.Contains(plain, "first failed output") || strings.Contains(plain, "second successful output") {
 		t.Fatalf("single run leaked another run:\n%s", plain)
 	}
-	if !strings.Contains(plain, "HISTORY · RUN #1 · 1 NEWER · [L] LATEST") {
+	if !strings.Contains(plain, "RUN #1/2 · [L] LATEST") {
 		t.Fatalf("historical run has no newer-runs indicator:\n%s", plain)
 	}
 }
@@ -45,30 +47,30 @@ func TestRunLabelsSeparateAutoUpdatingLatestAndHistoryViews(t *testing.T) {
 	finishTestServiceRun(t, model, "api", 0, "run one")
 	finishTestServiceRun(t, model, "api", 0, "run two")
 	model.refreshServices()
-	if got := model.runViewLabel(); got != "ALL RUNS · INCLUDES NEW" {
+	if got := model.runViewLabel(); got != "ALL RUNS" {
 		t.Fatalf("combined label = %q", got)
 	}
 	model.selectLatestRun()
-	if got := model.runViewLabel(); got != "LATEST RUN #2" {
+	if got := model.runViewLabel(); got != "RUN #2/2" {
 		t.Fatalf("latest label = %q", got)
 	}
 
 	finishTestServiceRun(t, model, "api", 0, "run three")
 	model.refreshServices()
-	if got := model.runViewLabel(); got != "LATEST RUN #3" || model.selectedRun != 3 {
+	if got := model.runViewLabel(); got != "RUN #3/3" || model.selectedRun != 3 {
 		t.Fatalf("latest view did not follow the new run: label=%q run=%d", got, model.selectedRun)
 	}
 	model.moveRun(-1, false)
-	if got := model.runViewLabel(); got != "HISTORY · RUN #2 · 1 NEWER · [L] LATEST" {
+	if got := model.runViewLabel(); got != "RUN #2/3 · [L] LATEST" {
 		t.Fatalf("explicit history label = %q", got)
 	}
 	finishTestServiceRun(t, model, "api", 0, "run four")
 	model.refreshServices()
-	if got := model.runViewLabel(); got != "HISTORY · RUN #2 · 2 NEWER · [L] LATEST" || model.selectedRun != 2 {
+	if got := model.runViewLabel(); got != "RUN #2/4 · [L] LATEST" || model.selectedRun != 2 {
 		t.Fatalf("history view followed a new run: label=%q run=%d", got, model.selectedRun)
 	}
 	model.selectLatestRun()
-	if got := model.runViewLabel(); got != "LATEST RUN #4" {
+	if got := model.runViewLabel(); got != "RUN #4/4" {
 		t.Fatalf("returned latest label = %q", got)
 	}
 }
@@ -122,7 +124,7 @@ func TestRunListIncludesRetentionAndProvenanceFields(t *testing.T) {
 	model.refreshServices()
 	model.openRunList()
 	plain := ansi.Strip(model.renderRunListView())
-	for _, expected := range []string{"RUN", "STATUS", "START", "DURATION", "EXIT", "REASON", "INITIATOR", "OUTPUT", "#1", "7", "runtime", "complete", "Filter: all"} {
+	for _, expected := range []string{"RUN", "STATUS", "START", "DURATION", "EXIT", "REASON", "INITIATOR", "OUTPUT", "#1", "7", "runtime", "complete", "Run history · api"} {
 		if !strings.Contains(plain, expected) {
 			t.Fatalf("run list missing %q:\n%s", expected, plain)
 		}
@@ -138,7 +140,21 @@ func TestRunListFiltersAndSelectsByKeyboardAndMouse(t *testing.T) {
 	model.refreshServices()
 	model.openRunList()
 
-	for range 3 { // all -> running -> succeeded -> failed
+	// Tab must only ever offer a filter this target's history can satisfy.
+	// A service that exits cleanly is "stopped", never "succeeded", so a fixed
+	// cycle would land on filters whose only result is "No runs match".
+	filters := model.runStatusFilters()
+	for range len(filters) {
+		_, _ = model.handleRunListKeys(tea.KeyMsg{Type: tea.KeyTab})
+		if len(model.filteredRunList()) == 0 {
+			t.Fatalf("filter %q offered by Tab matches no run in %v", model.runStatusFilter, filters)
+		}
+	}
+	if model.runStatusFilter != runFilterAll {
+		t.Fatalf("a full Tab cycle ended on %q, want %q", model.runStatusFilter, runFilterAll)
+	}
+
+	for model.runStatusFilter != runFilterFailed {
 		_, _ = model.handleRunListKeys(tea.KeyMsg{Type: tea.KeyTab})
 	}
 	filtered := model.filteredRunList()
@@ -306,7 +322,7 @@ func TestActionOutputDefaultsToSingleLatestRun(t *testing.T) {
 	}
 	model.focusedAction = &id
 	plain := ansi.Strip(model.renderActionLogPanel(100, 12))
-	if model.runMode != runViewSingle || model.selectedRun != 1 || !strings.Contains(plain, "succeeded · LATEST RUN #1") || !strings.Contains(plain, "action-output") {
+	if model.runMode != runViewSingle || model.selectedRun != 1 || !strings.Contains(plain, "check · RUN #1/1") || !strings.Contains(plain, "action-output") {
 		t.Fatalf("action did not open latest single run: mode=%d run=%d\n%s", model.runMode, model.selectedRun, plain)
 	}
 }
@@ -352,4 +368,171 @@ func finishTestServiceRun(t *testing.T, model *Model, name string, exitCode int,
 	state.ExitCode = exitCode
 	model.app.SetServiceStateForTest(name, state)
 	model.app.SetServiceStatusForTest(name, config.StatusStopped)
+}
+
+func TestRunListWindowsLongHistoryIntoTheTerminal(t *testing.T) {
+	model := newTestModel()
+	defer model.Shutdown()
+	model.width, model.height, model.ready = 140, 24, true
+	for range 40 {
+		finishTestServiceRun(t, model, "api", 0, "output")
+	}
+	model.refreshServices()
+	model.openRunList()
+
+	// The modal must fit the terminal on its own. placeOverlay clips instead of
+	// scrolling, so an unwindowed list silently loses its footer and cursor.
+	rendered := ansi.Strip(model.renderRunListView())
+	if height := len(strings.Split(rendered, "\n")); height > model.height {
+		t.Fatalf("run list rendered %d rows into a %d-row terminal", height, model.height)
+	}
+	for _, expected := range []string{"[Enter] Open run", "1/40"} {
+		if !strings.Contains(rendered, expected) {
+			t.Fatalf("windowed run list is missing %q:\n%s", expected, rendered)
+		}
+	}
+
+	// The selected run has to stay visible however far down the history it is.
+	for range 39 {
+		_, _ = model.handleRunListKeys(tea.KeyMsg{Type: tea.KeyDown})
+	}
+	rendered = ansi.Strip(model.renderRunListView())
+	if !strings.Contains(rendered, "#40") || !strings.Contains(rendered, "40/40") {
+		t.Fatalf("cursor scrolled out of the window:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "[Enter] Open run") {
+		t.Fatalf("windowed run list lost its footer:\n%s", rendered)
+	}
+}
+
+func TestRunListClickSelectsTheClickedRunNotItsPrefix(t *testing.T) {
+	model := newTestModel()
+	defer model.Shutdown()
+	model.width, model.height, model.ready = 140, 40, true
+	for range 12 {
+		finishTestServiceRun(t, model, "api", 0, "output")
+	}
+	model.refreshServices()
+	model.openRunList()
+
+	// "#1" is a prefix of "#12": the click must land on the row it points at.
+	clickRenderedText(t, model, "#12")
+	if model.selectedRun != 12 {
+		t.Fatalf("clicking #12 selected run %d", model.selectedRun)
+	}
+}
+
+func TestRunListOffersOnlyFiltersThatDivideTheHistory(t *testing.T) {
+	model := newTestModel()
+	defer model.Shutdown()
+	model.width, model.height, model.ready = 140, 30, true
+
+	// A filter every run matches narrows nothing. With three clean runs the
+	// only status is "stopped", so "all" is the whole cycle and Tab is not
+	// offered at all.
+	for range 3 {
+		finishTestServiceRun(t, model, "api", 0, "output")
+	}
+	model.refreshServices()
+	model.openRunList()
+	if got := model.runStatusFilters(); len(got) != 1 || got[0] != runFilterAll {
+		t.Fatalf("uniform history offers %v, want only %q", got, runFilterAll)
+	}
+	if strings.Contains(ansi.Strip(model.renderRunListView()), "[Tab]") {
+		t.Fatalf("a single-filter list still advertises Tab:\n%s", ansi.Strip(model.renderRunListView()))
+	}
+
+	// One failure makes "failed" a real division of the list, and every offered
+	// filter must select a proper, non-empty subset.
+	finishTestServiceRun(t, model, "api", 3, "boom")
+	model.refreshServices()
+	filters := model.runStatusFilters()
+	if !slices.Contains(filters, runFilterFailed) {
+		t.Fatalf("a mixed history does not offer %q: %v", runFilterFailed, filters)
+	}
+	total := len(model.runsForTarget(model.runTarget))
+	for _, filter := range filters[1:] {
+		model.runStatusFilter = filter
+		if matched := len(model.filteredRunList()); matched == 0 || matched == total {
+			t.Fatalf("filter %q selects %d of %d runs and divides nothing", filter, matched, total)
+		}
+	}
+}
+
+func TestRunListShowsRetentionOnlyWhereOutputWasActuallyLost(t *testing.T) {
+	model := newTestModel()
+	defer model.Shutdown()
+	model.width, model.height, model.ready = 140, 30, true
+	finishTestServiceRun(t, model, "api", 0, "output")
+	model.refreshServices()
+	model.openRunList()
+
+	// Budgets that explain nothing are noise. While the history is intact the
+	// modal says nothing about retention.
+	plain := ansi.Strip(model.renderRunListView())
+	for _, unwanted := range []string{"budgets", "dropped", "missing output", "evicted"} {
+		if strings.Contains(plain, unwanted) {
+			t.Fatalf("intact history reports retention %q:\n%s", unwanted, plain)
+		}
+	}
+	if notice := model.runRetentionNotice(); notice != "" {
+		t.Fatalf("intact history has retention notice %q", notice)
+	}
+
+	// Clearing the buffer keeps the summary and drops its output, which is
+	// exactly the gap the budgets are there to explain.
+	model.app.ClearLogs("api")
+	model.refreshServices()
+	if notice := model.runRetentionNotice(); !strings.Contains(notice, "missing output") {
+		t.Fatalf("lost output is not reported: %q", notice)
+	}
+	if plain = ansi.Strip(model.renderRunListView()); !strings.Contains(plain, "MB") {
+		t.Fatalf("retention notice does not name a readable budget:\n%s", plain)
+	}
+}
+
+func TestActionRunLabelHoldsItsColumnWhateverTheOutcome(t *testing.T) {
+	// Two actions with the same name, so the title prefix is identical in width
+	// and only the trailing outcome differs. The status word exists only while
+	// a run is live or after it failed; ahead of the run label it shifted the
+	// label sideways on every invocation, which is the jump under test.
+	good := config.ActionID{OwnerKind: config.ActionOwnerGroup, Owner: "ops", Name: "check"}
+	bad := config.ActionID{OwnerKind: config.ActionOwnerGroup, Owner: "qa", Name: "check"}
+	model := NewModel(&config.Config{Project: "actions", ActionGroups: map[string]config.ActionGroup{
+		"ops": {Actions: map[string]config.Action{"check": {Command: "true"}}},
+		"qa":  {Actions: map[string]config.Action{"check": {Command: "exit 3"}}},
+	}}, "test")
+	defer model.Shutdown()
+	model.width, model.height, model.ready = 120, 20, true
+
+	runColumn := func(id config.ActionID) (int, string) {
+		t.Helper()
+		if _, err := model.app.RunAction(context.Background(), id); err != nil && id == good {
+			t.Fatal(err)
+		}
+		model.focusedAction = &id
+		model.syncRunTarget()
+		title := ansi.Strip(model.renderActionLogPanel(110, 8))
+		index := strings.Index(title, "RUN #")
+		if index < 0 {
+			t.Fatalf("title has no run label:\n%s", title)
+		}
+		// Terminal cells, not bytes: the ✓ and × indicators differ in byte
+		// length while occupying the same single column.
+		return lipgloss.Width(title[:index]), title
+	}
+
+	succeeded, succeededTitle := runColumn(good)
+	failed, failedTitle := runColumn(bad)
+	if succeeded != failed {
+		t.Fatalf("run label sits at column %d when the run succeeded and %d when it failed:\n%s\n%s",
+			succeeded, failed, succeededTitle, failedTitle)
+	}
+	// The word still has to be reachable, just behind the anchor.
+	if !strings.Contains(strings.SplitN(failedTitle, "\n", 2)[0], "FAILED") {
+		t.Fatalf("a failed run does not name its outcome:\n%s", failedTitle)
+	}
+	if strings.Contains(strings.SplitN(succeededTitle, "\n", 2)[0], "succeeded") {
+		t.Fatalf("a successful run repeats what the indicator already says:\n%s", succeededTitle)
+	}
 }

--- a/internal/ui/view_logs.go
+++ b/internal/ui/view_logs.go
@@ -61,12 +61,16 @@ func (m *Model) renderActionLogPanel(width, height int) string {
 	if !exists {
 		return renderTitledPanel(m.panelStyle(panelLogs), m.panelTitleStyle(panelLogs), contentWidth, contentHeight, "[3] ACTION OUTPUT", []string{"", "Select an action"})
 	}
-	selectedRun, state, lines := m.actionLogContent(id, action, state)
-	name := actionRunName(id.Name, selectedRun)
-	title := "[3] ACTION OUTPUT" + ContextBarStyle.Render(" │ ") + actionStatusIndicator(state.Status) + " " + ServiceNameStyle.Render(name) + ContextBarStyle.Render(" · "+state.Status.String())
+	_, state, lines := m.actionLogContent(id, action, state)
+	// The run label already names the run, so a "stats#3" suffix restated it —
+	// and in combined mode it named one run while the panel showed all of them.
+	// The status word trails the label rather than preceding it: an action's
+	// word appears for exactly as long as the run lasts, so in front of the
+	// label it shifted the run position sideways on every single invocation.
+	title := "[3] ACTION OUTPUT" + ContextBarStyle.Render(" │ ") + actionStatusIndicator(state.Status) + " " + ServiceNameStyle.Render(id.Name)
 	title += ContextBarStyle.Render(" · ") + RunningBadgeStyle.Render(m.runViewLabel())
-	if state.Status == app.ActionRunning {
-		title += StartingBadgeStyle.Render(" RUNNING")
+	if word := actionStatusWord(state.Status); word != "" {
+		title += ContextBarStyle.Render(" · ") + word
 	}
 	if len(lines) == 0 {
 		return renderTitledPanel(m.panelStyle(panelLogs), m.panelTitleStyle(panelLogs), contentWidth, contentHeight, title, []string{"", ContextBarStyle.Render("Press s to run this action")})
@@ -226,6 +230,10 @@ func (m *Model) renderLogPanelMode(svc *app.ServiceSnapshot, width, height int, 
 	}
 
 	visualState := m.serviceVisualState(svc)
+	runLabel := m.pinnedRunViewLabel()
+	if !pinned {
+		runLabel = m.runViewLabel()
+	}
 	title := titlePrefix + ContextBarStyle.Render(" │ ") + serviceStatusIndicator(visualState) + " " + ServiceNameStyle.Render(svc.Name) +
 		ContextBarStyle.Render(" · "+strings.ToLower(serviceStatusLabel(svc.State.Status, visualState)))
 	if !followMode {
@@ -240,10 +248,6 @@ func (m *Model) renderLogPanelMode(svc *app.ServiceSnapshot, width, height int, 
 	}
 	if m.showLogTime {
 		title += " " + RunningBadgeStyle.Render("TIME")
-	}
-	runLabel := m.pinnedRunViewLabel()
-	if !pinned {
-		runLabel = m.runViewLabel()
 	}
 
 	sourceEntries := m.app.Logs(svc.Name)
@@ -268,6 +272,10 @@ func (m *Model) renderLogPanelMode(svc *app.ServiceSnapshot, width, height int, 
 		}
 		title += SearchInputStyle.Render(fmt.Sprintf("  %s /%s/ · %d", modeLabel, searcher.Pattern(), len(searchMatches)))
 	}
+	// The run label keeps the trailing slot it has always had. The title
+	// truncates from the right, and at a narrow width the badges ahead of it —
+	// BROWSING, PAUSED, and the search pattern — are what explain a viewport
+	// that has stopped moving, so they are the ones that must survive.
 	title += ContextBarStyle.Render(" · ") + RunningBadgeStyle.Render(runLabel)
 	matchSet := make(map[int]bool, len(searchMatches))
 	for _, idx := range searchMatches {

--- a/internal/ui/view_modals.go
+++ b/internal/ui/view_modals.go
@@ -641,6 +641,10 @@ const (
 	// Gutter a flush modal keeps on the right, matching the indent its content
 	// carries on the left.
 	modalSideMargin = 2
+	// Rows ModalStyle's vertical padding adds above and below modal content.
+	// A modal that windows its own body has to subtract these from m.height,
+	// because placeOverlay clips whatever does not fit rather than scrolling.
+	modalVerticalChrome = 4
 )
 
 // renderThemeControlRows lays the picker's key hints out as two columns. The

--- a/internal/ui/view_services.go
+++ b/internal/ui/view_services.go
@@ -419,3 +419,19 @@ func containsTagStr(tags []string, tag string) bool {
 	}
 	return false
 }
+
+// actionStatusWord spells an outcome only where the indicator glyph cannot.
+// "✓" and "succeeded" are the same statement, and a running action already
+// carries its own badge, but "×" covers both failed and timed_out, so those
+// still need the word to stay distinguishable.
+func actionStatusWord(status app.ActionStatus) string {
+	switch status {
+	case app.ActionSucceeded, app.ActionReady:
+		return ""
+	case app.ActionRunning:
+		return StartingBadgeStyle.Render("RUNNING")
+	case app.ActionFailed, app.ActionTimedOut, app.ActionCancelled:
+		return FailedBadgeStyle.Render(strings.ToUpper(status.String()))
+	}
+	return ContextBarStyle.Render(status.String())
+}


### PR DESCRIPTION
## Summary

- finalize run-history UX and retained-run error handling
- publish the 0.10.0 changelog section dated 2026-08-28
- update README and release examples for numbered run history

## Verification

- `make verify`
- `make lint`
- `make release-check`
- docs link check and production build through the active Kranz runtime
- `make snapshot RELEASE_VERSION=0.10.0`
- local snapshot binary reports 0.10.0

Package installation verification was unavailable locally because Docker is not installed; GoReleaser produced all expected archives and Linux packages.