### PR TITLE
docs: prepare 0.11.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-08-29
+
+### Added
+
+- `KRANZ_PROJECT`, `KRANZ_DIRECTORY`, and `KRANZ_CONFIG` provide environment
+  defaults for the global `-p`, `-C`, and repeatable `-f` coordinates. Explicit
+  command-line options always win, including replacement of inherited
+  configuration layers.
+- An installable English `kranz-services` agent skill teaches coding agents to
+  discover and reuse the developer's live runtime, prefer MCP reads, route
+  declared actions through Kranz, and keep lifecycle mutations explicit.
+
+### Changed
+
+- The colored site hero now reaches a running MoonFlight graph in a few
+  seconds, runs `catalog-api/reindex` twice, and browses the two retained
+  results instead of pinning duplicate copies of one service log. The actions
+  guide includes its own focused numbered-run recording.
+
 ## [0.11.0] - 2026-08-28
 
 ### Changed
@@ -599,7 +618,8 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 - Explicit global-user and project-config save destinations in the live theme picker.
 - Native compatibility for common Process Compose configurations.
 
-[Unreleased]: https://github.com/kranz-org/kranz/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/kranz-org/kranz/compare/v0.11.1...HEAD
+[0.11.1]: https://github.com/kranz-org/kranz/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/kranz-org/kranz/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/kranz-org/kranz/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/kranz-org/kranz/compare/v0.8.2...v0.9.0

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -42,7 +42,7 @@ workflow; generated binaries are never checked into the repository.
    make verify
    make lint
    make release-check
-   make snapshot RELEASE_VERSION=0.11.0 # use the release being prepared
+   make snapshot RELEASE_VERSION=0.11.1 # use the release being prepared
    ./dist/kranz_darwin_arm64_v8.0/kranz --version # choose the local platform build
    make packages-verify
    PACKAGE_ARCH=arm64 make packages-verify
@@ -57,9 +57,9 @@ workflow; generated binaries are never checked into the repository.
 4. Create an annotated tag without pushing it automatically:
 
    ```bash
-   make tag RELEASE_VERSION=0.11.0 # use the release being published
-   git show v0.11.0
-   git push origin v0.11.0
+   make tag RELEASE_VERSION=0.11.1 # use the release being published
+   git show v0.11.1
+   git push origin v0.11.1
    ```
 
 ## Verify the published release
@@ -71,8 +71,8 @@ replaces generated commit notes with the matching version section from
 the release before announcing it:
 
 ```bash
-gh release view v0.11.0
-gh release download v0.11.0 \
+gh release view v0.11.1
+gh release download v0.11.1 \
   --pattern 'checksums.txt' \
   --pattern '*.tar.gz' \
   --pattern '*.deb' \


### PR DESCRIPTION
## Summary
- publish the 0.11.1 changelog section and comparison link
- update release commands to the exact patch version

## Release verification
- make verify
- make lint
- make release-check
- make snapshot RELEASE_VERSION=0.11.1
- snapshot binary reports 0.11.1
- docs/check-links and docs/build through the live Kranz runtime

Linux package installation verification is unavailable locally because neither Docker nor Podman is installed; the release workflow builds and verifies the packages in CI.