### PR TITLE
Repair and publish 0.12.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,15 @@ jobs:
         with:
           platforms: arm64
 
+      - name: Set exact release version
+        run: echo "SNAPSHOT_VERSION=${GITHUB_REF_NAME#v}" >> "${GITHUB_ENV}"
+
       - name: Build exact-version release candidate
-        run: make snapshot RELEASE_VERSION="${GITHUB_REF_NAME#v}"
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        with:
+          distribution: goreleaser
+          version: v2.17.0
+          args: release --snapshot --clean
 
       - name: Verify Linux packages
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-09-02
+
+This is the first published 0.12 release. The immutable `v0.12.0` tag stopped
+in its pre-publish workflow and produced no GitHub release or downloadable
+artifacts.
+
+### Added
+
+- The TUI quit confirmation can stop the runtime, detach while keeping it
+  running, or stay in the TUI, with the same choices for keyboard and mouse.
+
+### Changed
+
+- TUI, CLI, foreground `up`, and MCP now connect to an independently owned
+  per-project supervisor, so disconnecting a client does not stop services.
+- Idle dashboards cache rendered state, suppress redundant frames, bound mouse
+  refreshes, maintain log retention incrementally, and back off failed port
+  discovery.
+
+### Fixed
+
+- The release workflow now builds its pre-publish package snapshot through the
+  pinned GoReleaser action, avoiding a newer Go toolchain requirement than the
+  project declares while retaining amd64 and arm64 installation checks.
+
 ## [0.12.0] - 2026-09-02
 
 ### Added
@@ -654,7 +679,8 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 - Explicit global-user and project-config save destinations in the live theme picker.
 - Native compatibility for common Process Compose configurations.
 
-[Unreleased]: https://github.com/kranz-org/kranz/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/kranz-org/kranz/compare/v0.12.1...HEAD
+[0.12.1]: https://github.com/kranz-org/kranz/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/kranz-org/kranz/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/kranz-org/kranz/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/kranz-org/kranz/compare/v0.10.0...v0.11.0

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ terminal tabs, alongside Docker Compose when containers remain the right home
 for infrastructure.
 
 <p align="center">
-  <img src="docs/assets/kranz-demo.gif" alt="Kranz v0.12.0 terminal interface starting a project and browsing retained action runs">
+  <img src="docs/assets/kranz-demo.gif" alt="Kranz v0.12.1 terminal interface starting a project and browsing retained action runs">
 </p>
 
 ## TUI, CLI, and MCP

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -42,7 +42,7 @@ workflow; generated binaries are never checked into the repository.
    make verify
    make lint
    make release-check
-   make snapshot RELEASE_VERSION=0.12.0 # use the release being prepared
+   make snapshot RELEASE_VERSION=0.12.1 # use the release being prepared
    ./dist/kranz_darwin_arm64_v8.0/kranz --version # choose the local platform build
    make packages-verify
    PACKAGE_ARCH=arm64 make packages-verify
@@ -59,9 +59,9 @@ workflow; generated binaries are never checked into the repository.
 4. Create an annotated tag without pushing it automatically:
 
    ```bash
-   make tag RELEASE_VERSION=0.12.0 # use the release being published
-   git show v0.12.0
-   git push origin v0.12.0
+   make tag RELEASE_VERSION=0.12.1 # use the release being published
+   git show v0.12.1
+   git push origin v0.12.1
    ```
 
 ## Verify the published release
@@ -73,8 +73,8 @@ replaces generated commit notes with the matching version section from
 the release before announcing it:
 
 ```bash
-gh release view v0.12.0
-gh release download v0.12.0 \
+gh release view v0.12.1
+gh release download v0.12.1 \
   --pattern 'checksums.txt' \
   --pattern '*.tar.gz' \
   --pattern '*.deb' \

--- a/docs/assets/tapes/actions.tape
+++ b/docs/assets/tapes/actions.tape
@@ -1,6 +1,6 @@
 # Regenerate with: vhs docs/assets/tapes/actions.tape
 # Run from the repository root with a release-stamped binary in ./bin:
-#   make build VERSION=v0.12.0
+#   make build VERSION=v0.12.1
 Output docs/assets/actions.gif
 
 Set Shell "bash"

--- a/docs/assets/tapes/kranz-demo.tape
+++ b/docs/assets/tapes/kranz-demo.tape
@@ -1,6 +1,6 @@
 # The site hero, recorded from the MoonFlight showcase project.
 # Regenerate from the repository root with the release binary in ./bin:
-#   make build VERSION=v0.12.0 && vhs docs/assets/tapes/kranz-demo.tape
+#   make build VERSION=v0.12.1 && vhs docs/assets/tapes/kranz-demo.tape
 Output docs/assets/kranz-demo.gif
 
 Set Shell "bash"

--- a/docs/assets/tapes/mcp-shared-runtime.tape
+++ b/docs/assets/tapes/mcp-shared-runtime.tape
@@ -2,7 +2,7 @@
 # neutral temporary directory. Setup, authentication, commands, cleanup, and
 # the user's home directory stay hidden.
 # Regenerate from the repository root:
-#   make build VERSION=v0.12.0
+#   make build VERSION=v0.12.1
 #   vhs docs/assets/tapes/mcp-shared-runtime.tape
 Output docs/assets/mcp-shared-runtime.gif
 
@@ -17,7 +17,7 @@ Set Framerate 12
 Hide
 Type "DEMO_DIR=/private/tmp/kranz-mcp-demo; DEMO_CODEX_HOME=/private/tmp/kranz-codex-demo; DEMO_SESSION=kranz-mcp-demo"
 Enter
-Type "make build VERSION=v0.12.0"
+Type "make build VERSION=v0.12.1"
 Enter
 Type `mkdir -p "$DEMO_DIR" "$DEMO_CODEX_HOME"`
 Enter

--- a/docs/examples/mcp-shared-runtime.md
+++ b/docs/examples/mcp-shared-runtime.md
@@ -62,7 +62,7 @@ The recording is built from the same live client and project, with no fixture
 JSON or personal environment data:
 
 ```bash
-make build VERSION=v0.12.0
+make build VERSION=v0.12.1
 vhs docs/assets/tapes/mcp-shared-runtime.tape
 ```
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -24,7 +24,7 @@ go install github.com/kranz-org/kranz/cmd/kranz@latest
 ## Debian and Ubuntu
 
 ```bash
-VERSION=0.12.0
+VERSION=0.12.1
 ARCH=amd64  # use arm64 on an ARM machine
 curl -fLO "https://github.com/kranz-org/kranz/releases/download/v${VERSION}/kranz_${VERSION}_linux_${ARCH}.deb"
 sudo apt install "./kranz_${VERSION}_linux_${ARCH}.deb"
@@ -40,7 +40,7 @@ Remove it with `sudo apt remove kranz`.
 ## Fedora, RHEL, and Rocky
 
 ```bash
-VERSION=0.12.0
+VERSION=0.12.1
 ARCH=amd64  # use arm64 on an ARM machine
 sudo dnf install "https://github.com/kranz-org/kranz/releases/download/v${VERSION}/kranz_${VERSION}_linux_${ARCH}.rpm"
 kranz --version

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ features:
 
 <div class="demo-frame demo-frame--hero">
 
-![Kranz v0.12.0 starting a project, running an action twice, and browsing its retained runs](./assets/kranz-demo.gif)
+![Kranz v0.12.1 starting a project, running an action twice, and browsing its retained runs](./assets/kranz-demo.gif)
 
 </div>
 


### PR DESCRIPTION
## Summary

- build the pre-publish snapshot with the pinned GoReleaser action
- retain mandatory amd64 and arm64 package installation checks
- prepare 0.12.1 as the first published 0.12 release after the immutable 0.12.0 tag stopped before publication
- update release-facing documentation and recording recipes

## Verification

- documentation build and link checks
- workflow YAML parse
- release notes extraction tests
- GoReleaser configuration check
- exact 0.12.1 snapshot and checksum verification