### PR TITLE
Fix Darwin foreground signal re-raise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ artifacts.
 
 ### Fixed
 
+- Foreground `kranz up` now reliably preserves `SIGINT` and `SIGTERM` process
+  death on macOS even when the signal was temporarily blocked during handler
+  restoration.
 - The release workflow now builds its pre-publish package snapshot through the
   pinned GoReleaser action, avoiding a newer Go toolchain requirement than the
   project declares while retaining amd64 and arm64 installation checks.

--- a/cmd/kranz/signal_default_darwin_cgo.go
+++ b/cmd/kranz/signal_default_darwin_cgo.go
@@ -4,16 +4,22 @@ package main
 
 /*
 #include <errno.h>
+#include <pthread.h>
 #include <signal.h>
 #include <unistd.h>
 
 static int kranz_signal_default_and_raise(int sig) {
 	struct sigaction action;
+	sigset_t set;
 	if (sigemptyset(&action.sa_mask) != 0) return errno;
 	action.sa_handler = SIG_DFL;
 	action.sa_flags = 0;
 	if (sigaction(sig, &action, NULL) != 0) return errno;
-	if (kill(getpid(), sig) != 0) return errno;
+	if (sigemptyset(&set) != 0) return errno;
+	if (sigaddset(&set, sig) != 0) return errno;
+	int result = pthread_sigmask(SIG_UNBLOCK, &set, NULL);
+	if (result != 0) return result;
+	if (raise(sig) != 0) return errno;
 	return 0;
 }
 */


### PR DESCRIPTION
## Summary

- restore the default Darwin signal disposition before foreground exit
- unblock the signal on the current cgo thread
- use thread-directed raise so SIGINT and SIGTERM cannot race with a normal exit
- include the fix in 0.12.1 release notes

## Verification

- 100 race-enabled focused repetitions
- 100 CGO-disabled focused repetitions
- make verify
- make lint