### PR TITLE
Stabilize foreground remote-down test

### DIFF
--- a/cmd/kranz/main_test.go
+++ b/cmd/kranz/main_test.go
@@ -499,6 +499,36 @@ func TestForegroundRuntimeStatusAndRemoteDown(t *testing.T) {
 	if record.Mode != "background" || record.PID == command.Process.Pid {
 		t.Fatalf("foreground client did not use an independent runtime: mode=%q same_pid=%v", record.Mode, record.PID == command.Process.Pid)
 	}
+	probe, err := kranzruntime.Dial(record.Socket, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientDeadline := time.Now().Add(5 * time.Second)
+	for {
+		clients, clientsErr := probe.Clients()
+		if clientsErr != nil {
+			_ = probe.Close()
+			t.Fatal(clientsErr)
+		}
+		connected := false
+		for _, client := range clients {
+			if client.PID == command.Process.Pid && client.Surface == "cli" {
+				connected = true
+				break
+			}
+		}
+		if connected {
+			break
+		}
+		if time.Now().After(clientDeadline) {
+			_ = probe.Close()
+			t.Fatalf("foreground client did not connect; stderr=%s", childStderr.String())
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err := probe.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	var stdout, stderr bytes.Buffer
 	if code := execute([]string{"-p", name, "status", "--output=json"}, &stdout, &stderr); code != 0 {


### PR DESCRIPTION
## Summary

- wait until the foreground client is visible to the runtime before testing remote down
- preserve the test contract that an established foreground client exits cleanly when another client stops the runtime

## Verification

- 100 focused repetitions
- 30 race-enabled focused repetitions
- make verify
- make lint