### PR TITLE
feat: switch runtimes from the TUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 
 ### Fixed
 
+- Runtime and run-history modals now fit narrow terminals by selecting compact
+  table columns, wrapping complete shortcut groups, and reserving the wrapped
+  footer's height instead of clipping content at the screen edge.
 - Supervisor client surfaces and labels are stripped of terminal control
   characters and length-limited before they reach runtime lists or logs.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 
 ## [Unreleased]
 
+### Added
+
+- The TUI can switch between local Kranz runtimes without restarting: press
+  `p` for a live-updating list of every runtime registered on the machine,
+  and connect to another one in place. Each visited runtime keeps its own
+  selection, log filters, pinned log, and scroll position for the life of
+  the TUI process.
+- Losing the connection to the current runtime no longer closes the TUI; a
+  recovery screen offers to restart the same project or choose another
+  already-running runtime.
+- Running bare `kranz` outside a project directory now opens the same
+  runtime list immediately, when at least one local runtime is running,
+  instead of failing outright.
+
+### Changed
+
+- Pressing `q` in the TUI always opens the quit confirmation, including when
+  no service is running, so detaching can preserve the runtime and run history.
+- Switching runtimes never stops, restarts, or cancels work already accepted
+  by the runtime being left; an in-flight operation keeps running and its
+  result is shown if you switch back to it later.
+- Runtime discovery probes registered supervisors with bounded concurrency,
+  so one slow socket does not consume the rest of the list's refresh budget.
+- The runtime switcher now has aligned status, client-surface, service-count,
+  uptime, and directory columns, including a visible table header.
+
+### Fixed
+
+- Supervisor client surfaces and labels are stripped of terminal control
+  characters and length-limited before they reach runtime lists or logs.
+
 ## [0.12.1] - 2026-09-02
 
 This is the first published 0.12 release. The immutable `v0.12.0` tag stopped

--- a/cmd/kranz/attach.go
+++ b/cmd/kranz/attach.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"os/signal"
 	"sync"
 	"syscall"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -44,10 +46,10 @@ func runAttach(options kranzcli.GlobalOptions, args []string) (runErr error) {
 	if cfg == nil {
 		return errors.New("runtime returned no effective configuration")
 	}
-	return runAttachedTUI(client, cfg)
+	return runAttachedTUI(client, cfg, record, options)
 }
 
-func runAttachedTUI(client *kranzruntime.Client, cfg *config.Config) (runErr error) {
+func runAttachedTUI(client *kranzruntime.Client, cfg *config.Config, record kranzruntime.SessionRecord, options kranzcli.GlobalOptions) (runErr error) {
 	settingsPath, settingsPathErr := settings.DefaultPath()
 	if settingsPathErr != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Kranz settings warning: %v\n", settingsPathErr)
@@ -57,13 +59,26 @@ func runAttachedTUI(client *kranzruntime.Client, cfg *config.Config) (runErr err
 		_, _ = fmt.Fprintf(os.Stderr, "Kranz settings warning: %v\n", settingsErr)
 		userSettings = settings.Settings{}
 	}
+	registry, registryErr := kranzruntime.DefaultRegistry()
+	if registryErr != nil {
+		registry = nil
+	}
 	darkBackground := lipgloss.HasDarkBackground()
 	programReady := make(chan struct{})
 	focusReported := make(chan struct{})
 	var focusOnce sync.Once
 	model := ui.NewModelWithOptions(cfg, version, ui.ModelOptions{Settings: userSettings, SettingsPath: settingsPath, ConfigPaths: cfg.Paths, DarkBackground: &darkBackground, App: client, DetachOnExit: true, ProgramReady: func() { close(programReady) },
-		FocusReported: func() { focusOnce.Do(func() { close(focusReported) }) }})
-	defer func() { runErr = errors.Join(runErr, model.Shutdown()) }()
+		FocusReported: func() { focusOnce.Do(func() { close(focusReported) }) },
+		Registry:      registry, SessionRecord: record, RestartRuntime: makeRestartRuntime(options)})
+	defer func() {
+		runErr = errors.Join(runErr, model.Shutdown())
+		// Shutdown() only ever asks the runtime to stop something; it never
+		// closes the socket. Close whatever session is current when this
+		// returns, not the connection this function originally dialed — a
+		// switch may have retired that one long ago and left it as the only
+		// thing still referencing the live connection.
+		runErr = errors.Join(runErr, model.CloseCurrentConnection())
+	}()
 	program := tea.NewProgram(model, dashboardProgramOptions()...)
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
@@ -81,16 +96,87 @@ func runAttachedTUI(client *kranzruntime.Client, cfg *config.Config) (runErr err
 		select {
 		case <-signals:
 			program.Quit()
-		case <-client.Done():
-			program.Quit()
 		case <-done:
 		}
 	}()
-	if _, err := program.Run(); err != nil {
+	if _, err := runDashboardProgram(program); err != nil {
 		return &kranzcli.Error{Code: "tui", Message: "run attached TUI", ExitCode: kranzcli.ExitInternal, Cause: err}
 	}
 	if code := model.RequestedExitCode(); code != 0 {
 		return requestedExitError{code: code}
 	}
 	return nil
+}
+
+// runDashboardProgram runs the dashboard's Bubble Tea event loop. It exists
+// as a variable so a test can replace the real interactive loop (which
+// needs a terminal) while still exercising every routing decision around
+// it — config loading, runtime resolution, dialing, and model construction.
+var runDashboardProgram = func(program *tea.Program) (tea.Model, error) { return program.Run() }
+
+// openBareLaunchRegistry opens the registry a bare launch with no
+// discovered configuration probes for local runtimes to offer through the
+// picker (PRD 3.1, Scenario C). It exists as a variable so a test can point
+// it at an isolated temp registry instead of this machine's real one.
+var openBareLaunchRegistry = kranzruntime.DefaultRegistry
+
+// runRuntimePickerProgram runs the bare-launch runtime picker's Bubble Tea
+// event loop. Like runDashboardProgram, it is a variable so a test can drive
+// picker.Update directly (simulating a selection or a quit) instead of
+// needing a real terminal.
+var runRuntimePickerProgram = func(picker *ui.RuntimePicker) error {
+	_, err := tea.NewProgram(picker, dashboardProgramOptions()...).Run()
+	return err
+}
+
+// runtimeRegistryProbeTimeout bounds the registry query a bare launch makes
+// before deciding between the ordinary "no configuration" error and the
+// runtime picker (PRD 3.1: "a bounded-timeout registry query before the
+// full-screen TUI starts").
+const runtimeRegistryProbeTimeout = 2 * time.Second
+
+// runBareWithoutConfig handles a bare `kranz` launch where automatic
+// discovery found no configuration in the working directory (PRD 3.1,
+// Scenario C). It is reached only when discovery itself found nothing to
+// load, never when a discovered or explicitly named configuration exists
+// but fails to parse — that error is returned unchanged by the caller and
+// never reaches here, so an existing project's broken config is never
+// misreported as "no project here".
+func runBareWithoutConfig(options kranzcli.GlobalOptions) error {
+	notFound := &kranzcli.Error{
+		Code:     "config_not_found",
+		Message:  "no Kranz configuration was found in this directory, and no local Kranz runtime is running",
+		Hint:     "Run from a project directory, pass -f PATH, or start a runtime elsewhere first.",
+		ExitCode: kranzcli.ExitConfig,
+	}
+	registry, err := openBareLaunchRegistry()
+	if err != nil {
+		return notFound
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), runtimeRegistryProbeTimeout)
+	records, err := registry.List(ctx, version)
+	cancel()
+	if err != nil || len(records) == 0 {
+		return notFound
+	}
+
+	picker := ui.NewRuntimePicker(registry, version)
+	if err := runRuntimePickerProgram(picker); err != nil {
+		return &kranzcli.Error{Code: "tui", Message: "run runtime picker", ExitCode: kranzcli.ExitInternal, Cause: err}
+	}
+	record, chosen := picker.Selected()
+	if !chosen {
+		return nil
+	}
+	client, err := kranzruntime.DialWithIdentity(record.Socket, version,
+		kranzruntime.ClientIdentity{Surface: "tui", Label: "Kranz dashboard"})
+	if err != nil {
+		return classifyRuntimeError(err)
+	}
+	defer func() { _ = client.Close() }()
+	cfg := client.Config()
+	if cfg == nil {
+		return errors.New("runtime returned no effective configuration")
+	}
+	return runAttachedTUI(client, cfg, record, options)
 }

--- a/cmd/kranz/main.go
+++ b/cmd/kranz/main.go
@@ -404,7 +404,12 @@ func runTUI(options kranzcli.GlobalOptions) (runErr error) {
 	if len(cfgPaths) == 0 {
 		cfgPaths, err = config.DiscoverFiles(".")
 		if err != nil {
-			return &kranzcli.Error{Code: "config_not_found", Message: "discover configuration", ExitCode: kranzcli.ExitConfig, Cause: err}
+			// Automatic discovery, not an explicitly named path, found
+			// nothing here: this is the one case where an already-running
+			// local runtime is worth offering instead of failing outright
+			// (PRD 3.1, Scenario C). An invalid configuration that WAS
+			// found is a different error, returned below unchanged.
+			return runBareWithoutConfig(options)
 		}
 	}
 	cfg, err := config.LoadFiles(cfgPaths)
@@ -430,7 +435,23 @@ func runTUI(options kranzcli.GlobalOptions) (runErr error) {
 	if activeConfig == nil {
 		return errors.New("runtime returned no effective configuration")
 	}
-	return runAttachedTUI(client, activeConfig)
+	return runAttachedTUI(client, activeConfig, record, options)
+}
+
+// makeRestartRuntime builds the "Restart runtime" callback for the recovery
+// screen: the exact background-launch mechanism the ordinary bare-launch
+// path already uses, aimed at a specific project directory and config paths
+// instead of the current working directory. It never builds a shell string;
+// spawnBackground always execs the Kranz binary with an explicit argv.
+func makeRestartRuntime(base kranzcli.GlobalOptions) func(directory string, configPaths []string) error {
+	return func(directory string, configPaths []string) error {
+		options := base
+		options.Directory = directory
+		options.ConfigPaths = configPaths
+		options.Project = ""
+		options.Output = kranzcli.OutputText
+		return spawnBackground(options, nil, true, io.Discard)
+	}
 }
 
 func resolveOrStartDashboardRuntime(options kranzcli.GlobalOptions, cfgPaths []string, runtimeName, directory string) (kranzruntime.SessionRecord, error) {

--- a/cmd/kranz/startup_routing_test.go
+++ b/cmd/kranz/startup_routing_test.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/kranz-org/kranz/internal/app"
+	kranzcli "github.com/kranz-org/kranz/internal/cli"
+	"github.com/kranz-org/kranz/internal/config"
+	kranzruntime "github.com/kranz-org/kranz/internal/runtime"
+	"github.com/kranz-org/kranz/internal/ui"
+)
+
+// TestRunTUIValidConfigStartsAndAttachesNormally is the PRD 3.1 unit test
+// for "valid config": a bare launch in a project directory must start (or
+// attach to) its runtime and open the dashboard exactly as before this
+// feature — the runtime-picker fallback must never be consulted. It stops
+// short of the interactive event loop itself (which needs a terminal;
+// covered by manual verification) by replacing runDashboardProgram, so
+// everything before it — config loading, background spawn, registry
+// publish, dial, and Model construction — runs for real.
+func TestRunTUIValidConfigStartsAndAttachesNormally(t *testing.T) {
+	useHelperBackgroundRuntimes(t)
+	directory := t.TempDir()
+	name := fmt.Sprintf("valid-config-test-%d", os.Getpid())
+	document := "project: " + name + "\nruntime:\n  name: " + name + "\nservices:\n  api:\n    command: sleep 60\n"
+	if err := os.WriteFile(filepath.Join(directory, "kranz.yaml"), []byte(document), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = runDown(kranzcli.GlobalOptions{Project: name, Output: kranzcli.OutputText}, nil, io.Discard)
+	})
+
+	dashboardStarted := false
+	previousDashboard := runDashboardProgram
+	runDashboardProgram = func(*tea.Program) (tea.Model, error) {
+		dashboardStarted = true
+		return nil, nil
+	}
+	defer func() { runDashboardProgram = previousDashboard }()
+	pickerInvoked := false
+	previousPicker := runRuntimePickerProgram
+	runRuntimePickerProgram = func(*ui.RuntimePicker) error {
+		pickerInvoked = true
+		return nil
+	}
+	defer func() { runRuntimePickerProgram = previousPicker }()
+
+	if err := runTUI(kranzcli.GlobalOptions{Directory: directory, Output: kranzcli.OutputText}); err != nil {
+		t.Fatalf("runTUI with a valid config returned an error: %v", err)
+	}
+	if !dashboardStarted {
+		t.Fatal("the ordinary dashboard program was never started")
+	}
+	if pickerInvoked {
+		t.Fatal("the runtime picker must never run when a configuration was found")
+	}
+
+	registry, err := kranzruntime.DefaultRegistry()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := registry.Resolve(context.Background(), name, version); err != nil {
+		t.Fatalf("runtime never published to the registry: %v", err)
+	}
+}
+
+// asCommandError unwraps err into *kranzcli.Error, failing the test if it is
+// some other kind of error entirely.
+func asCommandError(t *testing.T, err error) *kranzcli.Error {
+	t.Helper()
+	var commandError *kranzcli.Error
+	if !errors.As(err, &commandError) {
+		t.Fatalf("error %v (%T) is not a *kranzcli.Error", err, err)
+	}
+	return commandError
+}
+
+// TestRunTUIInvalidConfigIsNotMaskedByTheRuntimePicker is the PRD 3.1 unit
+// test for "invalid config": a configuration that IS discovered but fails
+// to load must return the existing invalid_config error unchanged, never
+// the runtime-picker fallback (PRD acceptance criterion: "an existing
+// config error is never turned into an offer to connect to an unrelated
+// runtime").
+func TestRunTUIInvalidConfigIsNotMaskedByTheRuntimePicker(t *testing.T) {
+	directory := t.TempDir()
+	if err := os.WriteFile(filepath.Join(directory, "kranz.yaml"), []byte("not: [valid"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Even if local runtimes exist, a found-but-broken config must win.
+	previousRegistry := openBareLaunchRegistry
+	openBareLaunchRegistry = func() (*kranzruntime.Registry, error) {
+		t.Fatal("the registry must never be consulted when a discovered config is merely invalid")
+		return nil, nil
+	}
+	defer func() { openBareLaunchRegistry = previousRegistry }()
+
+	err := runTUI(kranzcli.GlobalOptions{Directory: directory, Output: kranzcli.OutputText})
+	if err == nil {
+		t.Fatal("bare launch over an invalid config returned no error")
+	}
+	if code := asCommandError(t, err).Code; code != "invalid_config" {
+		t.Fatalf("error code = %q, want invalid_config", code)
+	}
+}
+
+// TestRunBareWithoutConfigNoRuntimeReturnsClearError is the PRD 3.1 unit
+// test for "no config without runtimes": a directory with neither a
+// configuration nor any locally registered runtime must print a clear
+// terminal error and exit non-zero — and, by construction (no tea.Program
+// is ever created on this path), never touch the alternate screen.
+func TestRunBareWithoutConfigNoRuntimeReturnsClearError(t *testing.T) {
+	directory := t.TempDir()
+	previousRegistry := openBareLaunchRegistry
+	openBareLaunchRegistry = func() (*kranzruntime.Registry, error) {
+		return kranzruntime.NewRegistry(t.TempDir()) // isolated and empty
+	}
+	defer func() { openBareLaunchRegistry = previousRegistry }()
+	pickerInvoked := false
+	previousPicker := runRuntimePickerProgram
+	runRuntimePickerProgram = func(*ui.RuntimePicker) error {
+		pickerInvoked = true
+		return nil
+	}
+	defer func() { runRuntimePickerProgram = previousPicker }()
+
+	err := runTUI(kranzcli.GlobalOptions{Directory: directory, Output: kranzcli.OutputText})
+	if err == nil {
+		t.Fatal("bare launch with neither config nor runtime returned no error")
+	}
+	commandError := asCommandError(t, err)
+	if commandError.ExitCode != kranzcli.ExitConfig {
+		t.Fatalf("exit code = %d, want ExitConfig (%d)", commandError.ExitCode, kranzcli.ExitConfig)
+	}
+	if commandError.Code != "config_not_found" {
+		t.Fatalf("error code = %q, want config_not_found", commandError.Code)
+	}
+	if commandError.Error() == "" {
+		t.Fatal("error message is empty")
+	}
+	if pickerInvoked {
+		t.Fatal("the runtime picker must not run when the registry is empty")
+	}
+}
+
+// TestRunBareWithoutConfigOpensPickerWhenARuntimeExists is the PRD 3.1/
+// Scenario C unit test for "no config with runtimes": with at least one
+// runtime registered, the bare launch must open the picker instead of
+// failing outright. It drives the picker headlessly through its own
+// exported Update/Init methods (via the injected program runner) rather
+// than a real terminal, then has it quit without choosing, which proves the
+// routing decision without needing a live dashboard.
+func TestRunBareWithoutConfigOpensPickerWhenARuntimeExists(t *testing.T) {
+	directory := t.TempDir()
+	registry, err := kranzruntime.NewRegistry(t.TempDir())
+	if err != nil {
+		t.Fatalf("new registry: %v", err)
+	}
+	runtimeName := fmt.Sprintf("picker-test-%d", os.Getpid())
+	rt := startPickerTestRuntime(t, registry, runtimeName)
+	defer rt.stop()
+
+	previousRegistry := openBareLaunchRegistry
+	openBareLaunchRegistry = func() (*kranzruntime.Registry, error) { return registry, nil }
+	defer func() { openBareLaunchRegistry = previousRegistry }()
+
+	pickerInvoked := false
+	previousPicker := runRuntimePickerProgram
+	runRuntimePickerProgram = func(picker *ui.RuntimePicker) error {
+		pickerInvoked = true
+		// Drive discovery once, synchronously, the same way Bubble Tea's own
+		// loop would feed the result of Init()'s command back in — then quit
+		// without selecting anything.
+		if cmd := picker.Init(); cmd != nil {
+			if msg := cmd(); msg != nil {
+				picker.Update(msg)
+			}
+		}
+		picker.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+		return nil
+	}
+	defer func() { runRuntimePickerProgram = previousPicker }()
+
+	err = runTUI(kranzcli.GlobalOptions{Directory: directory, Output: kranzcli.OutputText})
+	if !pickerInvoked {
+		t.Fatal("the runtime picker was never invoked even though a runtime is registered")
+	}
+	if err != nil {
+		t.Fatalf("quitting the picker without a choice should return no error, got %v", err)
+	}
+}
+
+// pickerTestRuntime is a minimal real supervisor registered in an isolated
+// registry, just enough for the picker to discover and for a would-be
+// selection to dial.
+type pickerTestRuntime struct {
+	stop func()
+}
+
+func startPickerTestRuntime(t *testing.T, registry *kranzruntime.Registry, name string) *pickerTestRuntime {
+	t.Helper()
+	directory := t.TempDir()
+	document := "project: " + name + "\nservices: {}\n"
+	if err := os.WriteFile(filepath.Join(directory, "kranz.yaml"), []byte(document), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	session, err := registry.Acquire(name)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	metadata, err := session.Prepare(name, "test", "background", directory)
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	cfg := &config.Config{Project: name, Services: map[string]config.Service{}}
+	local := app.NewLocal(cfg, []string{filepath.Join(directory, "kranz.yaml")}, app.Options{SessionID: metadata.ID})
+	supervisor := kranzruntime.NewSupervisor(local)
+	if err := supervisor.Listen(metadata.Socket); err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	if err := session.Publish(); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- supervisor.Serve() }()
+	return &pickerTestRuntime{stop: func() {
+		_ = supervisor.Close()
+		<-serveErr
+		_ = session.Close()
+		_ = local.Shutdown()
+	}}
+}

--- a/docs/guide/tui.md
+++ b/docs/guide/tui.md
@@ -100,7 +100,7 @@ kranz attach
 ```
 
 Every TUI is attached to an independently owned runtime, including the one
-opened by bare `kranz`. When services are active, the quit confirmation shows
+opened by bare `kranz`. The quit confirmation always shows
 which managed processes and configured detached resources will stop and which
 external resources will remain active. Confirm shutdown with `Enter` or `y`,
 press `d` to detach the TUI and keep the complete runtime running, or use `Esc`
@@ -108,6 +108,32 @@ or `n` to stay.
 
 The [CLI workflow](./cli-workflow) and [MCP guide](./mcp) operate the same live
 runtime. A restart from either is reflected immediately in this TUI.
+
+## Switch between local runtimes
+
+Working on several projects at once no longer means running a separate TUI
+for each. Press `p` to open a modal styled like Run history with every Kranz
+runtime registered on this machine — current runtime first — and press
+`Enter` on another one to attach to it in the same process. `Esc` closes the
+modal without changing anything.
+
+Each runtime you visit keeps its own selection, log filters, pinned log, and
+scroll position for as long as this TUI process runs, so returning to one
+looks exactly as you left it. Switching never stops, restarts, or otherwise
+touches the runtime you are leaving: an operation it already accepted keeps
+running, and you see its result if you switch back before it finishes.
+
+Starting `kranz` outside a project directory behaves the same way it always
+has once one is found. Without one, if any local runtime is already running,
+the same list opens immediately instead of failing; if none is, Kranz prints
+an error and exits.
+
+If the runtime the dashboard is currently showing stops — the process
+crashed, or was stopped from elsewhere — the TUI shows a recovery screen
+instead of closing, offering `r` to restart that project or `c` to choose
+another running one. See the [switching runtimes
+reference](../reference/controls#switching-runtimes) for the complete key
+list, row states, and recovery behavior.
 
 ## Common keys
 
@@ -124,10 +150,11 @@ runtime. A restart from either is reflected immediately in this TUI.
 | `[` / `]` | Move to the previous/next run |
 | `v` | Open run history; filter and select with keyboard or mouse |
 | `e` / `Shift+E` | Export the selected run to clipboard / a chosen file |
+| `p` | Switch to another local Kranz runtime |
 | `Ctrl+T` | Open the theme and appearance picker |
 | `Ctrl+L` | Reload configuration |
 | `?` | Open help |
-| `q` | Quit, with cleanup confirmation when required |
+| `q` | Open the quit confirmation |
 
 The [complete controls reference](../reference/controls) covers selection
 overrides, log navigation, health history, notifications, shell handoff, mouse

--- a/docs/guide/tui.md
+++ b/docs/guide/tui.md
@@ -117,6 +117,11 @@ runtime registered on this machine — current runtime first — and press
 `Enter` on another one to attach to it in the same process. `Esc` closes the
 modal without changing anything.
 
+Runtime and Run history tables adapt to the terminal width. Wide terminals
+show their complete detail; narrower ones remove secondary columns first and
+wrap shortcut groups onto additional footer rows, keeping the selection and
+close controls visible without horizontal clipping.
+
 Each runtime you visit keeps its own selection, log filters, pinned log, and
 scroll position for as long as this TUI process runs, so returning to one
 looks exactly as you left it. Switching never stops, restarts, or otherwise

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -4,6 +4,11 @@ Kranz has one binary and no daemon. Running `kranz` with no subcommand opens the
 terminal UI; every other command either describes a project or talks to one
 running project runtime.
 
+Outside a project directory, a bare `kranz` opens a list of any local runtimes
+already running instead of failing, and lets you attach to one from there
+(see [switching runtimes](./controls#switching-runtimes)). It only reports an
+error if it finds neither a configuration nor a runtime.
+
 ## Synopsis
 
 ```bash

--- a/docs/reference/controls.md
+++ b/docs/reference/controls.md
@@ -100,8 +100,9 @@ accent-coloured shortcuts.
 | `Ctrl+T` | Theme and appearance picker |
 | `Ctrl+L` | Reload configuration and terminal appearance |
 | `Ctrl+O` | Hand terminal to a shell; press again to return |
+| `p` | Switch to another local Kranz runtime |
 | `?` | Help |
-| `q` | Open the quit confirmation when services are active |
+| `q` | Always open the quit confirmation |
 | `Ctrl+C` | Immediate shutdown |
 
 The quit confirmation shows the complete shutdown plan. `Enter` or `y` stops
@@ -109,3 +110,59 @@ the runtime and quits, `d` detaches the TUI while keeping the runtime running,
 and `Esc` or `n` stays in the TUI. Shutdown stops process-owned services and
 only detached services with `stop_on_exit: true`; other external resources are
 listed and remain active.
+
+## Switching runtimes
+
+`p` opens a list of every Kranz runtime registered on the machine, current
+runtime first, then the rest ordered by how recently they started. It
+refreshes on its own while open — a runtime that starts or stops elsewhere
+appears or disappears without reopening the modal.
+
+| Key | Action |
+| --- | --- |
+| `↑` / `↓`, `j` / `k` | Move the selection |
+| `Enter` | Connect to the selected runtime |
+| `Esc` or `p` | Close the modal and stay on the current runtime |
+
+The table has separate `RUNTIME`, `STATUS`, `CLIENTS`, `SERVICES`, `UPTIME`,
+and `DIRECTORY` columns. `STATUS` is `current` for the runtime already open
+and `started` for another available runtime. `CLIENTS` lists the unique client
+surfaces connected to it (for example `TUI · MCP`) without counts, while
+`SERVICES` shows running/total in the same `3/5` form as `kranz ps`. A runtime
+running an incompatible protocol version, or one the switcher cannot currently
+reach, is shown greyed out with the reason and cannot be selected; in a narrow
+terminal the directory, uptime, and client detail give way before the runtime
+name or status. Mouse clicks move the selection the same way arrow keys do,
+and a second click on the same row within the usual double-click window
+connects to it.
+
+Connecting is all-or-nothing: Kranz only switches once the new runtime has
+answered a handshake and handed over its configuration and current state. A
+failed connection leaves the previous runtime's dashboard exactly as it was,
+with an error explaining why. Switching never stops, restarts, or otherwise
+disturbs the runtime being left — a start, stop, or restart it already
+accepted keeps running, and its result is shown if you switch back before it
+finishes. Each visited runtime keeps its own selection, filters, pinned log,
+and scroll position for the life of the TUI process; none of it is written to
+disk, and it is cleared on exit.
+
+If `kranz` is started outside a project directory but at least one local
+runtime is already running, the switcher opens immediately instead of
+failing. If neither a configuration nor a runtime is found, Kranz prints an
+error to the terminal and exits without opening a screen at all.
+
+### If the current runtime stops
+
+Losing the connection to the runtime the dashboard is showing does not close
+the TUI. Instead it shows a recovery screen:
+
+| Key | Action |
+| --- | --- |
+| `r` or `Enter` | Restart the same project's runtime and reattach |
+| `c` | Choose a different, already-running runtime |
+| `q` or `Ctrl+C` | Close only the TUI |
+
+A restart reuses the project directory and configuration paths Kranz already
+had for that runtime; it does not repeat any command a user typed. If it
+fails, the reason stays on screen and either action can be tried again. Both
+options are also available by clicking their label.

--- a/docs/reference/controls.md
+++ b/docs/reference/controls.md
@@ -130,10 +130,12 @@ and `started` for another available runtime. `CLIENTS` lists the unique client
 surfaces connected to it (for example `TUI · MCP`) without counts, while
 `SERVICES` shows running/total in the same `3/5` form as `kranz ps`. A runtime
 running an incompatible protocol version, or one the switcher cannot currently
-reach, is shown greyed out with the reason and cannot be selected; in a narrow
-terminal the directory, uptime, and client detail give way before the runtime
-name or status. Mouse clicks move the selection the same way arrow keys do,
-and a second click on the same row within the usual double-click window
+reach, is shown greyed out and cannot be selected; selecting it spells the
+reason out under the list. In a narrow terminal the directory is dropped
+first, then the client surfaces shorten, then the runtime name; `UPTIME` and
+`CLIENTS` disappear only after that, and `STATUS` and `SERVICES` are the last
+to give up any width. Mouse clicks move the selection the same way arrow keys
+do, and a second click on the same row within the usual double-click window
 connects to it.
 
 The runtime and Run history modals keep a small dashboard gutter instead of

--- a/docs/reference/controls.md
+++ b/docs/reference/controls.md
@@ -136,6 +136,12 @@ name or status. Mouse clicks move the selection the same way arrow keys do,
 and a second click on the same row within the usual double-click window
 connects to it.
 
+The runtime and Run history modals keep a small dashboard gutter instead of
+growing to the full terminal width. When space is limited, their tables remove
+secondary columns and shorten cells before any horizontal clipping occurs.
+Shortcut groups wrap onto complete additional rows, and list windowing reserves
+those rows so the cursor and close action remain visible.
+
 Connecting is all-or-nothing: Kranz only switches once the new runtime has
 answered a handshake and handed over its configuration and current state. A
 failed connection leaves the previous runtime's dashboard exactly as it was,

--- a/internal/runtime/client.go
+++ b/internal/runtime/client.go
@@ -37,6 +37,12 @@ type Client struct {
 	pendingMu sync.Mutex
 	pending   map[uint64]chan envelope
 
+	// inFlight counts requests currently between send and reply on this
+	// connection. CloseAfterIdle waits on it so retiring a client a TUI has
+	// switched away from never aborts an operation the supervisor already
+	// accepted (PRD: a switch must not cancel supervisor-owned work).
+	inFlight sync.WaitGroup
+
 	readErr   atomic.Value // error
 	closeOnce sync.Once
 	closeErr  error
@@ -156,6 +162,44 @@ func (c *Client) Close() error {
 
 func (c *Client) Done() <-chan struct{} { return c.done }
 
+// Retain reserves this connection for work that has been scheduled by a
+// caller but may not have entered roundTrip yet. The returned release must be
+// called exactly once. Runtime switching uses this boundary before handing a
+// command to Bubble Tea, so CloseAfterIdle cannot observe a transient zero and
+// close the old socket before that command's goroutine starts.
+func (c *Client) Retain() func() {
+	c.inFlight.Add(1)
+	var once sync.Once
+	return func() { once.Do(c.inFlight.Done) }
+}
+
+// CloseAfterIdle closes the connection once every retained or in-flight
+// request on it has returned, or after timeout, whichever comes first. A
+// non-positive timeout waits without a deadline. It
+// does not wait for or cancel anything itself — the goroutine that issued
+// each in-flight call is already waiting on its own result independent of
+// this client's lifetime — it only defers the socket teardown so a reply
+// already accepted by the supervisor is never lost to a closed connection.
+// The timeout is a backstop against a wedged call, not the expected path.
+func (c *Client) CloseAfterIdle(timeout time.Duration) {
+	idle := make(chan struct{})
+	go func() {
+		c.inFlight.Wait()
+		close(idle)
+	}()
+	go func() {
+		if timeout > 0 {
+			select {
+			case <-idle:
+			case <-time.After(timeout):
+			}
+		} else {
+			<-idle
+		}
+		_ = c.Close()
+	}()
+}
+
 func (c *Client) readLoop() {
 	defer c.doneOnce.Do(func() { close(c.done) })
 	for {
@@ -186,6 +230,8 @@ func (c *Client) failAllPending(err error) {
 // roundTrip sends one request and returns its response body, or the
 // reconstructed error if the server answered with one.
 func (c *Client) roundTrip(ctx context.Context, method string, reqBody []byte) (json.RawMessage, error) {
+	c.inFlight.Add(1)
+	defer c.inFlight.Done()
 	id := c.idSeq.Add(1)
 	replyCh := make(chan envelope, 1)
 	c.pendingMu.Lock()

--- a/internal/runtime/close_after_idle_test.go
+++ b/internal/runtime/close_after_idle_test.go
@@ -1,0 +1,122 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kranz-org/kranz/internal/app"
+	"github.com/kranz-org/kranz/internal/config"
+)
+
+// TestCloseAfterIdleWaitsForInFlightRequest proves the mechanism the
+// runtime switcher relies on to retire a connection it has switched away
+// from (PRD 3.3: "an operation already accepted by the supervisor keeps
+// running after the user leaves"). A request already on the wire when
+// CloseAfterIdle is called must still get its own answer, not a
+// "connection closed" error manufactured by the teardown itself.
+func TestCloseAfterIdleWaitsForInFlightRequest(t *testing.T) {
+	cfg := &config.Config{Project: "CloseIdle", Services: map[string]config.Service{
+		// Never started, so "running" never becomes true: Wait blocks for its
+		// whole timeout, giving a deterministic in-flight request to close
+		// the connection underneath.
+		"idle": {Command: "sleep 60", Dir: ".", Shell: "sh"},
+	}}
+	client, cleanup := startTestSupervisor(t, cfg, nil)
+	defer cleanup()
+
+	type waitOutcome struct {
+		result app.WaitResult
+		err    error
+	}
+	outcome := make(chan waitOutcome, 1)
+	go func() {
+		result, err := client.Wait(context.Background(), app.WaitRequest{
+			Selectors: []string{"idle"}, Condition: "running", Timeout: 300 * time.Millisecond,
+		})
+		outcome <- waitOutcome{result, err}
+	}()
+
+	// Give the request time to actually reach the server before retiring the
+	// connection, so this exercises "close while in flight" rather than
+	// "close before the request was even sent".
+	time.Sleep(50 * time.Millisecond)
+	client.CloseAfterIdle(5 * time.Second)
+
+	select {
+	case got := <-outcome:
+		var waitErr *app.WaitError
+		if !errors.As(got.err, &waitErr) {
+			t.Fatalf("Wait returned %v (%#v), want its own timeout WaitError, not a connection-closed error", got.err, got.result)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Wait never returned; CloseAfterIdle blocked or aborted it")
+	}
+
+	select {
+	case <-client.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("the connection was never actually closed once idle")
+	}
+}
+
+// TestCloseAfterIdleTimeoutClosesAWedgedConnection proves the backstop: a
+// request that never returns does not keep the connection open forever.
+func TestCloseAfterIdleTimeoutClosesAWedgedConnection(t *testing.T) {
+	cfg := &config.Config{Project: "WedgedIdle", Services: map[string]config.Service{}}
+	client, cleanup := startTestSupervisor(t, cfg, nil)
+	defer cleanup()
+
+	client.inFlight.Add(1) // simulates a call that will never itself return
+	defer client.inFlight.Done()
+
+	client.CloseAfterIdle(50 * time.Millisecond)
+	select {
+	case <-client.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("CloseAfterIdle's timeout backstop never closed the connection")
+	}
+}
+
+func TestRetainCoversARequestScheduledBeforeRetirement(t *testing.T) {
+	cfg := &config.Config{Project: "ScheduledIdle", Services: map[string]config.Service{
+		"idle": {Command: "sleep 60", Dir: ".", Shell: "sh"},
+	}}
+	client, cleanup := startTestSupervisor(t, cfg, nil)
+	defer cleanup()
+
+	release := client.Retain()
+	start := make(chan struct{})
+	outcome := make(chan error, 1)
+	go func() {
+		<-start
+		defer release()
+		_, err := client.Wait(context.Background(), app.WaitRequest{
+			Selectors: []string{"idle"}, Condition: "running", Timeout: 100 * time.Millisecond,
+		})
+		outcome <- err
+	}()
+
+	client.CloseAfterIdle(0)
+	select {
+	case <-client.Done():
+		t.Fatal("retired connection closed before its scheduled request started")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(start)
+	select {
+	case err := <-outcome:
+		var waitErr *app.WaitError
+		if !errors.As(err, &waitErr) {
+			t.Fatalf("scheduled request returned %v, want its own WaitError", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("scheduled request never completed")
+	}
+	select {
+	case <-client.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("retained connection did not close after the scheduled request completed")
+	}
+}

--- a/internal/runtime/integration_test.go
+++ b/internal/runtime/integration_test.go
@@ -259,6 +259,20 @@ func TestRunCatalogPreservesConnectionProvenanceAcrossRPC(t *testing.T) {
 	}
 }
 
+func TestSupervisorSanitizesClientIdentity(t *testing.T) {
+	client, cleanup := startTestSupervisorIdentity(t, &config.Config{Project: "Identity"}, nil,
+		ClientIdentity{Surface: "tu\x1bi", Label: "dashboard\n" + strings.Repeat("x", 100)})
+	defer cleanup()
+
+	clients, err := client.Clients()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(clients) != 1 || clients[0].Surface != "tui" || strings.ContainsAny(clients[0].Label, "\x1b\r\n") || len([]rune(clients[0].Label)) > 80 {
+		t.Fatalf("sanitized client identity = %#v", clients)
+	}
+}
+
 func TestDeleteRunCrossesRPCWithTypedErrors(t *testing.T) {
 	cfg := &config.Config{Project: "RPC delete", ActionGroups: map[string]config.ActionGroup{
 		"ops": {Actions: map[string]config.Action{"ping": {Command: "echo pong", Shell: "/bin/sh"}}},

--- a/internal/runtime/registry.go
+++ b/internal/runtime/registry.go
@@ -59,6 +59,11 @@ type SessionRecord struct {
 	// Clients counts the connections the runtime is serving, nil when it could
 	// not be reached. The listing probe is itself one of them and is excluded.
 	Clients *int `json:"clients"`
+	// ClientSurfaces lists the unique delivery-surface labels (for example
+	// "tui", "mcp") currently connected, excluding the listing probe itself
+	// and the background owner connection a detached runtime keeps for its
+	// own ownership bookkeeping. Nil when the runtime could not be reached.
+	ClientSurfaces []string `json:"client_surfaces"`
 }
 
 type Registry struct {
@@ -339,16 +344,48 @@ func atomicJSON(path string, value any) error {
 	return os.Rename(tmpName, path)
 }
 
+// registryProbeSurface identifies the transient connection List/Resolve opens
+// to inspect each session. It is deliberately distinct from every real
+// delivery surface ("tui", "cli", "mcp", ...) so it can be excluded from
+// client-facing counts and labels by identity rather than by a fragile
+// off-by-one assumption.
+const registryProbeSurface = "probe"
+
+// backgroundOwnerSurface is the connection a detached runtime's owning
+// process keeps open for the lifetime of the runtime to record ownership
+// snapshots. It is infrastructure, not a delivery surface a person or agent
+// is using, so it is excluded the same way the probe is.
+const backgroundOwnerSurface = "background"
+
+// registryProbeConcurrency keeps discovery responsive when one registered
+// socket is slow without opening an unbounded number of connections when a
+// user has many runtimes.
+const registryProbeConcurrency = 8
+
 func (r *Registry) List(ctx context.Context, clientVersion string) ([]SessionRecord, error) {
-	return r.list(ctx, clientVersion, false)
+	return r.list(ctx, clientVersion, false, "", 0)
 }
 
-func (r *Registry) list(ctx context.Context, clientVersion string, includeStale bool) ([]SessionRecord, error) {
+// ListForSwitcher lists sessions the same way List does, additionally
+// excluding one caller connection identified by (selfSurface, selfPID) from
+// the computed client surfaces of whichever session it happens to be
+// connected to. A TUI passes its own surface and PID so its own dashboard
+// connection to the current runtime does not inflate that runtime's own row;
+// the exclusion is a no-op for every other session, since a caller can only
+// ever be connected, under its own PID, to the one runtime it is attached to.
+func (r *Registry) ListForSwitcher(ctx context.Context, clientVersion, selfSurface string, selfPID int) ([]SessionRecord, error) {
+	return r.list(ctx, clientVersion, false, selfSurface, selfPID)
+}
+
+func (r *Registry) list(ctx context.Context, clientVersion string, includeStale bool, excludeSurface string, excludePID int) ([]SessionRecord, error) {
 	paths, err := filepath.Glob(filepath.Join(r.root, "*.json"))
 	if err != nil {
 		return nil, err
 	}
 	records := make([]SessionRecord, 0, len(paths))
+	var recordsMu sync.Mutex
+	var probes sync.WaitGroup
+	probeSlots := make(chan struct{}, registryProbeConcurrency)
 	for _, path := range paths {
 		if strings.HasSuffix(path, ".ownership.json") {
 			continue
@@ -362,10 +399,39 @@ func (r *Registry) list(ctx context.Context, clientVersion string, includeStale 
 		if probeErr != nil {
 			continue
 		}
-		record := SessionRecord{SessionMetadata: metadata, State: SessionUnreachable}
-		client, dialErr := DialContext(ctx, metadata.Socket, clientVersion)
-		if dialErr == nil {
-			snapshots := client.Services()
+		probes.Add(1)
+		go func(path string, metadata SessionMetadata, locked bool) {
+			defer probes.Done()
+			probeSlots <- struct{}{}
+			defer func() { <-probeSlots }()
+			record, keep := r.probeRecord(ctx, path, metadata, locked, clientVersion, includeStale, excludeSurface, excludePID)
+			if !keep {
+				return
+			}
+			recordsMu.Lock()
+			records = append(records, record)
+			recordsMu.Unlock()
+		}(path, metadata, locked)
+	}
+	probes.Wait()
+	sort.Slice(records, func(i, j int) bool { return records[i].Name < records[j].Name })
+	return records, nil
+}
+
+func (r *Registry) probeRecord(ctx context.Context, path string, metadata SessionMetadata, locked bool, clientVersion string, includeStale bool, excludeSurface string, excludePID int) (SessionRecord, bool) {
+	record := SessionRecord{SessionMetadata: metadata, State: SessionUnreachable}
+	client, dialErr := DialContextWithIdentity(ctx, metadata.Socket, clientVersion,
+		ClientIdentity{Surface: registryProbeSurface, Label: "Kranz runtime discovery"})
+	if dialErr == nil {
+		// Client inspection methods predate context-aware discovery. Closing the
+		// probe on cancellation makes their background RPCs obey the caller's
+		// list deadline as one unit.
+		stopClose := context.AfterFunc(ctx, func() { _ = client.Close() })
+		snapshots := client.Services()
+		connected, clientsErr := client.Clients()
+		stopClose()
+		_ = client.Close()
+		if ctx.Err() == nil && clientsErr == nil {
 			count := len(snapshots)
 			running := 0
 			for _, snapshot := range snapshots {
@@ -375,33 +441,48 @@ func (r *Registry) list(ctx context.Context, clientVersion string, includeStale 
 			}
 			record.Services, record.Running = &count, &running
 			record.State = SessionRunning
-			if connected, clientsErr := client.Clients(); clientsErr == nil {
-				// This probe holds one of those connections; reporting it would
-				// tell every reader a runtime nobody uses has one client.
-				others := max(0, len(connected)-1)
-				record.Clients = &others
+			others := 0
+			seen := make(map[string]bool, len(connected))
+			surfaces := make([]string, 0, len(connected))
+			for _, info := range connected {
+				if info.Surface == registryProbeSurface || info.Surface == backgroundOwnerSurface {
+					continue
+				}
+				if excludeSurface != "" && info.Surface == excludeSurface && info.PID == excludePID {
+					continue
+				}
+				others++
+				if !seen[info.Surface] {
+					seen[info.Surface] = true
+					surfaces = append(surfaces, info.Surface)
+				}
 			}
-			_ = client.Close()
+			sort.Strings(surfaces)
+			record.Clients = &others
+			record.ClientSurfaces = surfaces
 		} else {
-			var mismatch *VersionMismatchError
-			if errors.As(dialErr, &mismatch) {
-				record.State = SessionIncompatible
+			dialErr = clientsErr
+			if dialErr == nil {
+				dialErr = ctx.Err()
 			}
 		}
-		if !locked && dialErr != nil && record.State == SessionUnreachable {
-			_ = os.Remove(metadata.Socket)
-			_ = os.Remove(path)
-			_ = os.Remove(r.ownershipPath(metadata.Name))
-			if includeStale {
-				record.State = SessionStale
-				records = append(records, record)
-			}
-			continue
+	} else {
+		var mismatch *VersionMismatchError
+		if errors.As(dialErr, &mismatch) {
+			record.State = SessionIncompatible
 		}
-		records = append(records, record)
 	}
-	sort.Slice(records, func(i, j int) bool { return records[i].Name < records[j].Name })
-	return records, nil
+	if !locked && dialErr != nil && record.State == SessionUnreachable {
+		_ = os.Remove(metadata.Socket)
+		_ = os.Remove(path)
+		_ = os.Remove(r.ownershipPath(metadata.Name))
+		if includeStale {
+			record.State = SessionStale
+			return record, true
+		}
+		return SessionRecord{}, false
+	}
+	return record, true
 }
 
 // Resolve accepts an exact NAME, a full ID, or a unique ID prefix.
@@ -418,7 +499,7 @@ func (r *Registry) Resolve(ctx context.Context, reference, clientVersion string)
 // fallback for that launch instead of silently converting stale evidence into
 // "not found" and racing an unproven supervisor.
 func (r *Registry) ResolveForAttach(ctx context.Context, reference, clientVersion string) (SessionRecord, error) {
-	records, err := r.list(ctx, clientVersion, true)
+	records, err := r.list(ctx, clientVersion, true, "", 0)
 	if err != nil {
 		return SessionRecord{}, err
 	}

--- a/internal/runtime/registry.go
+++ b/internal/runtime/registry.go
@@ -422,6 +422,11 @@ func (r *Registry) probeRecord(ctx context.Context, path string, metadata Sessio
 	record := SessionRecord{SessionMetadata: metadata, State: SessionUnreachable}
 	client, dialErr := DialContextWithIdentity(ctx, metadata.Socket, clientVersion,
 		ClientIdentity{Surface: registryProbeSurface, Label: "Kranz runtime discovery"})
+	// Only a failed dial is evidence that the socket behind this record is
+	// gone; a runtime that answered and then ran out of the caller's listing
+	// budget is alive and must keep its registration. Deleting is driven by
+	// dialErr alone, never by an inspection error recorded after a successful
+	// handshake.
 	if dialErr == nil {
 		// Client inspection methods predate context-aware discovery. Closing the
 		// probe on cancellation makes their background RPCs obey the caller's
@@ -460,11 +465,6 @@ func (r *Registry) probeRecord(ctx context.Context, path string, metadata Sessio
 			sort.Strings(surfaces)
 			record.Clients = &others
 			record.ClientSurfaces = surfaces
-		} else {
-			dialErr = clientsErr
-			if dialErr == nil {
-				dialErr = ctx.Err()
-			}
 		}
 	} else {
 		var mismatch *VersionMismatchError

--- a/internal/runtime/supervisor.go
+++ b/internal/runtime/supervisor.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unicode"
 
 	"github.com/kranz-org/kranz/internal/app"
 	"github.com/kranz-org/kranz/internal/config"
@@ -378,8 +379,30 @@ func (s *Supervisor) handshake(c *codec) (service.RunProvenance, ClientInfo, boo
 	if c.send(envelope{Type: messageResponse, ID: msg.ID, Body: body}) != nil {
 		return service.RunProvenance{}, ClientInfo{}, false
 	}
-	info := ClientInfo{Surface: req.Surface, Label: req.ClientLabel, PID: req.ClientPID, Version: req.ClientVersion, ConnectedAt: time.Now()}
-	return service.RunProvenance{Surface: req.Surface, ClientLabel: req.ClientLabel}, info, true
+	surface := sanitizeClientIdentityText(req.Surface, 32)
+	if surface == "" {
+		surface = "unknown"
+	}
+	label := sanitizeClientIdentityText(req.ClientLabel, 80)
+	info := ClientInfo{Surface: surface, Label: label, PID: req.ClientPID, Version: req.ClientVersion, ConnectedAt: time.Now()}
+	return service.RunProvenance{Surface: surface, ClientLabel: label}, info, true
+}
+
+// sanitizeClientIdentityText keeps untrusted handshake metadata safe for TUI
+// rows, logs, and CLI tables. Control and formatting code points cannot reach
+// a terminal, and a peer cannot grow a row without bound.
+func sanitizeClientIdentityText(value string, maxRunes int) string {
+	clean := make([]rune, 0, min(len([]rune(value)), maxRunes))
+	for _, char := range value {
+		if unicode.IsControl(char) || unicode.In(char, unicode.Cf, unicode.Zl, unicode.Zp) {
+			continue
+		}
+		clean = append(clean, char)
+		if len(clean) == maxRunes {
+			break
+		}
+	}
+	return string(clean)
 }
 
 func (s *Supervisor) dispatch(ctx context.Context, c *codec, msg envelope, leases *connectionLeases) {

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -44,6 +44,7 @@ type KeyMap struct {
 	Cancel        key.Binding
 	Yes           key.Binding
 	No            key.Binding
+	Runtimes      key.Binding
 }
 
 // DefaultKeyMap returns Kranz's standard keyboard bindings.
@@ -196,6 +197,10 @@ func DefaultKeyMap() KeyMap {
 		No: key.NewBinding(
 			key.WithKeys("n", "esc"),
 			key.WithHelp("n", "no"),
+		),
+		Runtimes: key.NewBinding(
+			key.WithKeys("p"),
+			key.WithHelp("p", "switch runtime"),
 		),
 	}
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kranz-org/kranz/internal/app"
 	"github.com/kranz-org/kranz/internal/config"
 	kranzlog "github.com/kranz-org/kranz/internal/log"
+	kranzruntime "github.com/kranz-org/kranz/internal/runtime"
 	usersettings "github.com/kranz-org/kranz/internal/settings"
 )
 
@@ -38,6 +39,8 @@ const (
 	ModeRunList
 	ModeRunExport
 	ModeConfirmDeleteRun
+	ModeRuntimeSwitcher
+	ModeRuntimeLost
 )
 
 type runViewMode uint8
@@ -126,16 +129,18 @@ const (
 )
 
 type operationResultMsg struct {
-	id     int
-	kind   operationKind
-	target string
-	err    error
+	id         int
+	kind       operationKind
+	target     string
+	err        error
+	sessionGen uint64
 }
 
 type actionResultMsg struct {
-	id     config.ActionID
-	result app.ActionResult
-	err    error
+	id         config.ActionID
+	result     app.ActionResult
+	err        error
+	sessionGen uint64
 }
 
 type shutdownResultMsg struct{ err error }
@@ -161,22 +166,30 @@ type releasePortResultMsg struct {
 	pid         int
 	alreadyFree bool
 	err         error
+	sessionGen  uint64
 }
 type tickMsg time.Time
 
 type configReloadMsg struct {
-	result     app.ReloadResult
-	err        error
+	result app.ReloadResult
+	err    error
+	// generation is the *configuration* generation (app.ProjectSnapshot.
+	// Generation), used to detect whether the project itself changed.
 	generation uint64
 	changed    bool
+	// sessionGen is the runtime-session generation active when this reload
+	// was dispatched, guarding against a reload begun before a switch being
+	// applied to the dashboard of a different runtime after it.
+	sessionGen uint64
 }
 
 type portDetailsMsg struct {
-	id      int
-	service string
-	details map[int]*config.PortInfo
-	err     error
-	checked time.Time
+	id         int
+	service    string
+	details    map[int]*config.PortInfo
+	err        error
+	checked    time.Time
+	sessionGen uint64
 }
 
 // Model owns Kranz's Bubble Tea state and runtime service integrations.
@@ -335,6 +348,36 @@ type Model struct {
 	shutdownErr  error
 	detachOnExit bool
 	programReady func()
+
+	// Runtime switching. rpcClient is the same value as app when the model is
+	// attached to a real local supervisor over the wire; it is nil for tests
+	// and embedders that pass another app.API implementation, which makes
+	// every field and method below a no-op rather than a nil-pointer risk.
+	rpcClient          *kranzruntime.Client
+	registry           *kranzruntime.Registry
+	sessionID          string
+	sessionRecord      kranzruntime.SessionRecord
+	sessionConfigPaths []string
+	sessionGeneration  uint64
+	uiStateCache       map[string]runtimeUIState
+	restartRuntime     func(directory string, configPaths []string) error
+
+	switcherRows        []runtimeRow
+	switcherCursor      int
+	switcherLoading     bool
+	switcherErr         string
+	switcherGeneration  uint64
+	switcherRefreshBusy bool
+	lastSwitcherRefresh time.Time
+	switcherConnecting  string
+	switchSeq           uint64
+	exiting             bool
+
+	recoveryReason      string
+	recoveryBusy        bool
+	recoveryErr         string
+	recoveryShowingList bool
+	recoverySeq         uint64
 }
 
 // ModelOptions supplies user-level preferences and their persistence path.
@@ -359,6 +402,21 @@ type ModelOptions struct {
 	// It tells the mouse watchdog that this terminal announces the moment mouse
 	// mode needs restoring, so the frequent poll can stand down.
 	FocusReported func()
+	// SessionRecord is the registry record for the runtime App is attached to.
+	// It seeds the switcher's "current" row and is what Restart runtime uses
+	// after losing the connection. Zero for an App that is not a
+	// runtime.Client (tests, embedders).
+	SessionRecord kranzruntime.SessionRecord
+	// Registry is used to discover other local runtimes for the switcher. Nil
+	// disables the switcher and recovery screen entirely (no-op), which is
+	// what every test using a fake App wants; production passes
+	// runtime.DefaultRegistry().
+	Registry *kranzruntime.Registry
+	// RestartRuntime spawns a new background supervisor for the project at
+	// directory using configPaths, the same way the executable's normal
+	// bare-launch path does — argv only, never a shell string. Nil disables
+	// "Restart runtime" in the recovery screen (tests, embedders).
+	RestartRuntime func(directory string, configPaths []string) error
 }
 
 // NewModel creates a model with default user settings and terminal detection.
@@ -369,6 +427,9 @@ func NewModel(cfg *config.Config, version string) *Model {
 // NewModelWithOptions creates a model with resolved project/user appearance.
 func NewModelWithOptions(cfg *config.Config, version string, options ModelOptions) *Model {
 	workingDirectory, _ := os.Getwd()
+	if options.SessionRecord.Directory != "" {
+		workingDirectory = options.SessionRecord.Directory
+	}
 	terminalDark := true
 	if options.DarkBackground != nil {
 		terminalDark = *options.DarkBackground
@@ -384,6 +445,7 @@ func NewModelWithOptions(cfg *config.Config, version string, options ModelOption
 	}
 	services := application.Services()
 	project := application.Project()
+	rpcClient, _ := application.(*kranzruntime.Client)
 
 	model := &Model{
 		cfg:                 application.Config(),
@@ -431,6 +493,13 @@ func NewModelWithOptions(cfg *config.Config, version string, options ModelOption
 		notifications:       make([]config.Notification, 0),
 		conflictPorts:       make(map[int]*config.PortInfo),
 		configPaths:         append([]string(nil), options.ConfigPaths...),
+		rpcClient:           rpcClient,
+		registry:            options.Registry,
+		sessionID:           project.SessionID,
+		sessionRecord:       options.SessionRecord,
+		sessionConfigPaths:  append([]string(nil), project.ConfigPaths...),
+		uiStateCache:        make(map[string]runtimeUIState),
+		restartRuntime:      options.RestartRuntime,
 	}
 	if len(model.configPaths) == 0 {
 		model.configPaths = append([]string(nil), cfg.Paths...)
@@ -466,7 +535,8 @@ func (m *Model) Init() tea.Cmd {
 	}
 	// The tick is only the backstop; read the appearance once straight away so
 	// startup does not wait a whole interval for the first answer.
-	return tea.Batch(m.pollServices(), m.scanFocusedPorts(true), m.pollSystemAppearance(), m.probeSystemAppearance())
+	return tea.Batch(m.pollServices(), m.scanFocusedPorts(true), m.pollSystemAppearance(), m.probeSystemAppearance(),
+		m.watchCurrentClientDone())
 }
 
 func (m *Model) pollServices() tea.Cmd {
@@ -511,10 +581,19 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.MouseMsg:
 		return m.handleMouseMsg(msg)
 	case operationResultMsg:
+		if msg.sessionGen != m.sessionGeneration {
+			return m, nil
+		}
 		return m.handleOperationResult(msg)
 	case actionResultMsg:
+		if msg.sessionGen != m.sessionGeneration {
+			return m, nil
+		}
 		return m.handleActionResult(msg)
 	case releasePortResultMsg:
+		if msg.sessionGen != m.sessionGeneration {
+			return m, nil
+		}
 		if msg.err != nil {
 			m.addNotification("port", msg.err.Error(), config.LogError)
 			return m, nil
@@ -572,7 +651,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.systemDark = msg.dark
 		return m, tea.Batch(poll, m.applyDetectedBackground(msg.dark, "System"))
 	case portDetailsMsg:
-		if msg.id != m.portScanID {
+		if msg.id != m.portScanID || msg.sessionGen != m.sessionGeneration {
 			return m, nil
 		}
 		m.portScanBusy = false
@@ -584,8 +663,14 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case tickMsg:
-		m.refreshServices()
 		m.expireToast()
+		if m.mode == ModeRuntimeLost {
+			// The current connection is dead: do not poll it, but keep the
+			// tick chain alive and keep the switcher list fresh if the user
+			// opened "Choose running runtime" from recovery.
+			return m, tea.Batch(m.pollServices(), m.refreshRuntimeListIfVisible())
+		}
+		m.refreshServices()
 		if requested, _ := m.app.ProjectExitRequested(); requested && !m.projectExitHandled {
 			m.projectExitHandled = true
 			return m.beginShutdown()
@@ -594,6 +679,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.pollServices(),
 			m.scanFocusedPorts(false),
 			m.reloadConfig(false),
+			m.refreshRuntimeListIfVisible(),
 		)
 	case searchNudgeMsg:
 		// Ignore a chain left over from an earlier click.
@@ -606,7 +692,18 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, m.scheduleSearchNudge(m.searchNudge)
 	case configReloadMsg:
+		if msg.sessionGen != m.sessionGeneration {
+			return m, nil
+		}
 		return m.handleConfigReload(msg)
+	case runtimeListMsg:
+		return m.handleRuntimeListMsg(msg)
+	case switchTargetMsg:
+		return m.handleSwitchTargetMsg(msg)
+	case currentRuntimeLostMsg:
+		return m.handleCurrentRuntimeLostMsg(msg)
+	case restartRuntimeMsg:
+		return m.handleRestartRuntimeMsg(msg)
 	default:
 		// textinput emits private follow-up messages for clipboard paste and
 		// cursor blinking. Feed them back to the component while the editor is

--- a/internal/ui/model_actions.go
+++ b/internal/ui/model_actions.go
@@ -192,6 +192,7 @@ func (m *Model) runInteractiveAction(id config.ActionID) tea.Cmd {
 		m.addNotification("action", id.Name+": "+err.Error(), config.LogError)
 		return nil
 	}
+	application, sessionGen := m.app, m.sessionGeneration
 	command := app.BuildInteractiveCommand(action)
 	m.addNotification("action", "Handing the terminal to "+id.Name, config.LogInfo)
 	return tea.ExecProcess(command, func(execErr error) tea.Msg {
@@ -205,11 +206,11 @@ func (m *Model) runInteractiveAction(id config.ActionID) tea.Cmd {
 				pid = command.Process.Pid
 			}
 		}
-		result, completeErr := m.app.CompleteInteractiveAction(id, lease, execErr, exitCode, pid)
+		result, completeErr := application.CompleteInteractiveAction(id, lease, execErr, exitCode, pid)
 		if execErr == nil {
 			execErr = completeErr
 		}
-		return actionResultMsg{id: id, result: result, err: execErr}
+		return actionResultMsg{id: id, result: result, err: execErr, sessionGen: sessionGen}
 	})
 }
 
@@ -225,9 +226,12 @@ func (m *Model) runAction(id config.ActionID, action config.Action) tea.Cmd {
 		return m.runInteractiveAction(id)
 	}
 	m.addNotification("action", "Running "+id.Name, config.LogInfo)
+	application, sessionGen := m.app, m.sessionGeneration
+	release := retainRuntimeApplication(application)
 	return func() tea.Msg {
-		result, err := m.app.RunAction(context.Background(), id)
-		return actionResultMsg{id: id, result: result, err: err}
+		defer release()
+		result, err := application.RunAction(context.Background(), id)
+		return actionResultMsg{id: id, result: result, err: err, sessionGen: sessionGen}
 	}
 }
 

--- a/internal/ui/model_config.go
+++ b/internal/ui/model_config.go
@@ -28,17 +28,20 @@ func (m *Model) reloadConfig(force bool) tea.Cmd {
 	}
 	m.lastConfigCheck = now
 	before := m.configGeneration
+	application, sessionGen := m.app, m.sessionGeneration
+	release := retainRuntimeApplication(application)
 	return func() tea.Msg {
+		defer release()
 		defer m.configReloadBusy.Store(false)
-		result, err := m.app.Reload(force)
+		result, err := application.Reload(force)
 		if err != nil {
-			return configReloadMsg{err: err}
+			return configReloadMsg{err: err, sessionGen: sessionGen}
 		}
-		project := m.app.Project()
+		project := application.Project()
 		if !force && project.Generation == before {
 			return nil
 		}
-		return configReloadMsg{result: result, generation: project.Generation, changed: project.Generation != before}
+		return configReloadMsg{result: result, generation: project.Generation, changed: project.Generation != before, sessionGen: sessionGen}
 	}
 }
 

--- a/internal/ui/model_keys.go
+++ b/internal/ui/model_keys.go
@@ -11,6 +11,11 @@ import (
 
 func (m *Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if msg.String() == "ctrl+c" {
+		if m.mode == ModeRuntimeLost {
+			m.recoverySeq++
+			m.cancelPendingRuntimeSwitch()
+			return m.beginDetach()
+		}
 		return m.beginShutdown()
 	}
 	if key.Matches(msg, m.keys.Shell) {
@@ -53,6 +58,10 @@ func (m *Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleRunExportKeys(msg)
 	case ModeConfirmDeleteRun:
 		return m.handleConfirmDeleteRunKeys(msg)
+	case ModeRuntimeSwitcher:
+		return m.handleRuntimeSwitcherKeys(msg)
+	case ModeRuntimeLost:
+		return m.handleRuntimeLostKeys(msg)
 	default:
 		if msg.String() == "esc" || msg.String() == "q" {
 			m.mode = ModeNormal
@@ -64,6 +73,9 @@ func (m *Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (m *Model) handleNormalKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if key.Matches(msg, m.keys.Reload) {
 		return m, tea.Batch(m.reloadConfig(true), m.probeTerminalBackground(true))
+	}
+	if key.Matches(msg, m.keys.Runtimes) {
+		return m, m.openRuntimeSwitcher()
 	}
 	if key.Matches(msg, m.keys.Open) && m.panelFocus == panelServices {
 		if m.listMode == listTags {
@@ -99,11 +111,8 @@ func (m *Model) handleNormalKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	if key.Matches(msg, m.keys.Quit) {
-		if m.app.HasRunningServices() || m.operation != "" {
-			m.mode = ModeConfirmQuit
-			return m, nil
-		}
-		return m.beginShutdown()
+		m.mode = ModeConfirmQuit
+		return m, nil
 	}
 	return m, nil
 }
@@ -302,11 +311,8 @@ func (m *Model) triggerAction(action string) (tea.Model, tea.Cmd) {
 		m.toggleAllSelection()
 		return m, nil
 	case "quit":
-		if m.app.HasRunningServices() || m.operation != "" {
-			m.mode = ModeConfirmQuit
-			return m, nil
-		}
-		return m.beginShutdown()
+		m.mode = ModeConfirmQuit
+		return m, nil
 	default:
 		return m, nil
 	}

--- a/internal/ui/model_lifecycle.go
+++ b/internal/ui/model_lifecycle.go
@@ -158,8 +158,9 @@ func (m *Model) startSelectedService() (tea.Model, tea.Cmd) {
 		return m.beginServiceStartConfirmation([]string{svc.Name}, svc.Name, false)
 	}
 	ctx, cancel := context.WithCancel(context.Background())
+	application := m.app
 	return m.beginCancelableOperation(operationStart, svc.Name, "Starting "+svc.Name, cancel, func() error {
-		return m.app.StartServicesContext(ctx, []string{svc.Name})
+		return application.StartServicesContext(ctx, []string{svc.Name})
 	})
 }
 
@@ -249,8 +250,9 @@ func (m *Model) toggleSelectedServices() (tea.Model, tea.Cmd) {
 		if m.requiresStopConfirmation(names) {
 			return m.beginServiceStopConfirmation(names, target, false)
 		}
+		application := m.app
 		return m.beginOperation(operationStopSet, target, "Stopping "+target, func() error {
-			return m.app.StopServices(names)
+			return application.StopServices(names)
 		})
 	}
 	for _, name := range names {
@@ -264,8 +266,9 @@ func (m *Model) toggleSelectedServices() (tea.Model, tea.Cmd) {
 		return m.beginServiceStartConfirmation(names, target, false)
 	}
 	ctx, cancel := context.WithCancel(context.Background())
+	application := m.app
 	return m.beginCancelableOperation(operationStartSet, target, "Starting "+target, cancel, func() error {
-		return m.app.StartServicesContext(ctx, names)
+		return application.StartServicesContext(ctx, names)
 	})
 }
 
@@ -298,8 +301,9 @@ func (m *Model) forceToggleSelectedServices() (tea.Model, tea.Cmd) {
 		if m.requiresStopConfirmation(names) {
 			return m.beginServiceStopConfirmation(names, target, true)
 		}
+		application := m.app
 		return m.beginOperation(operationForceStop, target, "Force stopping "+target, func() error {
-			return m.app.ForceStopServices(names)
+			return application.ForceStopServices(names)
 		})
 	}
 	for _, name := range names {
@@ -312,8 +316,9 @@ func (m *Model) forceToggleSelectedServices() (tea.Model, tea.Cmd) {
 	if m.requiresStartConfirmation(names, false) {
 		return m.beginServiceStartConfirmation(names, target, true)
 	}
+	application := m.app
 	return m.beginOperation(operationForceStart, target, "Force starting "+target, func() error {
-		return m.app.ForceStartServices(names)
+		return application.ForceStartServices(names)
 	})
 }
 
@@ -335,13 +340,15 @@ func (m *Model) confirmServiceStart() (tea.Model, tea.Cmd) {
 	force := m.pendingStartForce
 	m.cancelServiceStartConfirmation()
 	if force {
+		application := m.app
 		return m.beginOperation(operationForceStart, target, "Force starting "+target, func() error {
-			return m.app.ForceStartServices(names)
+			return application.ForceStartServices(names)
 		})
 	}
 	ctx, cancel := context.WithCancel(context.Background())
+	application := m.app
 	return m.beginCancelableOperation(operationStartSet, target, "Starting "+target, cancel, func() error {
-		return m.app.StartServicesContext(ctx, names)
+		return application.StartServicesContext(ctx, names)
 	})
 }
 
@@ -404,12 +411,14 @@ func (m *Model) confirmServiceStop() (tea.Model, tea.Cmd) {
 		return m.beginOperation(operationStopAll, target, "Stopping all services", m.app.StopAll)
 	}
 	if force {
+		application := m.app
 		return m.beginOperation(operationForceStop, target, "Force stopping "+target, func() error {
-			return m.app.ForceStopServices(names)
+			return application.ForceStopServices(names)
 		})
 	}
+	application := m.app
 	return m.beginOperation(operationStopSet, target, "Stopping "+target, func() error {
-		return m.app.StopServices(names)
+		return application.StopServices(names)
 	})
 }
 
@@ -433,8 +442,9 @@ func (m *Model) handleConfirmServiceStopKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd
 
 func (m *Model) beginRestart(name string) (tea.Model, tea.Cmd) {
 	m.mode = ModeNormal
+	application := m.app
 	return m.beginOperation(operationRestart, name, "Restarting "+name, func() error {
-		return m.app.RestartService(name)
+		return application.RestartService(name)
 	})
 }
 
@@ -454,9 +464,11 @@ func (m *Model) beginCancelableOperation(kind operationKind, target, label strin
 	m.operationKind = kind
 	m.operationCancel = cancel
 	m.operationID++
-	operationID := m.operationID
+	operationID, sessionGen := m.operationID, m.sessionGeneration
+	release := retainRuntimeApplication(m.app)
 	return m, func() tea.Msg {
-		return operationResultMsg{id: operationID, kind: kind, target: target, err: operation()}
+		defer release()
+		return operationResultMsg{id: operationID, kind: kind, target: target, err: operation(), sessionGen: sessionGen}
 	}
 }
 
@@ -545,6 +557,11 @@ func (m *Model) beginExit(operation string) (tea.Model, tea.Cmd) {
 		m.operation = operation
 	}
 	m.mode = ModeNormal
+	// Freeze m.app from this point on: Shutdown() reads it on the goroutine
+	// this command spawns, and a switch installing a new session afterward
+	// would otherwise race that read and could shut down the wrong runtime.
+	// Every switch entry point checks m.exiting before touching m.app.
+	m.exiting = true
 	return m, func() tea.Msg { return shutdownResultMsg{err: m.Shutdown()} }
 }
 

--- a/internal/ui/model_lifecycle_test.go
+++ b/internal/ui/model_lifecycle_test.go
@@ -88,6 +88,16 @@ func TestQuitConfirmationCanStopOrDetachRuntime(t *testing.T) {
 	})
 }
 
+func TestQuitAlwaysConfirmsWhenRuntimeHasNoRunningServices(t *testing.T) {
+	model := NewModelWithOptions(&config.Config{Project: "Idle runtime"}, "test", ModelOptions{DetachOnExit: true})
+	defer model.Shutdown()
+
+	_, command := model.handleKeyMsg(keyMessage("q"))
+	if command != nil || model.mode != ModeConfirmQuit {
+		t.Fatalf("idle runtime quit = command %v, mode %v", command, model.mode)
+	}
+}
+
 func TestQuitConfirmationMouseCanDetach(t *testing.T) {
 	model := newTestModel()
 	model.detachOnExit = false

--- a/internal/ui/model_ports.go
+++ b/internal/ui/model_ports.go
@@ -58,14 +58,16 @@ func (m *Model) scanFocusedPorts(force bool) tea.Cmd {
 	ports := append([]int(nil), svc.Config.Ports...)
 	m.portService = serviceName
 	m.portScanBusy = true
-	application := m.app
+	application, sessionGen := m.app, m.sessionGeneration
+	release := retainRuntimeApplication(application)
 	return func() tea.Msg {
+		defer release()
 		details, err := application.InspectPorts(ports)
 		if details == nil {
 			details = make(map[int]*config.PortInfo)
 		}
 		return portDetailsMsg{
-			id: scanID, service: serviceName, details: details, err: err, checked: time.Now(),
+			id: scanID, service: serviceName, details: details, err: err, checked: time.Now(), sessionGen: sessionGen,
 		}
 	}
 }
@@ -94,15 +96,17 @@ func (m *Model) handlePortConflictKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) releaseExternalPort(portNumber, expectedPID int) tea.Cmd {
-	application := m.app
+	application, sessionGen := m.app, m.sessionGeneration
+	release := retainRuntimeApplication(application)
 	return func() tea.Msg {
+		defer release()
 		alreadyFree, err := application.ReleaseExternalPort(portNumber, expectedPID)
 		if err != nil {
-			return releasePortResultMsg{port: portNumber, pid: expectedPID, err: err}
+			return releasePortResultMsg{port: portNumber, pid: expectedPID, err: err, sessionGen: sessionGen}
 		}
 		if alreadyFree {
-			return releasePortResultMsg{port: portNumber, pid: expectedPID, alreadyFree: true}
+			return releasePortResultMsg{port: portNumber, pid: expectedPID, alreadyFree: true, sessionGen: sessionGen}
 		}
-		return releasePortResultMsg{port: portNumber, pid: expectedPID}
+		return releasePortResultMsg{port: portNumber, pid: expectedPID, sessionGen: sessionGen}
 	}
 }

--- a/internal/ui/model_shell.go
+++ b/internal/ui/model_shell.go
@@ -15,7 +15,7 @@ import (
 // resumes afterwards without disturbing managed services.
 
 func (m *Model) openCommandShell() tea.Cmd {
-	command, cleanup, err := commandShell()
+	command, cleanup, err := commandShellInDirectory(m.workingDirectory)
 	if err != nil {
 		return func() tea.Msg { return shellFinishedMsg{err: err} }
 	}
@@ -27,6 +27,10 @@ func (m *Model) openCommandShell() tea.Cmd {
 }
 
 func commandShell() (*exec.Cmd, func(), error) {
+	return commandShellInDirectory("")
+}
+
+func commandShellInDirectory(directory string) (*exec.Cmd, func(), error) {
 	shell := strings.TrimSpace(os.Getenv("SHELL"))
 	if shell == "" {
 		shell = "/bin/sh"
@@ -83,6 +87,9 @@ func commandShell() (*exec.Cmd, func(), error) {
 		command = exec.Command(resolved, "-C", "bind \\co exit", "-i")
 	default:
 		command = exec.Command(resolved, "-i")
+	}
+	if directory != "" {
+		command.Dir = directory
 	}
 	return command, cleanup, nil
 }

--- a/internal/ui/model_shell.go
+++ b/internal/ui/model_shell.go
@@ -26,10 +26,11 @@ func (m *Model) openCommandShell() tea.Cmd {
 	})
 }
 
-func commandShell() (*exec.Cmd, func(), error) {
-	return commandShellInDirectory("")
-}
-
+// commandShellInDirectory builds the interactive shell handed the terminal
+// by Ctrl+O. An empty directory inherits the process's own working
+// directory; the dashboard always passes the current runtime's project
+// directory, which is not the process's own once the TUI has switched
+// runtimes.
 func commandShellInDirectory(directory string) (*exec.Cmd, func(), error) {
 	shell := strings.TrimSpace(os.Getenv("SHELL"))
 	if shell == "" {

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -985,7 +985,7 @@ func TestZshCommandShellBindsCtrlOAndPreservesEnvironment(t *testing.T) {
 	}
 	t.Setenv("SHELL", "/bin/zsh")
 	t.Setenv("ZDOTDIR", "/tmp/user-zdotdir")
-	command, cleanup, err := commandShell()
+	command, cleanup, err := commandShellInDirectory("")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/ui/mouse.go
+++ b/internal/ui/mouse.go
@@ -331,6 +331,25 @@ func (m *Model) handleOverlayMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		return m.closeOverlayOnClick(rendered, msg)
 	case ModeThemes:
 		return m.handleThemeMouseClick(rendered, msg)
+	case ModeRuntimeSwitcher:
+		return m.handleRuntimeRowClick(rendered, msg, m.closeRuntimeSwitcher)
+	case ModeRuntimeLost:
+		if m.recoveryShowingList {
+			return m.handleRuntimeRowClick(rendered, msg, func() {
+				m.cancelPendingRuntimeSwitch()
+				m.recoveryShowingList = false
+			})
+		}
+		if renderedTextHit(rendered, msg.X, msg.Y, "[r/Enter] Restart runtime") {
+			return m, m.beginRuntimeRestart()
+		}
+		if renderedTextHit(rendered, msg.X, msg.Y, "[c] Choose running runtime") {
+			return m.handleRuntimeLostKeys(keyMessage("c"))
+		}
+		if renderedTextHit(rendered, msg.X, msg.Y, "[q] Quit TUI") {
+			return m.handleRuntimeLostKeys(keyMessage("q"))
+		}
+		return m, nil
 	case ModeSearch:
 		model, command, handled := m.handleMouseKeyBindingsHandled(rendered, msg, []mouseKeyBinding{
 			{label: "[Tab]", key: "tab"},
@@ -447,6 +466,16 @@ func (m *Model) handleOverlayWheel(msg tea.MouseMsg) (tea.Model, tea.Cmd, bool) 
 			return m, nil, true
 		}
 	}
+	if m.mode == ModeRuntimeSwitcher || (m.mode == ModeRuntimeLost && m.recoveryShowingList) {
+		switch msg.Button {
+		case tea.MouseButtonWheelUp:
+			m.moveSwitcherCursor(-1)
+			return m, nil, true
+		case tea.MouseButtonWheelDown:
+			m.moveSwitcherCursor(1)
+			return m, nil, true
+		}
+	}
 	return m, nil, false
 }
 
@@ -502,6 +531,39 @@ func (m *Model) handleThemeMouseClick(rendered string, msg tea.MouseMsg) (tea.Mo
 		mouseKeyBinding{label: "[Esc] Cancel", key: "esc"},
 	)
 	return m.handleMouseKeyBindings(rendered, msg, bindings, m.handleThemeKeys)
+}
+
+// handleRuntimeRowClick gives the runtime switcher (and the recovery
+// screen's embedded copy of it) the same click/double-click behavior as
+// every other Kranz list: a single click moves the cursor, and a second
+// click on the same row within doubleClickInterval activates it, matching
+// openListOwnerOnDoubleClick's dashboard behavior (PRD 3.2).
+func (m *Model) handleRuntimeRowClick(rendered string, msg tea.MouseMsg, onClose func()) (tea.Model, tea.Cmd) {
+	for index, row := range m.switcherRows {
+		name := runtimeRowHitLabel(row)
+		if !renderedTextRegionHit(rendered, msg.X, msg.Y, name, 2, m.width) {
+			continue
+		}
+		m.switcherCursor = index
+		owner := "runtime:" + row.Record.ID
+		now := time.Now()
+		isDoubleClick := owner == m.lastListClickOwner &&
+			m.lastListClickSeq+1 == m.mousePressSequence &&
+			!m.lastListClickAt.IsZero() &&
+			now.Sub(m.lastListClickAt) >= 0 && now.Sub(m.lastListClickAt) <= doubleClickInterval
+		if isDoubleClick {
+			m.lastListClickOwner, m.lastListClickSeq, m.lastListClickAt = "", 0, time.Time{}
+			return m.connectToSwitcherSelection()
+		}
+		m.lastListClickOwner = owner
+		m.lastListClickSeq = m.mousePressSequence
+		m.lastListClickAt = now
+		return m, nil
+	}
+	if renderedTextHit(rendered, msg.X, msg.Y, "[Esc]") {
+		onClose()
+	}
+	return m, nil
 }
 
 func (m *Model) closeOverlayOnClick(rendered string, msg tea.MouseMsg) (tea.Model, tea.Cmd) {

--- a/internal/ui/run_view.go
+++ b/internal/ui/run_view.go
@@ -561,8 +561,15 @@ func formatBytes(bytes uint64) string {
 // rows already collected, the trailing blank and shortcut rows, and the modal's
 // own vertical padding are subtracted from the terminal height.
 func (m *Model) runListCapacity(headerLines int) int {
+	return capacityForHeight(m.height, headerLines)
+}
+
+// capacityForHeight is runListCapacity's underlying arithmetic, taken out so
+// a screen with no *Model — the bare-launch runtime picker — can size its
+// own list the same way the in-dashboard modals do.
+func capacityForHeight(height, headerLines int) int {
 	const trailingRows = 2 // the blank separator and the shortcut footer
-	return max(1, m.height-modalVerticalChrome-headerLines-trailingRows)
+	return max(1, height-modalVerticalChrome-headerLines-trailingRows)
 }
 
 // runListWindow centres a capacity-sized window on the cursor and reports

--- a/internal/ui/run_view.go
+++ b/internal/ui/run_view.go
@@ -505,10 +505,10 @@ func newRunListLayout(width int) []runListColumn {
 		base[adjustment.key] = column
 	}
 	if runListTableWidth(columns()) > width {
-		delete(selected, "duration")
+		selected["duration"] = false
 	}
 	if runListTableWidth(columns()) > width {
-		delete(selected, "output")
+		selected["output"] = false
 	}
 	for _, adjustment := range []struct {
 		key   string

--- a/internal/ui/run_view.go
+++ b/internal/ui/run_view.go
@@ -447,26 +447,131 @@ func (m *Model) handleRunListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+type runListColumn struct {
+	key, label string
+	width      int
+}
+
+func runListTableWidth(columns []runListColumn) int {
+	width := max(0, 2*(len(columns)-1))
+	for _, column := range columns {
+		width += column.width
+	}
+	return width
+}
+
+func newRunListLayout(width int) []runListColumn {
+	base := map[string]runListColumn{
+		"run":       {key: "run", label: "RUN", width: 5},
+		"status":    {key: "status", label: "STATUS", width: 10},
+		"start":     {key: "start", label: "START", width: 8},
+		"duration":  {key: "duration", label: "DURATION", width: 10},
+		"exit":      {key: "exit", label: "EXIT", width: 6},
+		"reason":    {key: "reason", label: "REASON", width: 14},
+		"initiator": {key: "initiator", label: "INITIATOR", width: 14},
+		"output":    {key: "output", label: "OUTPUT", width: 10},
+	}
+	selected := map[string]bool{"run": true, "status": true, "duration": true, "output": true}
+	ordered := []string{"run", "status", "start", "duration", "exit", "reason", "initiator", "output"}
+	columns := func() []runListColumn {
+		result := make([]runListColumn, 0, len(ordered))
+		for _, key := range ordered {
+			if selected[key] {
+				result = append(result, base[key])
+			}
+		}
+		return result
+	}
+
+	for _, key := range []string{"exit", "start", "reason", "initiator"} {
+		selected[key] = true
+		if runListTableWidth(columns()) > width {
+			selected[key] = false
+		}
+	}
+	if runListTableWidth(columns()) <= width {
+		return columns()
+	}
+
+	for _, adjustment := range []struct {
+		key   string
+		floor int
+	}{{"output", 6}, {"status", 8}, {"duration", 8}} {
+		if runListTableWidth(columns()) <= width {
+			break
+		}
+		column := base[adjustment.key]
+		column.width = max(adjustment.floor, column.width-(runListTableWidth(columns())-width))
+		base[adjustment.key] = column
+	}
+	if runListTableWidth(columns()) > width {
+		delete(selected, "duration")
+	}
+	if runListTableWidth(columns()) > width {
+		delete(selected, "output")
+	}
+	for _, adjustment := range []struct {
+		key   string
+		floor int
+	}{{"status", 4}, {"run", 3}} {
+		if runListTableWidth(columns()) <= width {
+			break
+		}
+		column := base[adjustment.key]
+		column.width = max(adjustment.floor, column.width-(runListTableWidth(columns())-width))
+		base[adjustment.key] = column
+	}
+	return columns()
+}
+
+func renderRunListColumns(layout []runListColumn, values map[string]string) string {
+	columns := make([]string, 0, len(layout))
+	for _, column := range layout {
+		columns = append(columns, padOrTruncate(values[column.key], column.width))
+	}
+	return strings.Join(columns, "  ")
+}
+
 func (m *Model) renderRunListView() string {
 	runs := m.filteredRunList()
-	lines := []string{ModalTitleStyle.Render(" Run history · " + runTargetLabel(m.runTarget)), ""}
+	contentWidth := flushModalContentWidth(m.width, 104)
+	rowWidth := max(3, contentWidth-2)
+	layout := newRunListLayout(rowWidth)
+	shortcutGroups := []string{"[↑/↓] Select", "[Enter] Open run", "[d] Delete"}
+	if filters := m.runStatusFilters(); len(filters) > 1 {
+		filter := m.runStatusFilter
+		if filter == "" {
+			filter = runFilterAll
+		}
+		shortcutGroups = append(shortcutGroups, "[Tab] "+filter)
+	}
+	shortcutGroups = append(shortcutGroups, "[Esc] Close")
+	shortcutRows := renderModalShortcutRows(shortcutGroups, contentWidth, lipgloss.NewStyle().Foreground(ColorDim))
+	lines := []string{ansi.Truncate(ModalTitleStyle.Render(" Run history · "+runTargetLabel(m.runTarget)), contentWidth, "…"), ""}
 	// Retention is an exception report, not a permanent header. While nothing
 	// has been lost, the budgets only told the user that nothing had been lost,
 	// in ninety characters. They appear when they explain a gap.
 	if notice := m.runRetentionNotice(); notice != "" {
-		lines = append(lines, ContextBarStyle.Render("  "+notice), "")
+		for _, wrapped := range modalTextRows(notice, contentWidth) {
+			lines = append(lines, ContextBarStyle.Render(wrapped))
+		}
+		lines = append(lines, "")
 	}
 	if len(runs) == 0 {
-		lines = append(lines, "  No runs match this filter")
+		lines = append(lines, ansi.Truncate("  No runs match this filter", contentWidth, "…"))
 	} else {
-		lines = append(lines, DetailLabelStyle.Render(fmt.Sprintf("  %-5s %-10s  %-8s  %8s  %-8s  %-18s  %-18s  %s",
-			"RUN", "STATUS", "START", "DURATION", "EXIT", "REASON", "INITIATOR", "OUTPUT")))
+		header := make(map[string]string, len(layout))
+		for _, column := range layout {
+			header[column.key] = column.label
+		}
+		lines = append(lines, DetailLabelStyle.Render("  "+renderRunListColumns(layout, header)))
 	}
 	// A target retains up to RunRetention().MaxRuns summaries, far more than any
 	// terminal can show. Without a window the modal grew past m.height, the
 	// overlay clipped the bottom, and the cursor and the shortcut footer both
 	// vanished — the list looked frozen while the selection kept moving.
-	start, visible, windowed := runListWindow(len(runs), m.runListCursor, m.runListCapacity(len(lines)))
+	start, visible, windowed := runListWindow(len(runs), m.runListCursor,
+		m.runListCapacity(len(lines)+max(0, len(shortcutRows)-1)))
 	for index := start; index < start+visible; index++ {
 		run := runs[index]
 		exit := "-"
@@ -481,8 +586,12 @@ func (m *Model) renderRunListView() string {
 		if run.ClientLabel != "" {
 			initiator += ":" + run.ClientLabel
 		}
-		line := fmt.Sprintf("  %-5s %-10s  %-8s  %8s  %-8s  %-18s  %-18s  %s", fmt.Sprintf("#%d", run.Run), run.Status,
-			run.StartedAt.Local().Format("15:04:05"), duration.Round(time.Millisecond), exit, run.StartReason, initiator, run.Output.State)
+		values := map[string]string{
+			"run": fmt.Sprintf("#%d", run.Run), "status": run.Status,
+			"start": run.StartedAt.Local().Format("15:04:05"), "duration": duration.Round(time.Millisecond).String(),
+			"exit": exit, "reason": run.StartReason, "initiator": initiator, "output": string(run.Output.State),
+		}
+		line := "  " + renderRunListColumns(layout, values)
 		if index == m.runListCursor {
 			line = SelectionStyle.Render(line)
 		}
@@ -493,15 +602,8 @@ func (m *Model) renderRunListView() string {
 	}
 	// The filter belongs with the key that changes it. As its own header line it
 	// spent a row restating "all" on the common path where nothing is filtered.
-	shortcuts := "  [↑/↓] Select  [Enter] Open run  [d] Delete"
-	if filters := m.runStatusFilters(); len(filters) > 1 {
-		filter := m.runStatusFilter
-		if filter == "" {
-			filter = runFilterAll
-		}
-		shortcuts += "  [Tab] " + filter
-	}
-	lines = append(lines, "", renderModalShortcuts(shortcuts+"  [Esc] Close", lipgloss.NewStyle().Foreground(ColorDim)))
+	lines = append(lines, "")
+	lines = append(lines, shortcutRows...)
 	return m.placeOverlay(renderFlushModal(strings.Join(lines, "\n")))
 }
 

--- a/internal/ui/run_view_test.go
+++ b/internal/ui/run_view_test.go
@@ -407,6 +407,28 @@ func TestRunListWindowsLongHistoryIntoTheTerminal(t *testing.T) {
 	}
 }
 
+func TestRunListKeepsControlsAndCoreColumnsInNarrowTerminal(t *testing.T) {
+	model := newTestModel()
+	defer model.Shutdown()
+	model.width, model.height, model.ready = 46, 18, true
+	finishTestServiceRun(t, model, "api", 0, "done")
+	model.refreshServices()
+	model.openRunList()
+
+	rendered := model.renderRunListView()
+	plain := ansi.Strip(rendered)
+	for _, expected := range []string{"RUN", "STATUS", "#1", "[Enter] Open run", "[Esc] Close"} {
+		if !strings.Contains(plain, expected) {
+			t.Fatalf("narrow run modal lost %q:\n%s", expected, plain)
+		}
+	}
+	for index, line := range strings.Split(rendered, "\n") {
+		if width := lipgloss.Width(line); width > model.width {
+			t.Fatalf("narrow run modal row %d is %d cells wide in a %d-cell terminal", index, width, model.width)
+		}
+	}
+}
+
 func TestRunListClickSelectsTheClickedRunNotItsPrefix(t *testing.T) {
 	model := newTestModel()
 	defer model.Shutdown()

--- a/internal/ui/runtime_integration_test.go
+++ b/internal/ui/runtime_integration_test.go
@@ -125,6 +125,15 @@ func emptyProjectConfig(project string) *config.Config {
 	return &config.Config{Project: project, Services: map[string]config.Service{}}
 }
 
+// serviceProjectConfig gives a test runtime one service, which is what the
+// run-history half of the UI state needs: without a service there is no run
+// target to select a run within.
+func serviceProjectConfig(project, service string) *config.Config {
+	return &config.Config{Project: project, Services: map[string]config.Service{
+		service: {Command: "sleep 60", Dir: ".", Shell: "sh"},
+	}}
+}
+
 // switchTo drives the full PRD 3.3 algorithm (discover, select, dial,
 // handshake, install) against a real target and fails the test if the
 // target never appears in discovery or the connection is refused.
@@ -155,10 +164,14 @@ func switchTo(t *testing.T, model *Model, target kranzruntime.SessionRecord) {
 
 func TestRuntimeSwitcherEndToEndSwitchesAndRestoresState(t *testing.T) {
 	registry := testRegistry(t)
-	alpha := startTestRuntime(t, registry, "switch-alpha", emptyProjectConfig("Alpha"), t.TempDir())
+	alpha := startTestRuntime(t, registry, "switch-alpha", serviceProjectConfig("Alpha", "api"), t.TempDir())
 	beta := startTestRuntime(t, registry, "switch-beta", emptyProjectConfig("Beta"), t.TempDir())
 
 	model := newSwitchableTestModel(t, registry, alpha, ModelOptions{})
+	if err := alpha.client.StartServicesContext(context.Background(), []string{"api"}); err != nil {
+		t.Fatalf("start api: %v", err)
+	}
+	model.refreshRunSummaries()
 	if model.cfg.Project != "Alpha" {
 		t.Fatalf("initial project = %q, want Alpha", model.cfg.Project)
 	}
@@ -168,6 +181,13 @@ func TestRuntimeSwitcherEndToEndSwitchesAndRestoresState(t *testing.T) {
 	// restore it on return, is unambiguous.
 	model.panelFocus = panelDetails
 	model.wrapLogs = true
+	// The run half of PRD 3.4's field list: which run is open, and where its
+	// output is scrolled. Both are derived state elsewhere in the model, so
+	// they are the parts a restore is most likely to quietly drop.
+	model.syncRunTarget()
+	model.runMode, model.selectedRun, model.runFollowsLatest = runViewSingle, 1, false
+	alphaViewport := model.runViewportKey()
+	model.runViewports[alphaViewport] = runViewportState{Offset: 17, Anchor: 4}
 	model.operation = "Starting alpha"
 	oldOperationCanceled := false
 	model.operationCancel = func() { oldOperationCanceled = true }
@@ -213,6 +233,14 @@ func TestRuntimeSwitcherEndToEndSwitchesAndRestoresState(t *testing.T) {
 	}
 	if model.panelFocus != panelDetails || !model.wrapLogs {
 		t.Fatalf("alpha's UI state was not restored on return: panelFocus=%v wrapLogs=%v", model.panelFocus, model.wrapLogs)
+	}
+	if model.runTarget != app.ServiceRunTarget("api") || model.runMode != runViewSingle || model.selectedRun != 1 {
+		t.Fatalf("alpha's run selection was not restored: target=%#v runMode=%v selectedRun=%d",
+			model.runTarget, model.runMode, model.selectedRun)
+	}
+	if model.logOffset != 17 || model.logAnchor != 4 {
+		t.Fatalf("alpha's run history scroll position was not restored: offset=%d anchor=%d",
+			model.logOffset, model.logAnchor)
 	}
 
 	switchTo(t, model, beta.record)

--- a/internal/ui/runtime_integration_test.go
+++ b/internal/ui/runtime_integration_test.go
@@ -1,0 +1,403 @@
+package ui
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/kranz-org/kranz/internal/app"
+	"github.com/kranz-org/kranz/internal/config"
+	kranzruntime "github.com/kranz-org/kranz/internal/runtime"
+)
+
+// testRuntime is one real local supervisor, registered in a real (temp)
+// registry and reachable over a real Unix socket — the same stack a live
+// `kranz up -d` builds — so the switching tests below exercise the actual
+// discovery, handshake, and RPC path rather than a fake app.API.
+type testRuntime struct {
+	name       string
+	local      *app.Local
+	supervisor *kranzruntime.Supervisor
+	session    *kranzruntime.SessionHandle
+	client     *kranzruntime.Client
+	record     kranzruntime.SessionRecord
+	serveErr   chan error
+	closed     bool
+}
+
+func startTestRuntime(t *testing.T, registry *kranzruntime.Registry, name string, cfg *config.Config, directory string) *testRuntime {
+	t.Helper()
+	session, err := registry.Acquire(name)
+	if err != nil {
+		t.Fatalf("acquire %s: %v", name, err)
+	}
+	metadata, err := session.Prepare(cfg.Project, "test", "background", directory)
+	if err != nil {
+		t.Fatalf("prepare %s: %v", name, err)
+	}
+	local := app.NewLocal(cfg, []string{directory + "/kranz.yaml"}, app.Options{SessionID: metadata.ID})
+	supervisor := kranzruntime.NewSupervisor(local)
+	if err := supervisor.Listen(metadata.Socket); err != nil {
+		t.Fatalf("listen %s: %v", name, err)
+	}
+	if err := session.Publish(); err != nil {
+		t.Fatalf("publish %s: %v", name, err)
+	}
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- supervisor.Serve() }()
+
+	var client *kranzruntime.Client
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		client, err = kranzruntime.DialWithIdentity(metadata.Socket, "test",
+			kranzruntime.ClientIdentity{Surface: "tui", Label: "test-" + name})
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("dial %s: %v", name, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	record, err := registry.Resolve(context.Background(), name, "test")
+	if err != nil {
+		t.Fatalf("resolve %s: %v", name, err)
+	}
+
+	rt := &testRuntime{name: name, local: local, supervisor: supervisor, session: session, client: client, record: record, serveErr: serveErr}
+	t.Cleanup(rt.stop)
+	return rt
+}
+
+// stop tears the runtime down as if its process had exited: connections
+// severed and its registry entry released. Idempotent, so it is safe both
+// to call explicitly (to simulate a crash mid-test) and again from cleanup.
+func (rt *testRuntime) stop() {
+	if rt.closed {
+		return
+	}
+	rt.closed = true
+	_ = rt.client.Close()
+	_ = rt.supervisor.Close()
+	<-rt.serveErr
+	_ = rt.session.Close()
+	_ = rt.local.Shutdown()
+}
+
+func testRegistry(t *testing.T) *kranzruntime.Registry {
+	t.Helper()
+	registry, err := kranzruntime.NewRegistry(t.TempDir())
+	if err != nil {
+		t.Fatalf("new registry: %v", err)
+	}
+	return registry
+}
+
+// fireOnce invokes cmd exactly once and, if it produced a message, feeds it
+// through Update. It intentionally does not chase batched or long-blocking
+// follow-up commands (a poll tick, watchCurrentClientDone's wait on Done())
+// — tests drive exactly the message under test and assert on its effect.
+func fireOnce(model *Model, cmd tea.Cmd) tea.Cmd {
+	if cmd == nil {
+		return nil
+	}
+	msg := cmd()
+	if msg == nil {
+		return nil
+	}
+	_, next := model.Update(msg)
+	return next
+}
+
+func newSwitchableTestModel(t *testing.T, registry *kranzruntime.Registry, current *testRuntime, options ModelOptions) *Model {
+	t.Helper()
+	options.App = current.client
+	options.Registry = registry
+	options.SessionRecord = current.record
+	model := NewModelWithOptions(current.client.Config(), "test", options)
+	t.Cleanup(func() { _ = model.Shutdown() })
+	return model
+}
+
+func emptyProjectConfig(project string) *config.Config {
+	return &config.Config{Project: project, Services: map[string]config.Service{}}
+}
+
+// switchTo drives the full PRD 3.3 algorithm (discover, select, dial,
+// handshake, install) against a real target and fails the test if the
+// target never appears in discovery or the connection is refused.
+func switchTo(t *testing.T, model *Model, target kranzruntime.SessionRecord) {
+	t.Helper()
+	next := fireOnce(model, model.openRuntimeSwitcher())
+	_ = next
+	found := false
+	for index, row := range model.switcherRows {
+		if row.Record.ID == target.ID {
+			model.switcherCursor = index
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("target %s not discovered; rows=%#v (switcherErr=%q)", target.Name, model.switcherRows, model.switcherErr)
+	}
+	_, cmd := model.connectToSwitcherSelection()
+	if cmd == nil {
+		t.Fatal("connectToSwitcherSelection produced no command")
+	}
+	fireOnce(model, cmd)
+	if model.switcherErr != "" {
+		t.Fatalf("switch to %s failed: %s", target.Name, model.switcherErr)
+	}
+}
+
+func TestRuntimeSwitcherEndToEndSwitchesAndRestoresState(t *testing.T) {
+	registry := testRegistry(t)
+	alpha := startTestRuntime(t, registry, "switch-alpha", emptyProjectConfig("Alpha"), t.TempDir())
+	beta := startTestRuntime(t, registry, "switch-beta", emptyProjectConfig("Beta"), t.TempDir())
+
+	model := newSwitchableTestModel(t, registry, alpha, ModelOptions{})
+	if model.cfg.Project != "Alpha" {
+		t.Fatalf("initial project = %q, want Alpha", model.cfg.Project)
+	}
+	firstGeneration := model.sessionGeneration
+
+	// Mark Alpha's UI state distinctly so a bleed into Beta, or a failure to
+	// restore it on return, is unambiguous.
+	model.panelFocus = panelDetails
+	model.wrapLogs = true
+	model.operation = "Starting alpha"
+	oldOperationCanceled := false
+	model.operationCancel = func() { oldOperationCanceled = true }
+	model.logEntries[app.ServiceRunTarget("shared-name")] = []config.LogEntry{{Text: "alpha-only"}}
+
+	switchTo(t, model, beta.record)
+	if model.cfg.Project != "Beta" {
+		t.Fatalf("after switch, project = %q, want Beta", model.cfg.Project)
+	}
+	if model.sessionID != beta.record.ID {
+		t.Fatalf("sessionID = %q, want %q", model.sessionID, beta.record.ID)
+	}
+	if model.sessionGeneration == firstGeneration {
+		t.Fatal("sessionGeneration did not advance across a switch")
+	}
+	// Beta was never visited before: it gets Kranz's ordinary defaults, not
+	// whatever Alpha happened to be showing.
+	if model.panelFocus != panelServices || model.wrapLogs {
+		t.Fatalf("beta inherited alpha's UI state: panelFocus=%v wrapLogs=%v", model.panelFocus, model.wrapLogs)
+	}
+	if model.workingDirectory != beta.record.Directory {
+		t.Fatalf("working directory = %q, want target runtime directory %q", model.workingDirectory, beta.record.Directory)
+	}
+	if len(model.configPaths) != 1 || model.configPaths[0] != beta.record.Directory+"/kranz.yaml" {
+		t.Fatalf("config paths = %#v, want target runtime config path", model.configPaths)
+	}
+	if model.operation != "" || model.operationCancel != nil || oldOperationCanceled {
+		t.Fatalf("old operation leaked or was canceled: operation=%q cancelSet=%v canceled=%v",
+			model.operation, model.operationCancel != nil, oldOperationCanceled)
+	}
+	if len(model.logEntries) != 0 {
+		t.Fatalf("old runtime log cache leaked into target: %#v", model.logEntries)
+	}
+	secondGeneration := model.sessionGeneration
+	model.panelFocus = panelLogs
+
+	switchTo(t, model, alpha.record)
+	if model.cfg.Project != "Alpha" {
+		t.Fatalf("after switching back, project = %q, want Alpha", model.cfg.Project)
+	}
+	if model.sessionGeneration == secondGeneration {
+		t.Fatal("sessionGeneration did not advance on the second switch")
+	}
+	if model.panelFocus != panelDetails || !model.wrapLogs {
+		t.Fatalf("alpha's UI state was not restored on return: panelFocus=%v wrapLogs=%v", model.panelFocus, model.wrapLogs)
+	}
+
+	switchTo(t, model, beta.record)
+	if model.panelFocus != panelLogs {
+		t.Fatalf("beta's second-visit state was not restored: panelFocus=%v", model.panelFocus)
+	}
+}
+
+// TestRuntimeSwitcherStaleSwitchResultIsDroppedAndConnectionRetired verifies
+// the seq guard PRD 3.3 requires: a switchTargetMsg superseded by a newer
+// attempt must never mutate the dashboard, and the connection it already
+// opened must still be closed rather than leaked.
+func TestRuntimeSwitcherStaleSwitchResultIsDroppedAndConnectionRetired(t *testing.T) {
+	registry := testRegistry(t)
+	alpha := startTestRuntime(t, registry, "stale-alpha", emptyProjectConfig("Alpha"), t.TempDir())
+	beta := startTestRuntime(t, registry, "stale-beta", emptyProjectConfig("Beta"), t.TempDir())
+
+	model := newSwitchableTestModel(t, registry, alpha, ModelOptions{})
+
+	// Stand in for an attempt that dialed and handshook beta successfully,
+	// whose result is about to arrive after a newer attempt superseded it.
+	staleClient, err := kranzruntime.DialWithIdentity(beta.record.Socket, "test",
+		kranzruntime.ClientIdentity{Surface: "tui", Label: "stale"})
+	if err != nil {
+		t.Fatalf("dial beta directly: %v", err)
+	}
+	staleMsg := switchTargetMsg{seq: model.switchSeq, record: beta.record, client: staleClient, cfg: staleClient.Config()}
+	model.switchSeq++ // a newer attempt started and will resolve on its own
+
+	fireOnce(model, func() tea.Msg { return staleMsg })
+	if model.cfg.Project != "Alpha" {
+		t.Fatalf("stale switch result changed the dashboard to %q", model.cfg.Project)
+	}
+	select {
+	case <-staleClient.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("the stale attempt's connection was never closed (leaked)")
+	}
+}
+
+// TestRuntimeLossRecoveryChooseRunningRuntime covers PRD 3.5's second
+// recovery branch: the current runtime's connection ends, and the user
+// picks another already-running one from the embedded list.
+func TestRuntimeLossRecoveryChooseRunningRuntime(t *testing.T) {
+	registry := testRegistry(t)
+	alpha := startTestRuntime(t, registry, "lost-alpha", emptyProjectConfig("Alpha"), t.TempDir())
+	beta := startTestRuntime(t, registry, "lost-beta", emptyProjectConfig("Beta"), t.TempDir())
+
+	model := newSwitchableTestModel(t, registry, alpha, ModelOptions{})
+	doneCmd := model.watchCurrentClientDone()
+	if doneCmd == nil {
+		t.Fatal("watchCurrentClientDone produced no command")
+	}
+	result := make(chan tea.Msg, 1)
+	go func() { result <- doneCmd() }()
+
+	alpha.stop() // simulate the runtime process exiting
+
+	var msg tea.Msg
+	select {
+	case msg = <-result:
+	case <-time.After(3 * time.Second):
+		t.Fatal("currentRuntimeLostMsg never arrived after the runtime stopped")
+	}
+	if _, next := model.Update(msg); next != nil {
+		fireOnce(model, next)
+	}
+	if model.mode != ModeRuntimeLost {
+		t.Fatalf("mode = %v, want ModeRuntimeLost", model.mode)
+	}
+
+	_, cmd := model.handleRuntimeLostKeys(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
+	if !model.recoveryShowingList {
+		t.Fatal("'c' did not open the running-runtime list")
+	}
+	fireOnce(model, cmd)
+	betaIndex := -1
+	for index, row := range model.switcherRows {
+		if row.Record.ID == beta.record.ID {
+			betaIndex = index
+		}
+	}
+	if betaIndex < 0 {
+		t.Fatalf("beta not discovered during recovery: %#v", model.switcherRows)
+	}
+	model.switcherCursor = betaIndex
+	_, connectCmd := model.connectToSwitcherSelection()
+	fireOnce(model, connectCmd)
+
+	if model.mode != ModeNormal {
+		t.Fatalf("mode after recovering to beta = %v, want ModeNormal", model.mode)
+	}
+	if model.cfg.Project != "Beta" {
+		t.Fatalf("project after recovery = %q, want Beta", model.cfg.Project)
+	}
+}
+
+// TestRuntimeLossRecoveryRestartSameProject covers PRD 3.5's first recovery
+// branch: restarting the same project after its runtime stopped, using a
+// fake background launcher that stands in for the real spawnBackground
+// mechanism (that mechanism itself — argv-only, no shell — is exercised by
+// cmd/kranz's own tests).
+func TestRuntimeLossRecoveryRestartSameProject(t *testing.T) {
+	registry := testRegistry(t)
+	directory := t.TempDir()
+	alpha := startTestRuntime(t, registry, "restart-alpha", emptyProjectConfig("Alpha"), directory)
+
+	var restarted *testRuntime
+	model := newSwitchableTestModel(t, registry, alpha, ModelOptions{
+		RestartRuntime: func(dir string, configPaths []string) error {
+			restarted = startTestRuntime(t, registry, "restart-alpha", emptyProjectConfig("Alpha"), dir)
+			return nil
+		},
+	})
+
+	doneCmd := model.watchCurrentClientDone()
+	result := make(chan tea.Msg, 1)
+	go func() { result <- doneCmd() }()
+	alpha.stop()
+	var msg tea.Msg
+	select {
+	case msg = <-result:
+	case <-time.After(3 * time.Second):
+		t.Fatal("currentRuntimeLostMsg never arrived")
+	}
+	model.Update(msg)
+	if model.mode != ModeRuntimeLost {
+		t.Fatalf("mode = %v, want ModeRuntimeLost", model.mode)
+	}
+
+	_, cmd := model.handleRuntimeLostKeys(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("restart produced no command")
+	}
+	fireOnce(model, cmd)
+
+	if model.recoveryErr != "" {
+		t.Fatalf("restart failed: %s", model.recoveryErr)
+	}
+	if model.mode != ModeNormal {
+		t.Fatalf("mode after restart = %v, want ModeNormal", model.mode)
+	}
+	if model.cfg.Project != "Alpha" {
+		t.Fatalf("project after restart = %q, want Alpha", model.cfg.Project)
+	}
+	if restarted == nil {
+		t.Fatal("the fake restart launcher was never invoked")
+	}
+	if model.sessionID != restarted.record.ID {
+		t.Fatalf("sessionID = %q, want the restarted session %q", model.sessionID, restarted.record.ID)
+	}
+}
+
+// TestClientSurfacesExcludeProbeAndSelf is the protocol-level check PRD 9
+// asks for: the switcher's client-surface list never counts the transient
+// discovery probe, and never counts the viewer's own connection to the
+// runtime it is currently attached to.
+func TestClientSurfacesExcludeProbeAndSelf(t *testing.T) {
+	registry := testRegistry(t)
+	alpha := startTestRuntime(t, registry, "surfaces-alpha", emptyProjectConfig("Alpha"), t.TempDir())
+
+	model := newSwitchableTestModel(t, registry, alpha, ModelOptions{})
+	fireOnce(model, model.openRuntimeSwitcher())
+
+	var row runtimeRow
+	found := false
+	for _, candidate := range model.switcherRows {
+		if candidate.Record.ID == alpha.record.ID {
+			row, found = candidate, true
+		}
+	}
+	if !found {
+		t.Fatalf("alpha not discovered: %#v", model.switcherRows)
+	}
+	if !row.IsCurrent {
+		t.Fatal("alpha should be marked as the current runtime")
+	}
+	for _, surface := range row.Record.ClientSurfaces {
+		if surface == "probe" {
+			t.Fatalf("client surfaces leaked the discovery probe: %v", row.Record.ClientSurfaces)
+		}
+	}
+	// The model's own dashboard connection to its current runtime must not
+	// inflate that runtime's own surface list (PRD 3.2).
+	if len(row.Record.ClientSurfaces) != 0 {
+		t.Fatalf("current runtime's own connection was counted as a client surface: %v", row.Record.ClientSurfaces)
+	}
+}

--- a/internal/ui/runtime_picker.go
+++ b/internal/ui/runtime_picker.go
@@ -56,7 +56,11 @@ func (p *RuntimePicker) Init() tea.Cmd {
 	return p.refresh()
 }
 
+// refresh starts one discovery round. Bumping the generation first makes any
+// still-running earlier round's result stale, so a slow probe cannot land on
+// top of a newer one.
 func (p *RuntimePicker) refresh() tea.Cmd {
+	p.generation++
 	generation := p.generation
 	registry := p.registry
 	clientVersion := p.clientVersion

--- a/internal/ui/runtime_picker.go
+++ b/internal/ui/runtime_picker.go
@@ -1,0 +1,218 @@
+package ui
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	kranzruntime "github.com/kranz-org/kranz/internal/runtime"
+)
+
+// RuntimePicker is the standalone bootstrap screen Kranz shows when it is
+// launched outside a project directory (no configuration was discovered)
+// but local runtimes already exist (PRD Scenario C / 3.1). It is a small,
+// separate Bubble Tea program rather than the dashboard Model tolerating a
+// nil current session: it reuses the exact discovery, sorting, and row
+// rendering the in-dashboard switcher uses, then hands its selection back to
+// the executable, which attaches the ordinary way and starts the dashboard.
+type RuntimePicker struct {
+	registry      *kranzruntime.Registry
+	clientVersion string
+
+	rows       []runtimeRow
+	cursor     int
+	loading    bool
+	errText    string
+	generation uint64
+
+	width, height int
+	ready         bool
+
+	selected *kranzruntime.SessionRecord
+
+	lastClickID string
+	lastClickAt time.Time
+}
+
+// NewRuntimePicker constructs the picker. registry must not be nil.
+func NewRuntimePicker(registry *kranzruntime.Registry, clientVersion string) *RuntimePicker {
+	return &RuntimePicker{registry: registry, clientVersion: clientVersion, loading: true}
+}
+
+// Selected returns the runtime the user picked, if the program ended that
+// way. It returns false if the user quit without choosing one.
+func (p *RuntimePicker) Selected() (kranzruntime.SessionRecord, bool) {
+	if p.selected == nil {
+		return kranzruntime.SessionRecord{}, false
+	}
+	return *p.selected, true
+}
+
+type runtimePickerTickMsg struct{}
+
+func (p *RuntimePicker) Init() tea.Cmd {
+	return p.refresh()
+}
+
+func (p *RuntimePicker) refresh() tea.Cmd {
+	generation := p.generation
+	registry := p.registry
+	clientVersion := p.clientVersion
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), runtimeDiscoveryTimeout)
+		defer cancel()
+		rows, err := discoverRuntimeRows(ctx, registry, clientVersion, "")
+		return runtimeListMsg{generation: generation, rows: rows, err: err}
+	}
+}
+
+func (p *RuntimePicker) tick() tea.Cmd {
+	return tea.Tick(switcherRefreshInterval, func(time.Time) tea.Msg { return runtimePickerTickMsg{} })
+}
+
+func (p *RuntimePicker) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		p.width, p.height, p.ready = msg.Width, msg.Height, true
+		return p, nil
+	case runtimePickerTickMsg:
+		return p, p.refresh()
+	case runtimeListMsg:
+		if msg.generation != p.generation {
+			return p, nil
+		}
+		p.loading = false
+		if msg.err != nil {
+			p.errText = msg.err.Error()
+			return p, p.tick()
+		}
+		p.errText = ""
+		previousID := ""
+		if p.cursor >= 0 && p.cursor < len(p.rows) {
+			previousID = p.rows[p.cursor].Record.ID
+		}
+		p.rows = msg.rows
+		p.cursor = -1
+		for index, row := range p.rows {
+			if row.Record.ID == previousID {
+				p.cursor = index
+				break
+			}
+		}
+		if p.cursor < 0 {
+			for index, row := range p.rows {
+				if row.Selectable {
+					p.cursor = index
+					break
+				}
+			}
+		}
+		if p.cursor < 0 && len(p.rows) > 0 {
+			p.cursor = 0
+		}
+		return p, p.tick()
+	case tea.KeyMsg:
+		return p.handleKey(msg)
+	case tea.MouseMsg:
+		return p.handleMouse(msg)
+	}
+	return p, nil
+}
+
+func (p *RuntimePicker) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	msg = normalizeShortcutKey(msg)
+	switch msg.String() {
+	case "up", "k":
+		if len(p.rows) > 0 {
+			p.cursor = max(0, p.cursor-1)
+		}
+	case "down", "j":
+		if len(p.rows) > 0 {
+			p.cursor = min(len(p.rows)-1, p.cursor+1)
+		}
+	case "enter":
+		return p.selectCurrent()
+	case "esc", "q", "ctrl+c":
+		return p, tea.Quit
+	}
+	return p, nil
+}
+
+func (p *RuntimePicker) selectCurrent() (tea.Model, tea.Cmd) {
+	if p.cursor < 0 || p.cursor >= len(p.rows) || !p.rows[p.cursor].Selectable {
+		return p, nil
+	}
+	record := p.rows[p.cursor].Record
+	p.selected = &record
+	return p, tea.Quit
+}
+
+func (p *RuntimePicker) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	switch msg.Button {
+	case tea.MouseButtonWheelUp:
+		if len(p.rows) > 0 {
+			p.cursor = max(0, p.cursor-1)
+		}
+		return p, nil
+	case tea.MouseButtonWheelDown:
+		if len(p.rows) > 0 {
+			p.cursor = min(len(p.rows)-1, p.cursor+1)
+		}
+		return p, nil
+	}
+	if msg.Action != tea.MouseActionPress || msg.Button != tea.MouseButtonLeft {
+		return p, nil
+	}
+	rendered := p.View()
+	for index, row := range p.rows {
+		if !renderedTextRegionHit(rendered, msg.X, msg.Y, runtimeRowHitLabel(row), 2, p.width) {
+			continue
+		}
+		p.cursor = index
+		now := time.Now()
+		if p.lastClickID == row.Record.ID && !p.lastClickAt.IsZero() && now.Sub(p.lastClickAt) >= 0 && now.Sub(p.lastClickAt) <= doubleClickInterval {
+			p.lastClickID, p.lastClickAt = "", time.Time{}
+			return p.selectCurrent()
+		}
+		p.lastClickID, p.lastClickAt = row.Record.ID, now
+		return p, nil
+	}
+	if renderedTextHit(rendered, msg.X, msg.Y, "[q] Quit") {
+		return p, tea.Quit
+	}
+	return p, nil
+}
+
+func (p *RuntimePicker) View() string {
+	if !p.ready {
+		return ""
+	}
+	lines := []string{
+		ModalTitleStyle.Render(" Kranz "),
+		"",
+		"  No Kranz configuration was found in this directory.",
+		"  Choose a local runtime to attach to, or press q to quit.",
+		"",
+	}
+	if p.errText != "" {
+		lines = append(lines, ContextBarStyle.Render("  "+p.errText), "")
+	} else if p.loading && len(p.rows) == 0 {
+		lines = append(lines, "  Discovering local runtimes…", "")
+	}
+	rowLines := renderRuntimeRowLines(p.rows, p.cursor, capacityForHeight(p.height, len(lines)), p.width)
+	if len(rowLines) == 0 && p.errText == "" && !p.loading {
+		lines = append(lines, "  No local runtimes are registered")
+	} else {
+		lines = append(lines, rowLines...)
+	}
+	lines = append(lines, "", runtimeModalShortcuts("  [↑/↓ · j/k] Select  [Enter] Connect  [q] Quit"))
+	// The picker has no dashboard to overlay, so it centres the same modal on
+	// an empty canvas instead of calling placeOverlay. The chrome, the row
+	// rendering, and the shortcut strip are the ones the in-dashboard
+	// switcher uses, so the two screens are recognisably the same modal.
+	modal := renderFlushModal(strings.Join(lines, "\n"))
+	centred := lipgloss.Place(p.width, p.height, lipgloss.Center, lipgloss.Center, modal)
+	return frameToTerminal(centred, p.width, p.height)
+}

--- a/internal/ui/runtime_picker.go
+++ b/internal/ui/runtime_picker.go
@@ -189,25 +189,30 @@ func (p *RuntimePicker) View() string {
 	if !p.ready {
 		return ""
 	}
-	lines := []string{
-		ModalTitleStyle.Render(" Kranz "),
-		"",
-		"  No Kranz configuration was found in this directory.",
-		"  Choose a local runtime to attach to, or press q to quit.",
-		"",
-	}
+	contentWidth := flushModalContentWidth(p.width, 110)
+	shortcutRows := renderModalShortcutRows([]string{"[↑/↓ · j/k] Select", "[Enter] Connect", "[q] Quit"}, contentWidth, lipgloss.NewStyle().Foreground(ColorDim))
+	lines := []string{ModalTitleStyle.Render(" Kranz "), ""}
+	lines = append(lines, modalTextRows("No Kranz configuration was found in this directory.", contentWidth)...)
+	lines = append(lines, modalTextRows("Choose a local runtime to attach to, or press q to quit.", contentWidth)...)
+	lines = append(lines, "")
 	if p.errText != "" {
-		lines = append(lines, ContextBarStyle.Render("  "+p.errText), "")
+		for _, line := range modalTextRows(p.errText, contentWidth) {
+			lines = append(lines, ContextBarStyle.Render(line))
+		}
+		lines = append(lines, "")
 	} else if p.loading && len(p.rows) == 0 {
-		lines = append(lines, "  Discovering local runtimes…", "")
+		lines = append(lines, modalTextRows("Discovering local runtimes…", contentWidth)...)
+		lines = append(lines, "")
 	}
-	rowLines := renderRuntimeRowLines(p.rows, p.cursor, capacityForHeight(p.height, len(lines)), p.width)
+	rowLines := renderRuntimeRowLines(p.rows, p.cursor,
+		capacityForHeight(p.height, len(lines)+max(0, len(shortcutRows)-1)), contentWidth)
 	if len(rowLines) == 0 && p.errText == "" && !p.loading {
-		lines = append(lines, "  No local runtimes are registered")
+		lines = append(lines, modalTextRows("No local runtimes are registered", contentWidth)...)
 	} else {
 		lines = append(lines, rowLines...)
 	}
-	lines = append(lines, "", runtimeModalShortcuts("  [↑/↓ · j/k] Select  [Enter] Connect  [q] Quit"))
+	lines = append(lines, "")
+	lines = append(lines, shortcutRows...)
 	// The picker has no dashboard to overlay, so it centres the same modal on
 	// an empty canvas instead of calling placeOverlay. The chrome, the row
 	// rendering, and the shortcut strip are the ones the in-dashboard

--- a/internal/ui/runtime_recovery.go
+++ b/internal/ui/runtime_recovery.go
@@ -113,7 +113,7 @@ func (m *Model) handleRuntimeLostKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // paths — never a shell string built from user input (PRD 7) — then polls
 // the registry until it publishes and answers a handshake.
 func (m *Model) beginRuntimeRestart() tea.Cmd {
-	if m.restartRuntime == nil || !m.switcherSupported() || m.recoveryBusy {
+	if m.restartRuntime == nil || !m.switcherSupported() || m.recoveryBusy || m.exiting {
 		return nil
 	}
 	m.recoveryBusy = true

--- a/internal/ui/runtime_recovery.go
+++ b/internal/ui/runtime_recovery.go
@@ -1,0 +1,178 @@
+package ui
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/kranz-org/kranz/internal/config"
+	kranzruntime "github.com/kranz-org/kranz/internal/runtime"
+)
+
+// Loss-of-current-runtime recovery (PRD 3.5): closing the current
+// connection no longer quits the TUI. It moves the dashboard into
+// ModeRuntimeLost, which offers restarting the same project or choosing
+// another already-running one, without ever restarting automatically.
+
+// runtimeRestartTimeout bounds how long "Restart runtime" waits for the new
+// supervisor to publish itself to the registry and answer a handshake.
+const runtimeRestartTimeout = 15 * time.Second
+
+// restartPollInterval paces the registry polls "Restart runtime" makes while
+// waiting for the new supervisor to publish its session.
+const restartPollInterval = 200 * time.Millisecond
+
+// currentRuntimeLostMsg reports that the current session's connection ended.
+// sessionGen guards against a connection retired by a switch (whose Done()
+// channel also closes) being mistaken for losing the runtime the dashboard
+// is now showing.
+type currentRuntimeLostMsg struct {
+	sessionGen uint64
+}
+
+// watchCurrentClientDone waits on the current connection's Done() channel.
+// It is restarted on every successful switch and every successful recovery,
+// each time bound to the connection and generation active at that moment.
+func (m *Model) watchCurrentClientDone() tea.Cmd {
+	if m.rpcClient == nil {
+		return nil
+	}
+	client := m.rpcClient
+	sessionGen := m.sessionGeneration
+	return func() tea.Msg {
+		<-client.Done()
+		return currentRuntimeLostMsg{sessionGen: sessionGen}
+	}
+}
+
+func (m *Model) handleCurrentRuntimeLostMsg(msg currentRuntimeLostMsg) (tea.Model, tea.Cmd) {
+	if msg.sessionGen != m.sessionGeneration || m.exiting || m.mode == ModeRuntimeLost {
+		return m, nil
+	}
+	m.mode = ModeRuntimeLost
+	m.recoveryReason = "Runtime stopped"
+	m.recoveryErr = ""
+	m.recoveryBusy = false
+	m.recoveryShowingList = false
+	return m, nil
+}
+
+// restartRuntimeMsg carries the outcome of "Restart runtime": either a fresh
+// connection to the newly published supervisor, or why one never appeared.
+type restartRuntimeMsg struct {
+	sessionGen uint64
+	seq        uint64
+	record     kranzruntime.SessionRecord
+	client     *kranzruntime.Client
+	cfg        *config.Config
+	err        error
+}
+
+func (m *Model) handleRuntimeLostKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.recoveryShowingList {
+		switch {
+		case key.Matches(msg, m.keys.Up):
+			m.moveSwitcherCursor(-1)
+		case key.Matches(msg, m.keys.Down):
+			m.moveSwitcherCursor(1)
+		case msg.String() == "enter":
+			return m.connectToSwitcherSelection()
+		case msg.String() == "esc":
+			m.cancelPendingRuntimeSwitch()
+			m.recoveryShowingList = false
+		}
+		return m, nil
+	}
+	switch msg.String() {
+	case "r", "R", "enter":
+		return m, m.beginRuntimeRestart()
+	case "c", "C":
+		if !m.switcherSupported() {
+			return m, nil
+		}
+		// Choosing another runtime supersedes an in-progress reattach attempt.
+		// The background process may already have started, but it must not pull
+		// this TUI away from the chooser when its delayed result arrives.
+		m.recoverySeq++
+		m.recoveryBusy = false
+		m.recoveryShowingList = true
+		m.switcherGeneration++
+		return m, m.refreshRuntimeList()
+	case "q", "Q":
+		m.recoverySeq++
+		m.cancelPendingRuntimeSwitch()
+		return m.beginDetach()
+	}
+	return m, nil
+}
+
+// beginRuntimeRestart spawns a new supervisor for the same project the lost
+// session belonged to, using only its saved absolute directory and config
+// paths — never a shell string built from user input (PRD 7) — then polls
+// the registry until it publishes and answers a handshake.
+func (m *Model) beginRuntimeRestart() tea.Cmd {
+	if m.restartRuntime == nil || !m.switcherSupported() || m.recoveryBusy {
+		return nil
+	}
+	m.recoveryBusy = true
+	m.recoveryErr = ""
+	m.recoverySeq++
+	seq := m.recoverySeq
+	sessionGen := m.sessionGeneration
+	directory := m.sessionRecord.Directory
+	configPaths := append([]string(nil), m.sessionConfigPaths...)
+	runtimeName := m.sessionRecord.Name
+	registry := m.registry
+	clientVersion := m.version
+	restart := m.restartRuntime
+	return func() tea.Msg {
+		if err := restart(directory, configPaths); err != nil {
+			return restartRuntimeMsg{sessionGen: sessionGen, seq: seq, err: err}
+		}
+		deadline := time.Now().Add(runtimeRestartTimeout)
+		for {
+			resolveCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+			record, resolveErr := registry.Resolve(resolveCtx, runtimeName, clientVersion)
+			cancel()
+			if resolveErr == nil {
+				dialCtx, dialCancel := context.WithTimeout(context.Background(), time.Second)
+				client, dialErr := kranzruntime.DialContextWithIdentity(dialCtx, record.Socket, clientVersion,
+					kranzruntime.ClientIdentity{Surface: "tui", Label: "Kranz dashboard"})
+				dialCancel()
+				if dialErr == nil {
+					cfg := client.Config()
+					if cfg != nil {
+						return restartRuntimeMsg{sessionGen: sessionGen, seq: seq, record: record, client: client, cfg: cfg}
+					}
+					_ = client.Close()
+				}
+			}
+			if time.Now().After(deadline) {
+				return restartRuntimeMsg{sessionGen: sessionGen, seq: seq, err: errors.New("the runtime did not come back up in time")}
+			}
+			time.Sleep(restartPollInterval)
+		}
+	}
+}
+
+func (m *Model) handleRestartRuntimeMsg(msg restartRuntimeMsg) (tea.Model, tea.Cmd) {
+	if msg.sessionGen != m.sessionGeneration || msg.seq != m.recoverySeq {
+		// Superseded: the user picked a different runtime from "Choose
+		// running runtime" while this restart was still in flight.
+		retireClient(msg.client)
+		return m, nil
+	}
+	m.recoveryBusy = false
+	if msg.err != nil {
+		m.recoveryErr = msg.err.Error()
+		return m, nil
+	}
+	// A restart of the same project is the one case PRD 3.4 allows carrying
+	// UI state across a new session ID: seed the new session's cache slot
+	// with what the lost session was showing, and let installSession's
+	// ordinary by-name reconciliation decide what still applies.
+	m.uiStateCache[msg.record.ID] = m.captureUIState()
+	return m.installSession(msg.record, msg.client, msg.cfg)
+}

--- a/internal/ui/runtime_rows.go
+++ b/internal/ui/runtime_rows.go
@@ -1,0 +1,274 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+
+	kranzruntime "github.com/kranz-org/kranz/internal/runtime"
+)
+
+const runtimeRowNameWidth = 22
+
+// runtimeDiscoveryTimeout bounds one registry probe round. The registry
+// itself bounds each socket dial; this additionally bounds the whole listing
+// call so a pathological number of slow sockets cannot freeze the caller.
+const runtimeDiscoveryTimeout = 3 * time.Second
+
+// runtimeRow is one line of the runtime switcher: a session record annotated
+// with the display and selection facts the modal needs, computed once so
+// rendering and key/mouse handling never re-derive them.
+type runtimeRow struct {
+	Record     kranzruntime.SessionRecord
+	IsCurrent  bool
+	Selectable bool
+	// Reason explains why Selectable is false; empty when Selectable is true.
+	Reason string
+}
+
+// runtimeListMsg carries one discovery refresh. Generation lets the caller
+// drop a result superseded by a newer refresh or by leaving the switcher.
+type runtimeListMsg struct {
+	generation uint64
+	rows       []runtimeRow
+	err        error
+}
+
+// discoverRuntimeRows lists every locally registered runtime and classifies
+// each one for display. currentSessionID marks (and always sorts first) the
+// runtime the caller is already attached to; selfPID excludes the caller's
+// own connection from that runtime's reported client surfaces.
+func discoverRuntimeRows(ctx context.Context, registry *kranzruntime.Registry, clientVersion, currentSessionID string) ([]runtimeRow, error) {
+	records, err := registry.ListForSwitcher(ctx, clientVersion, "tui", os.Getpid())
+	if err != nil {
+		return nil, err
+	}
+	rows := make([]runtimeRow, 0, len(records))
+	for _, record := range records {
+		row := runtimeRow{Record: record, IsCurrent: record.ID == currentSessionID}
+		switch record.State {
+		case kranzruntime.SessionRunning:
+			row.Selectable = !row.IsCurrent
+		case kranzruntime.SessionIncompatible:
+			row.Reason = "incompatible protocol version"
+		case kranzruntime.SessionUnreachable:
+			row.Reason = "unreachable"
+		default:
+			row.Reason = string(record.State)
+		}
+		rows = append(rows, row)
+	}
+	sortRuntimeRows(rows)
+	return rows, nil
+}
+
+// sortRuntimeRows puts the current runtime first, then orders the rest by
+// most recently started, breaking ties by name and then ID so rows do not
+// reorder between otherwise-identical refreshes.
+func sortRuntimeRows(rows []runtimeRow) {
+	sort.SliceStable(rows, func(i, j int) bool {
+		a, b := rows[i], rows[j]
+		if a.IsCurrent != b.IsCurrent {
+			return a.IsCurrent
+		}
+		if !a.Record.StartedAt.Equal(b.Record.StartedAt) {
+			return a.Record.StartedAt.After(b.Record.StartedAt)
+		}
+		if a.Record.Name != b.Record.Name {
+			return a.Record.Name < b.Record.Name
+		}
+		return a.Record.ID < b.Record.ID
+	})
+}
+
+// runtimeRowUptime formats how long a runtime has been running the same way
+// `kranz ps` does, so the switcher and the CLI never disagree about what an
+// age looks like.
+func runtimeRowUptime(record kranzruntime.SessionRecord) string {
+	d := time.Since(record.StartedAt)
+	if d < 0 {
+		d = 0
+	}
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return strconv.Itoa(int(d.Minutes())) + "m"
+	case d < 24*time.Hour:
+		return strconv.Itoa(int(d.Hours())) + "h" + strconv.Itoa(int(d.Minutes())%60) + "m"
+	default:
+		return strconv.Itoa(int(d.Hours())/24) + "d" + strconv.Itoa(int(d.Hours())%24) + "h"
+	}
+}
+
+// runtimeRowSurfaceLabel joins the deduplicated client surfaces a row is
+// reporting into the compact form the modal shows, for example "TUI · MCP".
+// It never repeats a surface and never shows a count.
+func runtimeRowSurfaceLabel(row runtimeRow) string {
+	if row.Record.State != kranzruntime.SessionRunning || len(row.Record.ClientSurfaces) == 0 {
+		return ""
+	}
+	labels := make([]string, len(row.Record.ClientSurfaces))
+	for i, surface := range row.Record.ClientSurfaces {
+		labels[i] = strings.ToUpper(surface)
+	}
+	return strings.Join(labels, " · ")
+}
+
+// runtimeRowBaseStatus is the row's status word without any client-surface
+// detail: the part PRD 3.2 keeps visible even in a narrow terminal, after
+// the path and the surface list have already given way.
+func runtimeRowBaseStatus(row runtimeRow) string {
+	if row.IsCurrent {
+		return "current"
+	}
+	switch row.Record.State {
+	case kranzruntime.SessionRunning:
+		return "started"
+	case kranzruntime.SessionIncompatible:
+		return "incompatible"
+	case kranzruntime.SessionUnreachable:
+		return "unreachable"
+	default:
+		return string(row.Record.State)
+	}
+}
+
+// runtimeRowStatusLabel is kept separate from client surfaces so "current"
+// never competes with connection information for the same table cell.
+func runtimeRowStatusLabel(row runtimeRow) string {
+	return runtimeRowBaseStatus(row)
+}
+
+func runtimeRowServicesLabel(row runtimeRow) string {
+	if row.Record.Services == nil || row.Record.Running == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%d/%d", *row.Record.Running, *row.Record.Services)
+}
+
+// runtimeRowDisplayName prefers the runtime's own name and falls back to the
+// project name, matching what `kranz ps` shows for the same session.
+func runtimeRowDisplayName(row runtimeRow) string {
+	if row.Record.Name != "" {
+		return row.Record.Name
+	}
+	return row.Record.Project
+}
+
+// runtimeRowLine lays out one row within width, dropping the path and then
+// the client-surface detail before it would ever truncate the name or the
+// base status word (PRD 3.2: "path and client surfaces shrink before name
+// and state"). It takes width explicitly rather than reading it off a
+// *Model so the bare-launch runtime picker, which has no Model, can render
+// identical rows.
+type runtimeTableLayout struct {
+	nameWidth, statusWidth, clientsWidth, servicesWidth, uptimeWidth, pathWidth int
+	showClients, showUptime, showPath                                           bool
+}
+
+func newRuntimeTableLayout(width int) runtimeTableLayout {
+	layout := runtimeTableLayout{
+		nameWidth: runtimeRowNameWidth, statusWidth: 12, clientsWidth: 16,
+		servicesWidth: 8, uptimeWidth: 7, showClients: true, showUptime: true,
+	}
+	coreWidth := func() int {
+		widths := []int{layout.nameWidth, layout.statusWidth, layout.servicesWidth}
+		if layout.showClients {
+			widths = append(widths, layout.clientsWidth)
+		}
+		if layout.showUptime {
+			widths = append(widths, layout.uptimeWidth)
+		}
+		total := 2 * (len(widths) - 1)
+		for _, columnWidth := range widths {
+			total += columnWidth
+		}
+		return total
+	}
+
+	if remaining := width - coreWidth() - 2; remaining >= 8 {
+		layout.showPath, layout.pathWidth = true, remaining
+	}
+	if coreWidth() > width {
+		layout.showPath, layout.pathWidth = false, 0
+		layout.clientsWidth = max(8, layout.clientsWidth-(coreWidth()-width))
+	}
+	if coreWidth() > width {
+		layout.nameWidth = max(12, layout.nameWidth-(coreWidth()-width))
+	}
+	if coreWidth() > width {
+		layout.showUptime = false
+	}
+	if coreWidth() > width {
+		layout.showClients = false
+	}
+	if coreWidth() > width {
+		layout.nameWidth = max(4, layout.nameWidth-(coreWidth()-width))
+	}
+	if coreWidth() > width {
+		layout.statusWidth = max(8, layout.statusWidth-(coreWidth()-width))
+	}
+	if coreWidth() > width {
+		layout.servicesWidth = max(3, layout.servicesWidth-(coreWidth()-width))
+	}
+	return layout
+}
+
+func (layout runtimeTableLayout) columns(name, status, clients, services, uptime, directory string) string {
+	columns := []string{
+		padOrTruncate(name, layout.nameWidth),
+		padOrTruncate(status, layout.statusWidth),
+	}
+	if layout.showClients {
+		columns = append(columns, padOrTruncate(clients, layout.clientsWidth))
+	}
+	columns = append(columns, padOrTruncate(services, layout.servicesWidth))
+	if layout.showUptime {
+		columns = append(columns, fmt.Sprintf("%*s", layout.uptimeWidth, ansi.Truncate(uptime, layout.uptimeWidth, "…")))
+	}
+	line := strings.Join(columns, "  ")
+	if layout.showPath && directory != "" {
+		line += "  " + ansi.Truncate(directory, layout.pathWidth, "…")
+	}
+	return line
+}
+
+func runtimeRowHeader(width int) string {
+	layout := newRuntimeTableLayout(width)
+	return layout.columns("RUNTIME", "STATUS", "CLIENTS", "SERVICES", "UPTIME", "DIRECTORY")
+}
+
+func runtimeRowLine(row runtimeRow, width int) string {
+	layout := newRuntimeTableLayout(width)
+	clients := runtimeRowSurfaceLabel(row)
+	if clients == "" {
+		clients = "-"
+	}
+	return layout.columns(
+		runtimeRowDisplayName(row), runtimeRowStatusLabel(row), clients,
+		runtimeRowServicesLabel(row), runtimeRowUptime(row.Record), row.Record.Directory,
+	)
+}
+
+func runtimeRowHitLabel(row runtimeRow) string {
+	return strings.TrimSpace(padOrTruncate(runtimeRowDisplayName(row), runtimeRowNameWidth))
+}
+
+func padOrTruncate(text string, width int) string {
+	current := lipgloss.Width(text)
+	if current == width {
+		return text
+	}
+	if current > width {
+		return ansi.Truncate(text, width, "…")
+	}
+	return text + strings.Repeat(" ", width-current)
+}

--- a/internal/ui/runtime_rows.go
+++ b/internal/ui/runtime_rows.go
@@ -43,8 +43,8 @@ type runtimeListMsg struct {
 
 // discoverRuntimeRows lists every locally registered runtime and classifies
 // each one for display. currentSessionID marks (and always sorts first) the
-// runtime the caller is already attached to; selfPID excludes the caller's
-// own connection from that runtime's reported client surfaces.
+// runtime the caller is already attached to; this process's own PID excludes
+// its dashboard connection from that runtime's reported client surfaces.
 func discoverRuntimeRows(ctx context.Context, registry *kranzruntime.Registry, clientVersion, currentSessionID string) ([]runtimeRow, error) {
 	records, err := registry.ListForSwitcher(ctx, clientVersion, "tui", os.Getpid())
 	if err != nil {
@@ -57,11 +57,11 @@ func discoverRuntimeRows(ctx context.Context, registry *kranzruntime.Registry, c
 		case kranzruntime.SessionRunning:
 			row.Selectable = !row.IsCurrent
 		case kranzruntime.SessionIncompatible:
-			row.Reason = "incompatible protocol version"
+			row.Reason = "This runtime speaks a different protocol version. Update Kranz to attach to it."
 		case kranzruntime.SessionUnreachable:
-			row.Reason = "unreachable"
+			row.Reason = "This runtime is registered but is not answering. The list keeps retrying it."
 		default:
-			row.Reason = string(record.State)
+			row.Reason = "This runtime reports state " + string(record.State) + " and cannot be attached to."
 		}
 		rows = append(rows, row)
 	}
@@ -88,9 +88,12 @@ func sortRuntimeRows(rows []runtimeRow) {
 	})
 }
 
-// runtimeRowUptime formats how long a runtime has been running the same way
-// `kranz ps` does, so the switcher and the CLI never disagree about what an
-// age looks like.
+// runtimeRowUptime formats how long a runtime has been running. It follows
+// cmd/kranz's shortDuration for every unit above a minute, and deliberately
+// differs below one: a table read at a glance says "just now" where a CLI
+// column that is scanned for exact values says "42s". It is a copy rather
+// than a call because shortDuration lives in package main and cannot be
+// imported here; change the two together.
 func runtimeRowUptime(record kranzruntime.SessionRecord) string {
 	d := time.Since(record.StartedAt)
 	if d < 0 {
@@ -122,10 +125,10 @@ func runtimeRowSurfaceLabel(row runtimeRow) string {
 	return strings.Join(labels, " · ")
 }
 
-// runtimeRowBaseStatus is the row's status word without any client-surface
-// detail: the part PRD 3.2 keeps visible even in a narrow terminal, after
-// the path and the surface list have already given way.
-func runtimeRowBaseStatus(row runtimeRow) string {
+// runtimeRowStatusLabel is the row's status word on its own, never merged
+// with client-surface detail: PRD 3.2 keeps it visible even in a narrow
+// terminal, after the path and the surface list have already given way.
+func runtimeRowStatusLabel(row runtimeRow) string {
 	if row.IsCurrent {
 		return "current"
 	}
@@ -139,12 +142,6 @@ func runtimeRowBaseStatus(row runtimeRow) string {
 	default:
 		return string(row.Record.State)
 	}
-}
-
-// runtimeRowStatusLabel is kept separate from client surfaces so "current"
-// never competes with connection information for the same table cell.
-func runtimeRowStatusLabel(row runtimeRow) string {
-	return runtimeRowBaseStatus(row)
 }
 
 func runtimeRowServicesLabel(row runtimeRow) string {
@@ -163,12 +160,9 @@ func runtimeRowDisplayName(row runtimeRow) string {
 	return row.Record.Project
 }
 
-// runtimeRowLine lays out one row within width, dropping the path and then
-// the client-surface detail before it would ever truncate the name or the
-// base status word (PRD 3.2: "path and client surfaces shrink before name
-// and state"). It takes width explicitly rather than reading it off a
-// *Model so the bare-launch runtime picker, which has no Model, can render
-// identical rows.
+// runtimeTableLayout is the column budget one runtime table was laid out
+// with: which optional columns survived the available width, and how wide
+// each surviving column ended up.
 type runtimeTableLayout struct {
 	nameWidth, statusWidth, clientsWidth, servicesWidth, uptimeWidth, pathWidth int
 	showClients, showUptime, showPath                                           bool
@@ -246,6 +240,12 @@ func runtimeRowHeader(width int) string {
 	return layout.columns("RUNTIME", "STATUS", "CLIENTS", "SERVICES", "UPTIME", "DIRECTORY")
 }
 
+// runtimeRowLine lays out one row within width, dropping the path and then
+// the client-surface detail before it would ever truncate the name or the
+// status word (PRD 3.2: "path and client surfaces shrink before name and
+// state"). It takes width explicitly rather than reading it off a *Model so
+// the bare-launch runtime picker, which has no Model, can render identical
+// rows.
 func runtimeRowLine(row runtimeRow, width int) string {
 	layout := newRuntimeTableLayout(width)
 	clients := runtimeRowSurfaceLabel(row)

--- a/internal/ui/runtime_state.go
+++ b/internal/ui/runtime_state.go
@@ -206,22 +206,60 @@ func (m *Model) applyUIState(state runtimeUIState) {
 		_ = m.pinnedSearcher.SetPattern(state.pinnedPattern)
 	}
 
+	// runTarget is derived from the focus restored above rather than cached,
+	// so the two can never disagree about which target's runs the fields
+	// below describe. It has to be derived *before* them: syncRunTarget
+	// treats an unset runTarget as entering a new target and resets the run
+	// selection to that target's defaults, which would discard exactly what
+	// this function is restoring.
+	m.runTarget = app.RunTarget{}
+	m.syncRunTarget()
+
 	m.runMode = state.runMode
 	m.selectedRun = state.selectedRun
 	m.runFollowsLatest = state.runFollowsLatest
 	m.runListCursor = state.runListCursor
 	m.runStatusFilter = state.runStatusFilter
 	m.runViewports = copyViewportMap(state.runViewports)
+	m.reconcileRestoredRunSelection()
+	// syncRunTarget skipped its own restore while runTarget was still being
+	// established; the log panel has to be pointed at the cached viewport now
+	// that both the target and the selected run are back.
+	m.restoreRunViewport()
 	m.notifMu.Lock()
 	m.notifications = append([]config.Notification(nil), state.notifications...)
 	m.toastMessage, m.toastTimer = state.toastMessage, state.toastTimer
 	m.notifMu.Unlock()
-	// runTarget itself is deliberately left for syncRunTarget to derive from
-	// the focus just restored above: it recomputes on every render already,
-	// and deriving it here as well would let the two disagree about which
-	// target's runs m.selectedRun and m.runViewports actually describe.
-	m.runTarget = app.RunTarget{}
-	m.syncRunTarget()
+}
+
+// reconcileRestoredRunSelection keeps an exact saved run when it still
+// exists. If retention removed it while this runtime was detached, the
+// closest retained run becomes selected instead; follow-latest state always
+// advances to the current latest run.
+func (m *Model) reconcileRestoredRunSelection() {
+	if m.runMode != runViewSingle {
+		return
+	}
+	runs := m.runsForTarget(m.runTarget)
+	if m.runFollowsLatest || m.selectedRun == 0 {
+		m.selectedRun = latestRun(runs)
+		return
+	}
+	closest := uint32(0)
+	closestDistance := ^uint32(0)
+	for _, run := range runs {
+		if run.Run == m.selectedRun {
+			return
+		}
+		distance := run.Run - m.selectedRun
+		if run.Run < m.selectedRun {
+			distance = m.selectedRun - run.Run
+		}
+		if distance < closestDistance {
+			closest, closestDistance = run.Run, distance
+		}
+	}
+	m.selectedRun = closest
 }
 
 // resetUIStateToDefaults restores the values NewModelWithOptions gives a

--- a/internal/ui/runtime_state.go
+++ b/internal/ui/runtime_state.go
@@ -1,0 +1,338 @@
+package ui
+
+import (
+	"time"
+
+	"github.com/kranz-org/kranz/internal/app"
+	"github.com/kranz-org/kranz/internal/config"
+)
+
+// runtimeUIState is the volatile dashboard state Kranz keeps for one visited
+// runtime session, so returning to it looks the same as never having left.
+// It is indexed by session ID in Model.uiStateCache, lives only in process
+// memory, and is never written to disk (PRD 3.4).
+type runtimeUIState struct {
+	// populated distinguishes "no state captured yet" (a runtime visited for
+	// the first time gets the model's zero-value defaults) from a state that
+	// was genuinely captured and should be applied verbatim.
+	populated bool
+
+	focusedServiceName  string
+	focusedAction       *config.ActionID
+	focusedActionGroup  string
+	panelFocus          panelFocus
+	listMode            listMode
+	detailOffset        int
+	selectedTags        []string
+	selected            map[string]bool
+	expandedTags        map[string]bool
+	expandedActionOwner map[string]bool
+	tagCursor           int
+
+	pinnedLog     string
+	pinnedTarget  app.RunTarget
+	pinnedRunMode runViewMode
+	pinnedRun     uint32
+
+	logOffset, logAnchor         int
+	pinnedOffset, pinnedAnchor   int
+	followMode, pinnedFollow     bool
+	logPaused                    bool
+	wrapLogs, showLogTime        bool
+	searchMode, pinnedSearchMode logSearchMode
+	currentMatch, pinnedMatch    int
+	logPattern, pinnedPattern    string
+
+	runMode          runViewMode
+	selectedRun      uint32
+	runFollowsLatest bool
+	runListCursor    int
+	runStatusFilter  string
+	runViewports     map[runViewportKey]runViewportState
+
+	notifications []config.Notification
+	toastMessage  string
+	toastTimer    time.Time
+}
+
+// captureUIState snapshots every field runtimeUIState tracks from the live
+// model. Called synchronously on the Update goroutine, immediately before a
+// switch tears down the current session, so nothing here can race a
+// concurrent field write.
+func (m *Model) captureUIState() runtimeUIState {
+	m.notifMu.RLock()
+	notifications := append([]config.Notification(nil), m.notifications...)
+	toastMessage, toastTimer := m.toastMessage, m.toastTimer
+	m.notifMu.RUnlock()
+
+	state := runtimeUIState{
+		populated:           true,
+		focusedActionGroup:  m.focusedActionGroup,
+		panelFocus:          m.panelFocus,
+		listMode:            m.listMode,
+		detailOffset:        m.detailOffset,
+		selectedTags:        append([]string(nil), m.selectedTags...),
+		selected:            copyBoolMap(m.selected),
+		expandedTags:        copyBoolMap(m.expandedTags),
+		expandedActionOwner: copyBoolMap(m.expandedActionOwner),
+		tagCursor:           m.tagCursor,
+
+		pinnedLog:     m.pinnedLog,
+		pinnedTarget:  m.pinnedTarget,
+		pinnedRunMode: m.pinnedRunMode,
+		pinnedRun:     m.pinnedRun,
+
+		logOffset: m.logOffset, logAnchor: m.logAnchor,
+		pinnedOffset: m.pinnedOffset, pinnedAnchor: m.pinnedAnchor,
+		followMode: m.followMode, pinnedFollow: m.pinnedFollow,
+		logPaused:   m.logPaused,
+		wrapLogs:    m.wrapLogs,
+		showLogTime: m.showLogTime,
+
+		searchMode: m.searchMode, pinnedSearchMode: m.pinnedSearchMode,
+		currentMatch: m.currentMatch, pinnedMatch: m.pinnedMatch,
+
+		runMode:          m.runMode,
+		selectedRun:      m.selectedRun,
+		runFollowsLatest: m.runFollowsLatest,
+		runListCursor:    m.runListCursor,
+		runStatusFilter:  m.runStatusFilter,
+		runViewports:     copyViewportMap(m.runViewports),
+
+		notifications: notifications,
+		toastMessage:  toastMessage,
+		toastTimer:    toastTimer,
+	}
+	if svc := m.FocusedService(); svc != nil {
+		state.focusedServiceName = svc.Name
+	}
+	if m.focusedAction != nil {
+		id := *m.focusedAction
+		state.focusedAction = &id
+	}
+	if m.logSearcher != nil {
+		state.logPattern = m.logSearcher.Pattern()
+	}
+	if m.pinnedSearcher != nil {
+		state.pinnedPattern = m.pinnedSearcher.Pattern()
+	}
+	return state
+}
+
+// applyUIState installs state onto the model, reconciling every reference
+// against the just-fetched configuration and services of the session being
+// entered: a service, action, group, or run that no longer exists is
+// dropped rather than kept as a dangling reference (PRD 3.4's "reload
+// removes missing services/actions/runs from the restored selection").
+// Passing the zero value applies Kranz's ordinary defaults, which is what a
+// runtime visited for the first time in this process gets.
+func (m *Model) applyUIState(state runtimeUIState) {
+	if !state.populated {
+		m.resetUIStateToDefaults()
+		return
+	}
+
+	m.panelFocus = state.panelFocus
+	if m.panelFocus == 0 {
+		m.panelFocus = panelServices
+	}
+	m.listMode = state.listMode
+	m.detailOffset = max(0, state.detailOffset)
+	m.selectedTags = filterExistingTags(state.selectedTags, m.cfg)
+	m.selected = filterExistingServices(state.selected, m.cfg)
+	m.expandedTags = copyBoolMap(state.expandedTags)
+	m.expandedActionOwner = copyBoolMap(state.expandedActionOwner)
+	m.tagCursor = state.tagCursor
+
+	m.focusedAction = nil
+	m.focusedActionGroup = ""
+	if state.focusedAction != nil {
+		if _, exists := m.cfg.ResolveAction(*state.focusedAction); exists {
+			id := *state.focusedAction
+			m.focusedAction = &id
+		}
+	}
+	if m.focusedAction == nil && state.focusedActionGroup != "" {
+		if _, exists := m.cfg.ActionGroups[state.focusedActionGroup]; exists {
+			m.focusedActionGroup = state.focusedActionGroup
+		}
+	}
+	m.focused = 0
+	if m.focusedAction == nil && m.focusedActionGroup == "" && state.focusedServiceName != "" {
+		for index, svc := range m.services {
+			if svc.Name == state.focusedServiceName {
+				m.focused = index
+				break
+			}
+		}
+	}
+	if m.focusedAction != nil || m.focusedActionGroup != "" {
+		if row := m.focusedServiceListRow(); row >= 0 {
+			m.focusServiceListRow(row)
+		}
+	}
+
+	m.pinnedLog, m.pinnedTarget, m.pinnedRunMode, m.pinnedRun = "", app.RunTarget{}, runViewCombined, 0
+	if state.pinnedTarget.Kind != "" || state.pinnedLog != "" {
+		valid := false
+		if state.pinnedTarget.Kind == app.RunKindAction {
+			_, valid = m.cfg.ResolveAction(state.pinnedTarget.Action)
+		} else {
+			name := state.pinnedLog
+			if state.pinnedTarget.Kind == app.RunKindService {
+				name = state.pinnedTarget.Name
+			}
+			_, valid = m.cfg.Services[name]
+		}
+		if valid {
+			m.pinnedLog, m.pinnedTarget, m.pinnedRunMode, m.pinnedRun = state.pinnedLog, state.pinnedTarget, state.pinnedRunMode, state.pinnedRun
+		} else if m.panelFocus == panelPinnedLogs {
+			m.panelFocus = panelLogs
+		}
+	}
+
+	m.logOffset, m.logAnchor = state.logOffset, state.logAnchor
+	m.pinnedOffset, m.pinnedAnchor = state.pinnedOffset, state.pinnedAnchor
+	m.followMode, m.pinnedFollow = state.followMode, state.pinnedFollow
+	m.logPaused = state.logPaused
+	m.wrapLogs = state.wrapLogs
+	m.showLogTime = state.showLogTime
+	m.searchMode, m.pinnedSearchMode = state.searchMode, state.pinnedSearchMode
+	m.currentMatch, m.pinnedMatch = state.currentMatch, state.pinnedMatch
+	if m.logSearcher != nil {
+		_ = m.logSearcher.SetPattern(state.logPattern)
+	}
+	if m.pinnedSearcher != nil {
+		_ = m.pinnedSearcher.SetPattern(state.pinnedPattern)
+	}
+
+	m.runMode = state.runMode
+	m.selectedRun = state.selectedRun
+	m.runFollowsLatest = state.runFollowsLatest
+	m.runListCursor = state.runListCursor
+	m.runStatusFilter = state.runStatusFilter
+	m.runViewports = copyViewportMap(state.runViewports)
+	m.notifMu.Lock()
+	m.notifications = append([]config.Notification(nil), state.notifications...)
+	m.toastMessage, m.toastTimer = state.toastMessage, state.toastTimer
+	m.notifMu.Unlock()
+	// runTarget itself is deliberately left for syncRunTarget to derive from
+	// the focus just restored above: it recomputes on every render already,
+	// and deriving it here as well would let the two disagree about which
+	// target's runs m.selectedRun and m.runViewports actually describe.
+	m.runTarget = app.RunTarget{}
+	m.syncRunTarget()
+}
+
+// resetUIStateToDefaults restores the values NewModelWithOptions gives a
+// freshly constructed dashboard, for a runtime session with no cached state.
+func (m *Model) resetUIStateToDefaults() {
+	m.focused = 0
+	m.selected = make(map[string]bool)
+	m.detailOffset = 0
+	m.logOffset, m.logAnchor = 0, 0
+	m.pinnedOffset, m.pinnedAnchor = 0, 0
+	m.panelFocus = panelServices
+	m.listMode = listServices
+	m.focusedAction = nil
+	m.focusedActionGroup = ""
+	m.expandedActionOwner = make(map[string]bool)
+	m.pinnedLog, m.pinnedTarget, m.pinnedRunMode, m.pinnedRun = "", app.RunTarget{}, runViewCombined, 0
+	m.runTarget = app.RunTarget{}
+	m.runMode = runViewCombined
+	m.selectedRun = 0
+	m.runFollowsLatest = false
+	m.runListCursor = 0
+	m.runStatusFilter = ""
+	m.runViewports = make(map[runViewportKey]runViewportState)
+	m.followMode, m.pinnedFollow = true, true
+	m.logPaused = false
+	m.wrapLogs, m.showLogTime = false, false
+	m.selectedTags = nil
+	m.tagCursor = 0
+	m.expandedTags = make(map[string]bool)
+	m.currentMatch, m.pinnedMatch = -1, -1
+	m.searchMode, m.pinnedSearchMode = searchFilter, searchFilter
+	m.notifMu.Lock()
+	m.notifications = nil
+	m.toastMessage, m.toastTimer = "", time.Time{}
+	m.notifMu.Unlock()
+	if m.logSearcher != nil {
+		_ = m.logSearcher.SetPattern("")
+	}
+	if m.pinnedSearcher != nil {
+		_ = m.pinnedSearcher.SetPattern("")
+	}
+}
+
+// resetRuntimeDataCaches drops data fetched from the previously attached
+// runtime. The supervisor remains the source of truth and the new session is
+// fetched immediately after this reset; retaining these maps would let two
+// projects with the same service or action names share log cursors and append
+// each other's output.
+func (m *Model) resetRuntimeDataCaches() {
+	m.services = nil
+	m.allServices = nil
+	m.runs = nil
+	m.actionStates = make(map[config.ActionID]app.ActionResult)
+	m.logEntries = make(map[app.RunTarget][]config.LogEntry)
+	m.actionLogLines = make(map[app.RunTarget][]cachedActionLogLine)
+	m.actionRunLogLines = make(map[app.RunTarget]map[uint32][]cachedActionLogLine)
+	m.logCursors = make(map[app.RunTarget]string)
+	m.portDetails = make(map[int]*config.PortInfo)
+	m.portError = nil
+}
+
+func copyBoolMap(source map[string]bool) map[string]bool {
+	if source == nil {
+		return make(map[string]bool)
+	}
+	dest := make(map[string]bool, len(source))
+	for key, value := range source {
+		dest[key] = value
+	}
+	return dest
+}
+
+func copyViewportMap(source map[runViewportKey]runViewportState) map[runViewportKey]runViewportState {
+	if source == nil {
+		return make(map[runViewportKey]runViewportState)
+	}
+	dest := make(map[runViewportKey]runViewportState, len(source))
+	for key, value := range source {
+		dest[key] = value
+	}
+	return dest
+}
+
+func filterExistingTags(tags []string, cfg *config.Config) []string {
+	if len(tags) == 0 {
+		return nil
+	}
+	valid := make(map[string]bool)
+	for _, svc := range cfg.Services {
+		for _, tag := range svc.Tags {
+			valid[tag] = true
+		}
+	}
+	kept := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		if valid[tag] {
+			kept = append(kept, tag)
+		}
+	}
+	return kept
+}
+
+func filterExistingServices(selected map[string]bool, cfg *config.Config) map[string]bool {
+	kept := make(map[string]bool, len(selected))
+	for name, on := range selected {
+		if !on {
+			continue
+		}
+		if _, exists := cfg.Services[name]; exists {
+			kept[name] = true
+		}
+	}
+	return kept
+}

--- a/internal/ui/runtime_state_test.go
+++ b/internal/ui/runtime_state_test.go
@@ -1,0 +1,135 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kranz-org/kranz/internal/app"
+	"github.com/kranz-org/kranz/internal/config"
+)
+
+// TestApplyUIStateDropsReferencesRemovedByConfigChange is the PRD 9 unit
+// test for "UI state serialization and reconciliation by stable names after
+// a config reload": a cached selection, tag, and pin that named a service or
+// action gone from the config it is reapplied against must be dropped
+// rather than dangling or panicking.
+func TestApplyUIStateDropsReferencesRemovedByConfigChange(t *testing.T) {
+	before := &config.Config{Project: "Before", Services: map[string]config.Service{
+		"api": {Command: "sleep 1", Dir: ".", Shell: "sh", Tags: []string{"backend"},
+			Actions: map[string]config.Action{"migrate": {Command: "echo hi"}}},
+	}}
+	model := NewModel(before, "test")
+	defer model.Shutdown()
+
+	actionID := config.ActionID{OwnerKind: config.ActionOwnerService, Owner: "api", Name: "migrate"}
+	model.focusedAction = &actionID
+	model.selectedTags = []string{"backend"}
+	model.selected = map[string]bool{"api": true}
+	model.pinnedTarget = app.ActionRunTarget(actionID)
+
+	captured := model.captureUIState()
+	if captured.focusedAction == nil || *captured.focusedAction != actionID {
+		t.Fatalf("captureUIState lost the focused action: %#v", captured.focusedAction)
+	}
+	if len(captured.selectedTags) != 1 || captured.selectedTags[0] != "backend" {
+		t.Fatalf("captureUIState lost the selected tag: %#v", captured.selectedTags)
+	}
+
+	// A config reload (or a switch back to a runtime whose config changed
+	// while away) removes the service, its action, and its tag entirely.
+	after := &config.Config{Project: "After", Services: map[string]config.Service{}}
+	model.cfg = after
+	model.app = app.NewLocal(after, nil, app.Options{})
+	model.refreshServices()
+
+	model.applyUIState(captured) // must not panic
+
+	if model.focusedAction != nil {
+		t.Fatalf("removed action survived reconciliation: %v", *model.focusedAction)
+	}
+	if len(model.selectedTags) != 0 {
+		t.Fatalf("removed tag survived reconciliation: %v", model.selectedTags)
+	}
+	if model.selected["api"] {
+		t.Fatal("removed service's selection survived reconciliation")
+	}
+	if model.pinnedTarget.Kind != "" || model.pinnedLog != "" {
+		t.Fatalf("pinned target referencing a removed action survived: %#v / %q", model.pinnedTarget, model.pinnedLog)
+	}
+}
+
+// TestApplyUIStateKeepsValidSelectionAcrossAnUnrelatedConfigChange is the
+// complementary case: a reload that leaves the referenced service, action,
+// and tag in place must not lose the user's selection just because
+// something else in the config changed.
+func TestApplyUIStateKeepsValidSelectionAcrossAnUnrelatedConfigChange(t *testing.T) {
+	cfg := &config.Config{Project: "Stable", Services: map[string]config.Service{
+		"api": {Command: "sleep 1", Dir: ".", Shell: "sh", Tags: []string{"backend"}},
+	}}
+	model := NewModel(cfg, "test")
+	defer model.Shutdown()
+
+	model.selectedTags = []string{"backend"}
+	model.panelFocus = panelDetails
+	model.detailOffset = 7
+	model.wrapLogs = true
+	model.addNotification("api", "alpha notice", config.LogWarn)
+	captured := model.captureUIState()
+
+	model.resetUIStateToDefaults()
+	_ = model.logSearcher.SetPattern("wrong-runtime-filter")
+	model.applyUIState(captured)
+
+	if len(model.selectedTags) != 1 || model.selectedTags[0] != "backend" {
+		t.Fatalf("selectedTags = %v, want [backend] preserved", model.selectedTags)
+	}
+	if model.panelFocus != panelDetails {
+		t.Fatalf("panelFocus = %v, want panelDetails preserved", model.panelFocus)
+	}
+	if !model.wrapLogs {
+		t.Fatal("wrapLogs was not preserved")
+	}
+	if model.detailOffset != 7 {
+		t.Fatalf("detailOffset = %d, want 7 preserved", model.detailOffset)
+	}
+	if len(model.notifications) != 1 || model.notifications[0].Message != "alpha notice" {
+		t.Fatalf("notifications = %#v, want the runtime's own notification history", model.notifications)
+	}
+}
+
+// TestApplyUIStateZeroValueAppliesDefaults covers a runtime visited for the
+// first time in this TUI process: it gets Kranz's ordinary defaults, not a
+// zeroed-out or dangling state.
+func TestApplyUIStateZeroValueAppliesDefaults(t *testing.T) {
+	model := NewModel(&config.Config{Project: "Fresh", Services: map[string]config.Service{}}, "test")
+	defer model.Shutdown()
+	model.panelFocus = panelPinnedLogs
+	model.wrapLogs = true
+
+	model.applyUIState(runtimeUIState{})
+
+	if model.panelFocus != panelServices {
+		t.Fatalf("panelFocus = %v, want the default panelServices", model.panelFocus)
+	}
+	if model.wrapLogs {
+		t.Fatal("wrapLogs was not reset to its default")
+	}
+}
+
+func TestApplyUIStateClearsEmptySearchPatternsAndToast(t *testing.T) {
+	model := NewModel(&config.Config{Project: "Fresh", Services: map[string]config.Service{}}, "test")
+	defer model.Shutdown()
+	_ = model.logSearcher.SetPattern("from-other-runtime")
+	_ = model.pinnedSearcher.SetPattern("also-from-other-runtime")
+	model.toastMessage, model.toastTimer = "old toast", time.Now()
+
+	model.applyUIState(runtimeUIState{populated: true})
+
+	if model.logSearcher.Pattern() != "" || model.pinnedSearcher.Pattern() != "" {
+		t.Fatalf("empty cached patterns did not clear previous runtime filters: %q / %q",
+			model.logSearcher.Pattern(), model.pinnedSearcher.Pattern())
+	}
+	if model.toastMessage != "" || !model.toastTimer.IsZero() {
+		t.Fatalf("toast leaked across runtimes: %q at %v", model.toastMessage, model.toastTimer)
+	}
+}

--- a/internal/ui/runtime_state_test.go
+++ b/internal/ui/runtime_state_test.go
@@ -133,3 +133,75 @@ func TestApplyUIStateClearsEmptySearchPatternsAndToast(t *testing.T) {
 		t.Fatalf("toast leaked across runtimes: %q at %v", model.toastMessage, model.toastTimer)
 	}
 }
+
+// TestApplyUIStateRestoresRunSelectionAndViewport covers the run half of the
+// PRD 3.4 field list — "the selected run and the run history viewport" — that
+// its acceptance criterion sums up as restoring "the selected object, filters,
+// pin and scroll position". Restoring the run fields is only half the job:
+// syncRunTarget re-derives runTarget from the restored focus, and every field
+// that describes which run that target is showing has to survive it.
+func TestApplyUIStateRestoresRunSelectionAndViewport(t *testing.T) {
+	cfg := &config.Config{Project: "Runs", Services: map[string]config.Service{
+		"api": {Command: "sleep 1", Dir: ".", Shell: "sh"},
+	}}
+	model := NewModel(cfg, "test")
+	defer model.Shutdown()
+	model.refreshServices()
+	model.syncRunTarget()
+	model.runs = []app.RunSummary{{Target: app.ServiceRunTarget("api"), Run: 7}}
+
+	model.runMode = runViewSingle
+	model.selectedRun = 7
+	model.runFollowsLatest = false
+	viewportKey := model.runViewportKey()
+	model.runViewports[viewportKey] = runViewportState{Offset: 42, Anchor: 9}
+
+	captured := model.captureUIState()
+
+	// Leaving for another runtime and coming back: the model is carrying the
+	// other project's run state by the time this one is reapplied.
+	model.runMode, model.selectedRun, model.runFollowsLatest = runViewCombined, 0, true
+	model.runTarget = app.RunTarget{}
+	model.runViewports = make(map[runViewportKey]runViewportState)
+	model.logOffset, model.logAnchor = 0, 0
+
+	model.applyUIState(captured)
+
+	if model.runMode != runViewSingle || model.selectedRun != 7 || model.runFollowsLatest {
+		t.Fatalf("run selection was not restored: runMode=%v selectedRun=%d followsLatest=%v",
+			model.runMode, model.selectedRun, model.runFollowsLatest)
+	}
+	if model.runTarget != app.ServiceRunTarget("api") {
+		t.Fatalf("runTarget = %#v, want the focused service's target", model.runTarget)
+	}
+	if state, ok := model.runViewports[viewportKey]; !ok || state.Offset != 42 {
+		t.Fatalf("run viewport cache was not restored: %#v", model.runViewports)
+	}
+	if model.logOffset != 42 || model.logAnchor != 9 {
+		t.Fatalf("restored viewport was not applied to the live log panel: offset=%d anchor=%d",
+			model.logOffset, model.logAnchor)
+	}
+}
+
+func TestApplyUIStateChoosesClosestRunWhenSavedRunWasRemoved(t *testing.T) {
+	cfg := &config.Config{Project: "Runs", Services: map[string]config.Service{
+		"api": {Command: "sleep 1", Dir: ".", Shell: "sh"},
+	}}
+	model := NewModel(cfg, "test")
+	defer model.Shutdown()
+	model.refreshServices()
+	model.syncRunTarget()
+	model.runs = []app.RunSummary{
+		{Target: app.ServiceRunTarget("api"), Run: 4},
+		{Target: app.ServiceRunTarget("api"), Run: 8},
+	}
+
+	model.applyUIState(runtimeUIState{
+		populated: true, focusedServiceName: "api",
+		runMode: runViewSingle, selectedRun: 7,
+	})
+
+	if model.selectedRun != 8 {
+		t.Fatalf("selectedRun = %d, want closest retained run 8", model.selectedRun)
+	}
+}

--- a/internal/ui/runtime_switcher.go
+++ b/internal/ui/runtime_switcher.go
@@ -1,0 +1,337 @@
+package ui
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"time"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/kranz-org/kranz/internal/app"
+	"github.com/kranz-org/kranz/internal/config"
+	kranzruntime "github.com/kranz-org/kranz/internal/runtime"
+)
+
+// The runtime switcher: a modal list of every locally registered runtime,
+// reached with `p` from the dashboard, that lets the TUI attach to another
+// project without restarting the process (PRD 3.2/3.3).
+
+// switcherRefreshInterval bounds how often an open switcher re-probes the
+// registry. Faster than this wastes sockets on a list that mostly repeats
+// itself; slower would make a runtime that just started or stopped feel
+// unresponsive in the modal (PRD: "actualization ~once a second").
+const switcherRefreshInterval = time.Second
+
+// runtimeSwitchTimeout bounds dialing and handshaking a switch target. It is
+// generous relative to a local Unix-socket connection so a momentarily busy
+// supervisor is not mistaken for an unreachable one.
+const runtimeSwitchTimeout = 5 * time.Second
+
+// switchTargetMsg carries the outcome of dialing and handshaking a switch
+// target. seq guards against a superseded attempt (the user picked another
+// target, or closed the switcher, before this one answered) mutating the
+// dashboard.
+type switchTargetMsg struct {
+	seq    uint64
+	record kranzruntime.SessionRecord
+	client *kranzruntime.Client
+	cfg    *config.Config
+	err    error
+}
+
+// switcherSupported reports whether this model is attached to a real local
+// registry and can therefore switch or recover at all. It is false for
+// tests and embedders that supply their own app.API directly, which makes
+// every switcher and recovery entry point a no-op rather than a nil risk —
+// exactly the tests and embedding contracts that predate this feature.
+func (m *Model) switcherSupported() bool {
+	return m.registry != nil
+}
+
+func (m *Model) openRuntimeSwitcher() tea.Cmd {
+	if !m.switcherSupported() || m.exiting {
+		return nil
+	}
+	m.mode = ModeRuntimeSwitcher
+	m.switcherLoading = true
+	m.switcherErr = ""
+	m.switcherGeneration++
+	return m.refreshRuntimeList()
+}
+
+func (m *Model) closeRuntimeSwitcher() {
+	m.cancelPendingRuntimeSwitch()
+	m.mode = ModeNormal
+}
+
+func (m *Model) cancelPendingRuntimeSwitch() {
+	if m.switcherConnecting == "" {
+		return
+	}
+	m.switchSeq++
+	m.switcherConnecting = ""
+}
+
+// refreshRuntimeList dispatches one discovery round, single-flighted so an
+// auto-refresh tick never stacks a second probe on top of one still running
+// (PRD 8: "no accumulating parallel refresh cycles").
+func (m *Model) refreshRuntimeList() tea.Cmd {
+	if !m.switcherSupported() || m.switcherRefreshBusy {
+		return nil
+	}
+	m.switcherRefreshBusy = true
+	m.lastSwitcherRefresh = time.Now()
+	generation := m.switcherGeneration
+	registry := m.registry
+	clientVersion := m.version
+	sessionID := m.sessionID
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), runtimeDiscoveryTimeout)
+		defer cancel()
+		rows, err := discoverRuntimeRows(ctx, registry, clientVersion, sessionID)
+		return runtimeListMsg{generation: generation, rows: rows, err: err}
+	}
+}
+
+// refreshRuntimeListIfVisible is folded into the dashboard's regular tick so
+// an open switcher (or the "choose running runtime" list inside recovery)
+// keeps updating without the user ever needing to reopen it.
+func (m *Model) refreshRuntimeListIfVisible() tea.Cmd {
+	if m.mode != ModeRuntimeSwitcher && (m.mode != ModeRuntimeLost || !m.recoveryShowingList) {
+		return nil
+	}
+	if !m.lastSwitcherRefresh.IsZero() && time.Since(m.lastSwitcherRefresh) < switcherRefreshInterval {
+		return nil
+	}
+	return m.refreshRuntimeList()
+}
+
+func (m *Model) handleRuntimeListMsg(msg runtimeListMsg) (tea.Model, tea.Cmd) {
+	m.switcherRefreshBusy = false
+	if msg.generation != m.switcherGeneration {
+		return m, nil
+	}
+	m.switcherLoading = false
+	if msg.err != nil {
+		m.switcherErr = msg.err.Error()
+		return m, nil
+	}
+	m.switcherErr = ""
+	previousID := ""
+	if m.switcherCursor >= 0 && m.switcherCursor < len(m.switcherRows) {
+		previousID = m.switcherRows[m.switcherCursor].Record.ID
+	}
+	m.switcherRows = msg.rows
+	newIndex := -1
+	for index, row := range m.switcherRows {
+		if row.Record.ID == previousID {
+			newIndex = index
+			break
+		}
+	}
+	if newIndex < 0 {
+		// The row the cursor was on disappeared: land on the nearest
+		// remaining row instead of resetting to the top (PRD 3.2).
+		newIndex = min(m.switcherCursor, max(0, len(m.switcherRows)-1))
+	}
+	m.switcherCursor = newIndex
+	return m, nil
+}
+
+func (m *Model) handleRuntimeSwitcherKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch {
+	case key.Matches(msg, m.keys.Up):
+		m.moveSwitcherCursor(-1)
+	case key.Matches(msg, m.keys.Down):
+		m.moveSwitcherCursor(1)
+	case msg.String() == "enter":
+		return m.connectToSwitcherSelection()
+	case msg.String() == "esc", msg.String() == "p":
+		m.closeRuntimeSwitcher()
+	}
+	return m, nil
+}
+
+func (m *Model) moveSwitcherCursor(delta int) {
+	if len(m.switcherRows) == 0 {
+		return
+	}
+	m.switcherCursor = min(max(0, m.switcherCursor+delta), len(m.switcherRows)-1)
+}
+
+func (m *Model) connectToSwitcherSelection() (tea.Model, tea.Cmd) {
+	if m.switcherCursor < 0 || m.switcherCursor >= len(m.switcherRows) {
+		return m, nil
+	}
+	row := m.switcherRows[m.switcherCursor]
+	if !row.Selectable || row.IsCurrent {
+		return m, nil
+	}
+	return m, m.beginSwitchTo(row.Record)
+}
+
+// beginSwitchTo dials and handshakes record without touching m.app, m.cfg,
+// or any dashboard state yet: the switch only becomes visible once
+// handleSwitchTargetMsg confirms the connection, per the PRD 3.3 algorithm
+// ("dashboard changes current runtime only after successful connection").
+func (m *Model) beginSwitchTo(record kranzruntime.SessionRecord) tea.Cmd {
+	if !m.switcherSupported() || m.exiting || m.switcherConnecting != "" {
+		return nil
+	}
+	m.switcherConnecting = record.ID
+	m.switchSeq++
+	seq := m.switchSeq
+	clientVersion := m.version
+	socket := record.Socket
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), runtimeSwitchTimeout)
+		defer cancel()
+		client, err := kranzruntime.DialContextWithIdentity(ctx, socket, clientVersion,
+			kranzruntime.ClientIdentity{Surface: "tui", Label: "Kranz dashboard"})
+		if err != nil {
+			return switchTargetMsg{seq: seq, record: record, err: err}
+		}
+		cfg := client.Config()
+		if cfg == nil {
+			_ = client.Close()
+			return switchTargetMsg{seq: seq, record: record, err: errors.New("runtime returned no effective configuration")}
+		}
+		return switchTargetMsg{seq: seq, record: record, client: client, cfg: cfg}
+	}
+}
+
+func (m *Model) handleSwitchTargetMsg(msg switchTargetMsg) (tea.Model, tea.Cmd) {
+	if msg.seq != m.switchSeq {
+		// A newer attempt (or leaving the switcher and coming back)
+		// superseded this one. The connection was never installed anywhere,
+		// so nothing but its own socket depends on it.
+		retireClient(msg.client)
+		return m, nil
+	}
+	m.switcherConnecting = ""
+	if m.exiting {
+		retireClient(msg.client)
+		return m, nil
+	}
+	if msg.err != nil {
+		m.switcherErr = "Could not connect: " + msg.err.Error()
+		return m, m.refreshRuntimeList()
+	}
+	return m.installSession(msg.record, msg.client, msg.cfg)
+}
+
+// installSession is the atomic "commit" step of a switch: it saves the
+// departing session's UI state, points the model at the new connection, and
+// restores (or defaults) the arriving session's UI state, all synchronously
+// within one Update call so no render or async result can observe a mixed
+// state (PRD 3.3's "atomically shows the selected project").
+func (m *Model) installSession(record kranzruntime.SessionRecord, client *kranzruntime.Client, cfg *config.Config) (tea.Model, tea.Cmd) {
+	if m.sessionID != "" {
+		m.uiStateCache[m.sessionID] = m.captureUIState()
+	}
+	arrivingState := m.uiStateCache[record.ID]
+	oldClient := m.rpcClient
+	project := client.Project()
+	m.app = client
+	m.rpcClient = client
+	m.cfg = cfg
+	m.sessionID = record.ID
+	m.sessionRecord = record
+	m.sessionConfigPaths = append([]string(nil), project.ConfigPaths...)
+	if len(m.sessionConfigPaths) == 0 {
+		m.sessionConfigPaths = append([]string(nil), cfg.Paths...)
+	}
+	m.configPaths = append([]string(nil), m.sessionConfigPaths...)
+	m.workingDirectory = record.Directory
+	if m.workingDirectory == "" && len(m.configPaths) > 0 {
+		m.workingDirectory = filepath.Dir(m.configPaths[0])
+	}
+	m.sessionGeneration++
+	m.mode = ModeNormal
+	m.recoveryShowingList = false
+	m.recoveryReason = ""
+	m.recoveryErr = ""
+	m.projectExitHandled = false
+	m.configGeneration = project.Generation
+	m.lastConfigCheck = time.Time{}
+	m.cancelPendingRuntimeSwitch()
+	m.recoverySeq++
+
+	// An operation started in the previous session belongs to that supervisor.
+	// Leave its context and connection alone so it can finish there, but do not
+	// let its spinner or cancellation handle block commands in the new runtime.
+	m.operationID++
+	m.operation = ""
+	m.operationKind = ""
+	m.operationCancel = nil
+
+	m.resetRuntimeDataCaches()
+	m.allServices = m.app.Services()
+	m.services = m.allServices
+	m.refreshRunSummaries()
+	m.refreshActionStates()
+	m.applyUIState(arrivingState)
+	delete(m.uiStateCache, m.sessionID)
+	m.refreshVisibleLogCaches()
+	rows := m.tagRows()
+	m.tagCursor = min(max(0, len(rows)-1), max(0, m.tagCursor))
+	if len(m.services) == 0 {
+		m.focused = 0
+	} else if m.focused >= len(m.services) {
+		m.focused = len(m.services) - 1
+	}
+	m.markFocusedRead()
+	m.portService, m.portChecked, m.portScanBusy = "", time.Time{}, false
+	m.portScanID++
+
+	if err := m.applyEffectiveAppearance(); err != nil {
+		m.activeTheme, _ = applyAppearance(DefaultTheme, "", backgroundTerminal, colorModeAuto, m.terminalDark)
+		m.addNotification("appearance", err.Error()+"; using the Kranz theme", config.LogWarn)
+	}
+	for _, diagnostic := range cfg.Diagnostics {
+		m.addNotification("config", diagnostic, config.LogWarn)
+	}
+
+	if oldClient != nil {
+		retireClient(oldClient)
+	}
+
+	m.addNotification("runtime", "Switched to "+record.Name, config.LogInfo)
+	return m, tea.Batch(m.pollServices(), m.scanFocusedPorts(true), m.watchCurrentClientDone())
+}
+
+// CloseCurrentConnection closes whichever connection this model is
+// currently attached to over the wire, if any. It only hangs up this
+// client's own socket — asking the runtime to stop anything is Shutdown()'s
+// job — so it is always safe to call once the TUI program has stopped, and
+// is the only way for a caller to close the right connection after a
+// session that switched runtimes: the caller's own original client may
+// already have been retired.
+func (m *Model) CloseCurrentConnection() error {
+	if m.rpcClient == nil {
+		return nil
+	}
+	return m.rpcClient.Close()
+}
+
+// retireClient closes a connection this model no longer references, once
+// any request already accepted by its supervisor has answered, without
+// blocking the caller (PRD 3.3, risk table: retiring a client must never
+// cancel operation the server already committed to).
+func retireClient(client *kranzruntime.Client) {
+	if client == nil {
+		return
+	}
+	// There is deliberately no timeout here. A switch is a detach, and the
+	// product contract says work already accepted by the old supervisor keeps
+	// running even when readiness or an action takes longer than expected.
+	client.CloseAfterIdle(0)
+}
+
+func retainRuntimeApplication(application app.API) func() {
+	if client, ok := application.(*kranzruntime.Client); ok {
+		return client.Retain()
+	}
+	return func() {}
+}

--- a/internal/ui/runtime_switcher_test.go
+++ b/internal/ui/runtime_switcher_test.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 
 	kranzruntime "github.com/kranz-org/kranz/internal/runtime"
 )
@@ -107,6 +109,31 @@ func TestRuntimeTableSeparatesStatusClientsAndServices(t *testing.T) {
 	for _, value := range []string{"shop", "started", "MCP · TUI", "3/5"} {
 		if !strings.Contains(line, value) {
 			t.Fatalf("runtime row is missing %q: %q", value, line)
+		}
+	}
+}
+
+func TestRuntimeSwitcherFitsNarrowTerminalWithoutLosingCoreControls(t *testing.T) {
+	model := newTestModel()
+	defer model.Shutdown()
+	model.width, model.height, model.ready = 62, 18, true
+	model.mode = ModeRuntimeSwitcher
+	row := rowFor("s", "shop", time.Now(), false, kranzruntime.SessionRunning)
+	row.Record.ClientSurfaces = []string{"mcp", "tui"}
+	services, running := 5, 3
+	row.Record.Services, row.Record.Running = &services, &running
+	model.switcherRows = []runtimeRow{row}
+
+	rendered := model.renderRuntimeSwitcherView()
+	plain := ansi.Strip(rendered)
+	for _, expected := range []string{"RUNTIME", "STATUS", "CLIENTS", "SERVICES", "shop", "started", "MCP", "3/5", "[Enter] Connect", "[Esc] Cancel"} {
+		if !strings.Contains(plain, expected) {
+			t.Fatalf("narrow runtime modal lost %q:\n%s", expected, plain)
+		}
+	}
+	for index, line := range strings.Split(rendered, "\n") {
+		if width := lipgloss.Width(line); width > model.width {
+			t.Fatalf("narrow runtime modal row %d is %d cells wide in a %d-cell terminal", index, width, model.width)
 		}
 	}
 }

--- a/internal/ui/runtime_switcher_test.go
+++ b/internal/ui/runtime_switcher_test.go
@@ -1,0 +1,229 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	kranzruntime "github.com/kranz-org/kranz/internal/runtime"
+)
+
+func rowFor(id, name string, startedAt time.Time, current bool, state kranzruntime.SessionState) runtimeRow {
+	row := runtimeRow{
+		Record: kranzruntime.SessionRecord{
+			SessionMetadata: kranzruntime.SessionMetadata{ID: id, Name: name, StartedAt: startedAt},
+			State:           state,
+		},
+		IsCurrent: current,
+	}
+	switch state {
+	case kranzruntime.SessionRunning:
+		row.Selectable = !current
+	case kranzruntime.SessionIncompatible:
+		row.Reason = "incompatible protocol version"
+	case kranzruntime.SessionUnreachable:
+		row.Reason = "unreachable"
+	}
+	return row
+}
+
+func TestSortRuntimeRowsPutsCurrentFirstThenNewestThenStableTiebreak(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	rows := []runtimeRow{
+		rowFor("z-id", "zeta", base, false, kranzruntime.SessionRunning),
+		rowFor("a-id", "alpha", base.Add(time.Hour), true, kranzruntime.SessionRunning),
+		rowFor("b-id", "beta", base.Add(2*time.Hour), false, kranzruntime.SessionRunning),
+		rowFor("c-id", "charlie-2", base, false, kranzruntime.SessionRunning), // ties zeta's StartedAt
+		rowFor("d-id", "charlie-1", base, false, kranzruntime.SessionRunning), // ties charlie-2 too
+	}
+	sortRuntimeRows(rows)
+
+	if rows[0].Record.ID != "a-id" {
+		t.Fatalf("current runtime must sort first, got %q", rows[0].Record.ID)
+	}
+	if rows[1].Record.ID != "b-id" {
+		t.Fatalf("second row should be the newest non-current runtime, got %q", rows[1].Record.ID)
+	}
+	// Same StartedAt: stable tiebreak by name, then ID.
+	if rows[2].Record.Name != "charlie-1" || rows[3].Record.Name != "charlie-2" || rows[4].Record.Name != "zeta" {
+		names := []string{rows[2].Record.Name, rows[3].Record.Name, rows[4].Record.Name}
+		t.Fatalf("tiebreak order = %v, want [charlie-1 charlie-2 zeta]", names)
+	}
+
+	// Sorting again must not reorder rows that are already in a stable
+	// order (PRD 3.2: "rows do not jump between refreshes").
+	again := append([]runtimeRow(nil), rows...)
+	sortRuntimeRows(again)
+	for i := range rows {
+		if rows[i].Record.ID != again[i].Record.ID {
+			t.Fatalf("re-sorting an already-sorted list reordered row %d", i)
+		}
+	}
+}
+
+func TestRuntimeRowStatusLabelsMatchPRDStates(t *testing.T) {
+	now := time.Now()
+	current := rowFor("c", "current", now, true, kranzruntime.SessionRunning)
+	if label := runtimeRowStatusLabel(current); label != "current" {
+		t.Fatalf("current row label = %q, want current", label)
+	}
+	started := rowFor("s", "started", now, false, kranzruntime.SessionRunning)
+	if label := runtimeRowStatusLabel(started); label != "started" {
+		t.Fatalf("no-other-clients row label = %q, want started", label)
+	}
+	withClients := started
+	withClients.Record.ClientSurfaces = []string{"mcp", "tui"}
+	if label := runtimeRowStatusLabel(withClients); label != "started" {
+		t.Fatalf("client row status = %q, want started", label)
+	}
+	if label := runtimeRowSurfaceLabel(withClients); label != "MCP · TUI" {
+		t.Fatalf("client-surface label = %q, want %q", label, "MCP · TUI")
+	}
+	incompatible := rowFor("i", "incompatible", now, false, kranzruntime.SessionIncompatible)
+	if label := runtimeRowStatusLabel(incompatible); label != "incompatible" {
+		t.Fatalf("incompatible row label = %q", label)
+	}
+	unreachable := rowFor("u", "unreachable", now, false, kranzruntime.SessionUnreachable)
+	if label := runtimeRowStatusLabel(unreachable); label != "unreachable" {
+		t.Fatalf("unreachable row label = %q", label)
+	}
+}
+
+func TestRuntimeTableSeparatesStatusClientsAndServices(t *testing.T) {
+	row := rowFor("s", "shop", time.Now(), false, kranzruntime.SessionRunning)
+	row.Record.ClientSurfaces = []string{"mcp", "tui"}
+	services, running := 5, 3
+	row.Record.Services, row.Record.Running = &services, &running
+
+	header := runtimeRowHeader(100)
+	line := runtimeRowLine(row, 100)
+	for _, column := range []string{"RUNTIME", "STATUS", "CLIENTS", "SERVICES", "UPTIME", "DIRECTORY"} {
+		if !strings.Contains(header, column) {
+			t.Fatalf("runtime table header is missing %q: %q", column, header)
+		}
+	}
+	for _, value := range []string{"shop", "started", "MCP · TUI", "3/5"} {
+		if !strings.Contains(line, value) {
+			t.Fatalf("runtime row is missing %q: %q", value, line)
+		}
+	}
+}
+
+// TestSwitcherKeyboardNavigationAndDisabledRows exercises the reducer
+// (PRD 9's "navigation, sorting, refresh reconciliation, disabled rows")
+// without any network I/O: rows are fabricated directly.
+func TestSwitcherKeyboardNavigationAndDisabledRows(t *testing.T) {
+	model := newTestModel()
+	defer model.Shutdown()
+	now := time.Now()
+	model.mode = ModeRuntimeSwitcher
+	model.switcherRows = []runtimeRow{
+		rowFor("cur", "current", now, true, kranzruntime.SessionRunning),
+		rowFor("bad1", "incompatible-one", now.Add(-time.Minute), false, kranzruntime.SessionIncompatible),
+		rowFor("ok1", "ok-one", now.Add(-2*time.Minute), false, kranzruntime.SessionRunning),
+	}
+	model.switcherCursor = 0
+
+	model.handleRuntimeSwitcherKeys(tea.KeyMsg{Type: tea.KeyDown})
+	if model.switcherCursor != 1 {
+		t.Fatalf("cursor after down = %d, want 1", model.switcherCursor)
+	}
+	model.handleRuntimeSwitcherKeys(tea.KeyMsg{Type: tea.KeyDown})
+	if model.switcherCursor != 2 {
+		t.Fatalf("cursor after second down = %d, want 2", model.switcherCursor)
+	}
+	// Cursor does not run past the end of the list.
+	model.handleRuntimeSwitcherKeys(tea.KeyMsg{Type: tea.KeyDown})
+	if model.switcherCursor != 2 {
+		t.Fatalf("cursor overran the list: %d", model.switcherCursor)
+	}
+
+	// Enter on an incompatible (disabled) row must not connect anywhere:
+	// with no Registry configured, beginSwitchTo is a no-op regardless, so
+	// what this actually proves is that a disabled row is rejected before
+	// beginSwitchTo is even reached (switcherConnecting stays empty).
+	model.switcherCursor = 1
+	model.handleRuntimeSwitcherKeys(tea.KeyMsg{Type: tea.KeyEnter})
+	if model.switcherConnecting != "" {
+		t.Fatalf("connecting to a disabled row set switcherConnecting = %q", model.switcherConnecting)
+	}
+
+	// Enter on the current row is also a no-op (nothing to switch to).
+	model.switcherCursor = 0
+	model.handleRuntimeSwitcherKeys(tea.KeyMsg{Type: tea.KeyEnter})
+	if model.switcherConnecting != "" {
+		t.Fatal("connecting to the current row should be a no-op")
+	}
+
+	// Esc closes the modal without touching any row.
+	model.handleRuntimeSwitcherKeys(tea.KeyMsg{Type: tea.KeyEsc})
+	if model.mode != ModeNormal {
+		t.Fatalf("Esc left mode = %v, want ModeNormal", model.mode)
+	}
+}
+
+func TestClosingSwitcherSupersedesPendingConnection(t *testing.T) {
+	model := newTestModel()
+	defer model.Shutdown()
+	model.mode = ModeRuntimeSwitcher
+	model.switchSeq = 8
+	model.switcherConnecting = "pending-runtime"
+
+	model.closeRuntimeSwitcher()
+
+	if model.mode != ModeNormal || model.switcherConnecting != "" {
+		t.Fatalf("closing switcher left mode=%v connecting=%q", model.mode, model.switcherConnecting)
+	}
+	if model.switchSeq != 9 {
+		t.Fatalf("switchSeq = %d, want pending result invalidated at 9", model.switchSeq)
+	}
+}
+
+// TestRuntimeListRefreshKeepsCursorOnSameRuntime covers the reconciliation
+// PRD 3.2 requires: a live refresh must not move the cursor while the
+// runtime it was on is still listed, even if its position in the list (or
+// the total row count) changed.
+func TestRuntimeListRefreshKeepsCursorOnSameRuntime(t *testing.T) {
+	model := newTestModel()
+	defer model.Shutdown()
+	now := time.Now()
+	model.mode = ModeRuntimeSwitcher
+	model.switcherGeneration = 5
+	model.switcherRows = []runtimeRow{
+		rowFor("a", "alpha", now, false, kranzruntime.SessionRunning),
+		rowFor("b", "beta", now, false, kranzruntime.SessionRunning),
+		rowFor("c", "gamma", now, false, kranzruntime.SessionRunning),
+	}
+	model.switcherCursor = 2 // sitting on "gamma"
+
+	refreshed := []runtimeRow{
+		rowFor("d", "delta", now, false, kranzruntime.SessionRunning), // a new runtime appeared first
+		rowFor("a", "alpha", now, false, kranzruntime.SessionRunning),
+		rowFor("c", "gamma", now, false, kranzruntime.SessionRunning),
+	}
+	model.handleRuntimeListMsg(runtimeListMsg{generation: 5, rows: refreshed})
+	if model.switcherRows[model.switcherCursor].Record.ID != "c" {
+		t.Fatalf("cursor followed to index %d (%q), want to stay on gamma",
+			model.switcherCursor, model.switcherRows[model.switcherCursor].Record.ID)
+	}
+
+	// Now "gamma" disappears entirely: the cursor lands on the nearest
+	// remaining row instead of resetting to the top.
+	shrunk := []runtimeRow{
+		rowFor("d", "delta", now, false, kranzruntime.SessionRunning),
+		rowFor("a", "alpha", now, false, kranzruntime.SessionRunning),
+	}
+	model.handleRuntimeListMsg(runtimeListMsg{generation: 5, rows: shrunk})
+	if model.switcherCursor < 0 || model.switcherCursor >= len(model.switcherRows) {
+		t.Fatalf("cursor %d out of range after the selected row vanished", model.switcherCursor)
+	}
+
+	// A stale generation (a refresh that started before the modal was
+	// closed and reopened) must not touch the list at all.
+	model.handleRuntimeListMsg(runtimeListMsg{generation: 4, rows: nil})
+	if len(model.switcherRows) != len(shrunk) {
+		t.Fatal("a stale-generation refresh result was applied")
+	}
+}

--- a/internal/ui/runtime_switcher_test.go
+++ b/internal/ui/runtime_switcher_test.go
@@ -24,11 +24,39 @@ func rowFor(id, name string, startedAt time.Time, current bool, state kranzrunti
 	case kranzruntime.SessionRunning:
 		row.Selectable = !current
 	case kranzruntime.SessionIncompatible:
-		row.Reason = "incompatible protocol version"
+		row.Reason = "This runtime speaks a different protocol version. Update Kranz to attach to it."
 	case kranzruntime.SessionUnreachable:
-		row.Reason = "unreachable"
+		row.Reason = "This runtime is registered but is not answering. The list keeps retrying it."
 	}
 	return row
+}
+
+// TestSwitcherShowsWhyTheSelectedRowCannotBeSelected covers PRD 3.2's
+// requirement that an unavailable runtime stays visible *and* explains why:
+// the status column only fits the state word, so the reason belongs on
+// screen too rather than only in the row struct.
+func TestSwitcherShowsWhyTheSelectedRowCannotBeSelected(t *testing.T) {
+	model := newTestModel()
+	defer model.Shutdown()
+	model.width, model.height, model.ready = 100, 24, true
+	model.mode = ModeRuntimeSwitcher
+	incompatible := rowFor("bad", "old-runtime", time.Now(), false, kranzruntime.SessionIncompatible)
+	available := rowFor("ok", "new-runtime", time.Now(), false, kranzruntime.SessionRunning)
+	model.switcherRows = []runtimeRow{incompatible, available}
+
+	model.switcherCursor = 0
+	plain := ansi.Strip(model.renderRuntimeSwitcherView())
+	if !strings.Contains(plain, "Update Kranz to attach to it") {
+		t.Fatalf("switcher does not explain why the selected row is disabled:\n%s", plain)
+	}
+
+	// A selectable row has nothing to explain, so the line goes away again
+	// instead of leaving a stale reason under the list.
+	model.switcherCursor = 1
+	plain = ansi.Strip(model.renderRuntimeSwitcherView())
+	if strings.Contains(plain, "Update Kranz to attach to it") {
+		t.Fatalf("a disabled row's reason survived moving to a selectable row:\n%s", plain)
+	}
 }
 
 func TestSortRuntimeRowsPutsCurrentFirstThenNewestThenStableTiebreak(t *testing.T) {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -58,6 +58,10 @@ func (m *Model) View() string {
 		content = m.renderRunExportView()
 	case ModeConfirmDeleteRun:
 		content = m.renderConfirmDeleteRunView()
+	case ModeRuntimeSwitcher:
+		content = m.renderRuntimeSwitcherView()
+	case ModeRuntimeLost:
+		content = m.renderRuntimeLostView()
 	default:
 		// The dashboard reports the size it assembled itself at, so the frame
 		// can skip the measuring pass that fits it to the terminal.

--- a/internal/ui/view_modals.go
+++ b/internal/ui/view_modals.go
@@ -790,6 +790,66 @@ func renderModalShortcuts(value string, textStyle lipgloss.Style) string {
 	return result.String()
 }
 
+// flushModalContentWidth leaves room for the flush modal's own padding and a
+// small strip of dimmed dashboard on either side. preferred keeps list modals
+// readable on a very wide terminal instead of turning them into full-screen
+// tables.
+func flushModalContentWidth(terminalWidth, preferred int) int {
+	const flushChromeAndGutters = 10
+	return max(8, min(preferred, terminalWidth-flushChromeAndGutters))
+}
+
+// renderModalShortcutRows wraps controls only between complete key/action
+// groups. A narrow modal therefore gains another footer row instead of
+// cutting a key binding or its label in half.
+func renderModalShortcutRows(groups []string, width int, textStyle lipgloss.Style) []string {
+	const indent = "  "
+	rows := make([]string, 0, 2)
+	current := indent
+	for _, group := range groups {
+		if group == "" {
+			continue
+		}
+		if lipgloss.Width(indent+group) > width {
+			if current != indent {
+				rows = append(rows, renderModalShortcuts(current, textStyle))
+				current = indent
+			}
+			wrappedGroup := ansi.Hardwrap(ansi.Wordwrap(indent+group, width, ""), width, true)
+			for _, wrapped := range strings.Split(wrappedGroup, "\n") {
+				rows = append(rows, renderModalShortcuts(wrapped, textStyle))
+			}
+			continue
+		}
+		candidate := current
+		if candidate != indent {
+			candidate += "  "
+		}
+		candidate += group
+		if current != indent && lipgloss.Width(candidate) > width {
+			rows = append(rows, renderModalShortcuts(current, textStyle))
+			current = indent + group
+			continue
+		}
+		current = candidate
+	}
+	if current != indent {
+		rows = append(rows, renderModalShortcuts(current, textStyle))
+	}
+	return rows
+}
+
+func modalTextRows(value string, width int) []string {
+	const indent = "  "
+	available := max(1, width-lipgloss.Width(indent))
+	wrapped := ansi.Hardwrap(ansi.Wordwrap(value, available, ""), available, true)
+	parts := strings.Split(wrapped, "\n")
+	for index := range parts {
+		parts[index] = indent + parts[index]
+	}
+	return parts
+}
+
 func renderConfirmationModal(title string, bodyLines []string, actionLines ...string) string {
 	lines := []string{renderConfirmTitle(title)}
 	if len(bodyLines) > 0 {

--- a/internal/ui/view_modals.go
+++ b/internal/ui/view_modals.go
@@ -94,6 +94,7 @@ func helpSections() []helpSection {
 		{title: "APPLICATION", entries: []helpEntry{
 			{"Ctrl+L", "Reload configuration and detect terminal appearance"},
 			{"Ctrl+O", "Open command shell; Ctrl+O returns to Kranz"},
+			{"p", "Switch to another local Kranz runtime"},
 			{"?", "Show this help"},
 			{"q", "Quit"},
 		}},

--- a/internal/ui/view_runtime.go
+++ b/internal/ui/view_runtime.go
@@ -5,36 +5,38 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // renderRuntimeSwitcherView draws the `p` modal: every locally registered
 // runtime, current first, live-refreshing while open (PRD 3.2).
 func (m *Model) renderRuntimeSwitcherView() string {
-	lines := []string{ModalTitleStyle.Render(" Switch runtime "), ""}
-	if m.switcherErr != "" {
-		lines = append(lines, ContextBarStyle.Render("  "+m.switcherErr), "")
-	} else if m.switcherLoading && len(m.switcherRows) == 0 {
-		lines = append(lines, "  Discovering local runtimes…", "")
+	contentWidth := flushModalContentWidth(m.width, 110)
+	shortcutGroups := []string{"[↑/↓ · j/k] Select", "[Enter] Connect", "[Esc] Cancel"}
+	if m.switcherConnecting != "" {
+		shortcutGroups = append(shortcutGroups, "Connecting…")
 	}
-	rowLines := renderRuntimeRowLines(m.switcherRows, m.switcherCursor, m.runListCapacity(len(lines)), m.width)
+	shortcutRows := renderModalShortcutRows(shortcutGroups, contentWidth, lipgloss.NewStyle().Foreground(ColorDim))
+	lines := []string{ansi.Truncate(ModalTitleStyle.Render(" Switch runtime "), contentWidth, "…"), ""}
+	if m.switcherErr != "" {
+		for _, line := range modalTextRows(m.switcherErr, contentWidth) {
+			lines = append(lines, ContextBarStyle.Render(line))
+		}
+		lines = append(lines, "")
+	} else if m.switcherLoading && len(m.switcherRows) == 0 {
+		lines = append(lines, modalTextRows("Discovering local runtimes…", contentWidth)...)
+		lines = append(lines, "")
+	}
+	rowLines := renderRuntimeRowLines(m.switcherRows, m.switcherCursor,
+		m.runListCapacity(len(lines)+max(0, len(shortcutRows)-1)), contentWidth)
 	if len(rowLines) == 0 && m.switcherErr == "" && !m.switcherLoading {
-		lines = append(lines, "  No other local runtimes are registered")
+		lines = append(lines, modalTextRows("No other local runtimes are registered", contentWidth)...)
 	} else {
 		lines = append(lines, rowLines...)
 	}
-	connecting := ""
-	if m.switcherConnecting != "" {
-		connecting = "  Connecting…"
-	}
-	lines = append(lines, "", runtimeModalShortcuts("  [↑/↓ · j/k] Select  [Enter] Connect  [Esc] Cancel"+connecting))
+	lines = append(lines, "")
+	lines = append(lines, shortcutRows...)
 	return m.placeOverlay(renderFlushModal(strings.Join(lines, "\n")))
-}
-
-// runtimeModalShortcuts renders a runtime modal's footer with the same dim
-// text and accent-coloured keys the run history modal uses, so the two read
-// as the same control strip rather than two conventions.
-func runtimeModalShortcuts(value string) string {
-	return renderModalShortcuts(value, lipgloss.NewStyle().Foreground(ColorDim))
 }
 
 // renderRuntimeRowLines renders a windowed, cursor-highlighted list of rows
@@ -44,7 +46,7 @@ func renderRuntimeRowLines(rows []runtimeRow, cursor int, capacity int, width in
 	if len(rows) == 0 {
 		return nil
 	}
-	rowWidth := max(20, width-4)
+	rowWidth := max(8, width-2)
 	start, visible, windowed := runListWindow(len(rows), cursor, max(1, capacity-1))
 	lines := make([]string, 0, visible+2)
 	lines = append(lines, "  "+HelpSectionStyle.Render(runtimeRowHeader(rowWidth)))
@@ -69,29 +71,38 @@ func renderRuntimeRowLines(rows []runtimeRow, cursor int, capacity int, width in
 // runtime's connection ends (PRD 3.5): "Restart runtime", "Choose running
 // runtime", or the embedded list once the latter is chosen.
 func (m *Model) renderRuntimeLostView() string {
+	contentWidth := flushModalContentWidth(m.width, 110)
 	title := m.recoveryReason
 	if title == "" {
 		title = "Runtime stopped"
 	}
-	lines := []string{ModalTitleStyle.Render(" " + title + " "), ""}
+	lines := []string{ansi.Truncate(ModalTitleStyle.Render(" "+title+" "), contentWidth, "…"), ""}
 	if m.recoveryShowingList {
-		lines = append(lines, "  Choose a running runtime:", "")
-		rowLines := renderRuntimeRowLines(m.switcherRows, m.switcherCursor, m.runListCapacity(len(lines)), m.width)
+		shortcutRows := renderModalShortcutRows([]string{"[↑/↓ · j/k] Select", "[Enter] Connect", "[Esc] Back"}, contentWidth, lipgloss.NewStyle().Foreground(ColorDim))
+		lines = append(lines, modalTextRows("Choose a running runtime:", contentWidth)...)
+		lines = append(lines, "")
+		rowLines := renderRuntimeRowLines(m.switcherRows, m.switcherCursor,
+			m.runListCapacity(len(lines)+max(0, len(shortcutRows)-1)), contentWidth)
 		if len(rowLines) == 0 {
-			lines = append(lines, "  No other local runtimes are registered")
+			lines = append(lines, modalTextRows("No other local runtimes are registered", contentWidth)...)
 		} else {
 			lines = append(lines, rowLines...)
 		}
-		lines = append(lines, "", runtimeModalShortcuts("  [↑/↓ · j/k] Select  [Enter] Connect  [Esc] Back"))
+		lines = append(lines, "")
+		lines = append(lines, shortcutRows...)
 		return m.placeOverlay(renderFlushModal(strings.Join(lines, "\n")))
 	}
-	lines = append(lines, "  The connection to this project's runtime ended.", "")
+	lines = append(lines, modalTextRows("The connection to this project's runtime ended.", contentWidth)...)
+	lines = append(lines, "")
 	switch {
 	case m.recoveryBusy:
 		lines = append(lines, "  Restarting…", "")
 	case m.recoveryErr != "":
-		lines = append(lines, ContextBarStyle.Render("  "+m.recoveryErr), "")
+		for _, line := range modalTextRows(m.recoveryErr, contentWidth) {
+			lines = append(lines, ContextBarStyle.Render(line))
+		}
+		lines = append(lines, "")
 	}
-	lines = append(lines, runtimeModalShortcuts("  [r/Enter] Restart runtime  [c] Choose running runtime  [q] Quit TUI"))
+	lines = append(lines, renderModalShortcutRows([]string{"[r/Enter] Restart runtime", "[c] Choose running runtime", "[q] Quit TUI"}, contentWidth, lipgloss.NewStyle().Foreground(ColorDim))...)
 	return m.placeOverlay(renderFlushModal(strings.Join(lines, "\n")))
 }

--- a/internal/ui/view_runtime.go
+++ b/internal/ui/view_runtime.go
@@ -1,0 +1,97 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// renderRuntimeSwitcherView draws the `p` modal: every locally registered
+// runtime, current first, live-refreshing while open (PRD 3.2).
+func (m *Model) renderRuntimeSwitcherView() string {
+	lines := []string{ModalTitleStyle.Render(" Switch runtime "), ""}
+	if m.switcherErr != "" {
+		lines = append(lines, ContextBarStyle.Render("  "+m.switcherErr), "")
+	} else if m.switcherLoading && len(m.switcherRows) == 0 {
+		lines = append(lines, "  Discovering local runtimes…", "")
+	}
+	rowLines := renderRuntimeRowLines(m.switcherRows, m.switcherCursor, m.runListCapacity(len(lines)), m.width)
+	if len(rowLines) == 0 && m.switcherErr == "" && !m.switcherLoading {
+		lines = append(lines, "  No other local runtimes are registered")
+	} else {
+		lines = append(lines, rowLines...)
+	}
+	connecting := ""
+	if m.switcherConnecting != "" {
+		connecting = "  Connecting…"
+	}
+	lines = append(lines, "", runtimeModalShortcuts("  [↑/↓ · j/k] Select  [Enter] Connect  [Esc] Cancel"+connecting))
+	return m.placeOverlay(renderFlushModal(strings.Join(lines, "\n")))
+}
+
+// runtimeModalShortcuts renders a runtime modal's footer with the same dim
+// text and accent-coloured keys the run history modal uses, so the two read
+// as the same control strip rather than two conventions.
+func runtimeModalShortcuts(value string) string {
+	return renderModalShortcuts(value, lipgloss.NewStyle().Foreground(ColorDim))
+}
+
+// renderRuntimeRowLines renders a windowed, cursor-highlighted list of rows
+// shared by the switcher, the recovery screen's "choose running runtime",
+// and the bare-launch runtime picker (none of which share a common *Model).
+func renderRuntimeRowLines(rows []runtimeRow, cursor int, capacity int, width int) []string {
+	if len(rows) == 0 {
+		return nil
+	}
+	rowWidth := max(20, width-4)
+	start, visible, windowed := runListWindow(len(rows), cursor, max(1, capacity-1))
+	lines := make([]string, 0, visible+2)
+	lines = append(lines, "  "+HelpSectionStyle.Render(runtimeRowHeader(rowWidth)))
+	for index := start; index < start+visible; index++ {
+		row := rows[index]
+		text := "  " + runtimeRowLine(row, rowWidth)
+		if !row.Selectable {
+			text = ContextBarStyle.Render(text)
+		}
+		if index == cursor {
+			text = SelectionStyle.Render(text)
+		}
+		lines = append(lines, text)
+	}
+	if windowed {
+		lines = append(lines, "  "+ContextBarStyle.Render(fmt.Sprintf("%d/%d", cursor+1, len(rows))))
+	}
+	return lines
+}
+
+// renderRuntimeLostView draws the recovery screen shown once the current
+// runtime's connection ends (PRD 3.5): "Restart runtime", "Choose running
+// runtime", or the embedded list once the latter is chosen.
+func (m *Model) renderRuntimeLostView() string {
+	title := m.recoveryReason
+	if title == "" {
+		title = "Runtime stopped"
+	}
+	lines := []string{ModalTitleStyle.Render(" " + title + " "), ""}
+	if m.recoveryShowingList {
+		lines = append(lines, "  Choose a running runtime:", "")
+		rowLines := renderRuntimeRowLines(m.switcherRows, m.switcherCursor, m.runListCapacity(len(lines)), m.width)
+		if len(rowLines) == 0 {
+			lines = append(lines, "  No other local runtimes are registered")
+		} else {
+			lines = append(lines, rowLines...)
+		}
+		lines = append(lines, "", runtimeModalShortcuts("  [↑/↓ · j/k] Select  [Enter] Connect  [Esc] Back"))
+		return m.placeOverlay(renderFlushModal(strings.Join(lines, "\n")))
+	}
+	lines = append(lines, "  The connection to this project's runtime ended.", "")
+	switch {
+	case m.recoveryBusy:
+		lines = append(lines, "  Restarting…", "")
+	case m.recoveryErr != "":
+		lines = append(lines, ContextBarStyle.Render("  "+m.recoveryErr), "")
+	}
+	lines = append(lines, runtimeModalShortcuts("  [r/Enter] Restart runtime  [c] Choose running runtime  [q] Quit TUI"))
+	return m.placeOverlay(renderFlushModal(strings.Join(lines, "\n")))
+}

--- a/internal/ui/view_runtime.go
+++ b/internal/ui/view_runtime.go
@@ -42,13 +42,25 @@ func (m *Model) renderRuntimeSwitcherView() string {
 // renderRuntimeRowLines renders a windowed, cursor-highlighted list of rows
 // shared by the switcher, the recovery screen's "choose running runtime",
 // and the bare-launch runtime picker (none of which share a common *Model).
+// The status column only has room for the state word, so when the cursor is
+// on a row that cannot be selected, the reason behind that word is spelled
+// out on its own line below the list (PRD 3.2: an unavailable runtime stays
+// visible and explains why it is unavailable).
 func renderRuntimeRowLines(rows []runtimeRow, cursor int, capacity int, width int) []string {
 	if len(rows) == 0 {
 		return nil
 	}
 	rowWidth := max(8, width-2)
-	start, visible, windowed := runListWindow(len(rows), cursor, max(1, capacity-1))
-	lines := make([]string, 0, visible+2)
+	reason := ""
+	if cursor >= 0 && cursor < len(rows) {
+		reason = rows[cursor].Reason
+	}
+	listCapacity := max(1, capacity-1) // the header row
+	if reason != "" {
+		listCapacity = max(1, listCapacity-1)
+	}
+	start, visible, windowed := runListWindow(len(rows), cursor, listCapacity)
+	lines := make([]string, 0, visible+3)
 	lines = append(lines, "  "+HelpSectionStyle.Render(runtimeRowHeader(rowWidth)))
 	for index := start; index < start+visible; index++ {
 		row := rows[index]
@@ -63,6 +75,9 @@ func renderRuntimeRowLines(rows []runtimeRow, cursor int, capacity int, width in
 	}
 	if windowed {
 		lines = append(lines, "  "+ContextBarStyle.Render(fmt.Sprintf("%d/%d", cursor+1, len(rows))))
+	}
+	if reason != "" {
+		lines = append(lines, "  "+ContextBarStyle.Render(ansi.Truncate(reason, rowWidth, "…")))
 	}
 	return lines
 }


### PR DESCRIPTION
The TUI could only stay attached to the runtime selected at startup, and a bare launch outside a configured project had no way to attach to an already-running local runtime. This adds a Runs-style runtime modal, transactional switching with per-runtime UI state, recovery after connection loss, and a standalone picker when no config is present.

The runtime table separates status, client surfaces, running/total services, uptime, and directory. Runtime and Run history modals now choose compact columns and wrap complete shortcut groups on narrow terminals instead of clipping their right or bottom edges. Pressing `q` always opens the quit confirmation so an idle runtime and its run history can be preserved by detaching.

Validation:
- focused TUI runtime-table, narrow-modal, run-windowing, and idle-quit tests
- `make build`
- registry discovery smoke check with `kranz-dev ps --output json`
- `git diff --check`
- changed-file privacy audit

The full test suite was not rerun in the final review pass at the user's request; it had been run during the preceding implementation pass.
