### PR TITLE
fix(runtime): recover lost session descriptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 
 ## [Unreleased]
 
+### Fixed
+
+- A running runtime can no longer be stranded by the loss of its registry
+  descriptor. Losing that one file used to make the project invisible to
+  `kranz`, `kranz status`, and `kranz down` while a fresh start was still
+  refused as already active, with nothing able to recover it. Each runtime
+  now records its descriptor in the lock file it already holds, and
+  discovery restores a missing descriptor from there whenever the lock is
+  still held and the runtime still answers.
+
 ## [0.13.0] - 2026-09-06
 
 ### Added

--- a/cmd/kranz/startup_routing_test.go
+++ b/cmd/kranz/startup_routing_test.go
@@ -237,3 +237,58 @@ func startPickerTestRuntime(t *testing.T, registry *kranzruntime.Registry, name 
 		_ = local.Shutdown()
 	}}
 }
+
+// TestBareLaunchReattachesAfterTheDashboardDiesAbruptly is the contract a
+// user relies on when an editor takes its terminals down with it: the
+// supervisor is a detached background process, never the TUI, so running
+// `kranz` again in the same directory must reattach to the runtime that
+// is still there instead of starting a second one or refusing outright.
+// It covers the way that promise was broken in practice — a runtime left
+// holding its name with its descriptor gone, which made discovery report
+// an empty project while a fresh start was refused as already active.
+func TestBareLaunchReattachesAfterTheDashboardDiesAbruptly(t *testing.T) {
+	useHelperBackgroundRuntimes(t)
+	directory := t.TempDir()
+	name := fmt.Sprintf("reattach-test-%d", os.Getpid())
+	document := "project: " + name + "\nruntime:\n  name: " + name + "\nservices:\n  api:\n    command: sleep 60\n"
+	if err := os.WriteFile(filepath.Join(directory, "kranz.yaml"), []byte(document), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = runDown(kranzcli.GlobalOptions{Project: name, Output: kranzcli.OutputText}, nil, io.Discard)
+	})
+
+	previousDashboard := runDashboardProgram
+	runDashboardProgram = func(*tea.Program) (tea.Model, error) { return nil, nil }
+	defer func() { runDashboardProgram = previousDashboard }()
+
+	options := kranzcli.GlobalOptions{Directory: directory, Output: kranzcli.OutputText}
+	if err := runTUI(options); err != nil {
+		t.Fatalf("first bare launch failed: %v", err)
+	}
+	registry, err := kranzruntime.DefaultRegistry()
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := registry.Resolve(context.Background(), name, version)
+	if err != nil {
+		t.Fatalf("runtime never published: %v", err)
+	}
+
+	// The dashboard is gone and took its descriptor with it; the runtime
+	// itself is untouched and still owns the name.
+	if err := os.Remove(filepath.Join(os.TempDir(), fmt.Sprintf("kranz-%d", os.Getuid()), name+".json")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runTUI(options); err != nil {
+		t.Fatalf("relaunching in the same directory failed: %v", err)
+	}
+	reattached, err := registry.Resolve(context.Background(), name, version)
+	if err != nil {
+		t.Fatalf("runtime unresolvable after relaunch: %v", err)
+	}
+	if reattached.ID != started.ID {
+		t.Fatalf("relaunch replaced the runtime: %s -> %s", started.ID, reattached.ID)
+	}
+}

--- a/internal/runtime/registry.go
+++ b/internal/runtime/registry.go
@@ -23,6 +23,10 @@ import (
 
 const metadataVersion = 1
 
+// registryRepairDialTimeout bounds the liveness probe that decides whether
+// a descriptor found in a lock body still belongs to a running runtime.
+const registryRepairDialTimeout = 150 * time.Millisecond
+
 type SessionState string
 
 const (
@@ -179,6 +183,11 @@ func (r *Registry) acquire(name string, afterOpen func()) (*SessionHandle, error
 				matched, statErr := sameOpenFile(file, lockPath)
 				_ = file.Close()
 				if statErr == nil && matched {
+					// The name is genuinely taken, but the owner may be
+					// the stranded kind. Restore its descriptor so the
+					// advice this error carries — inspect it, stop it —
+					// can be followed instead of meeting an empty project.
+					r.repairLostDescriptors()
 					return nil, &SessionConflictError{Name: name}
 				}
 				continue
@@ -205,6 +214,53 @@ func (r *Registry) acquire(name string, afterOpen func()) (*SessionHandle, error
 		_ = file.Close()
 	}
 	return nil, fmt.Errorf("runtime lock %q kept changing", name)
+}
+
+// repairLostDescriptors republishes the descriptor of any runtime that is
+// still alive and still owns its name but whose <name>.json has gone
+// missing. Without this the runtime is stranded: discovery finds nothing,
+// so status, attach and down all report an empty project, while the lock
+// it still holds refuses a fresh start under the same name. Nothing else
+// recreates the file — a live session rewrites its ownership snapshot but
+// publishes its descriptor exactly once, at startup.
+//
+// A descriptor is only trusted when the lock is currently held and the
+// socket still answers, so neither a leftover body nor a runtime that
+// exited can be brought back.
+func (r *Registry) repairLostDescriptors() {
+	locks, err := filepath.Glob(filepath.Join(r.root, "*.lock"))
+	if err != nil {
+		return
+	}
+	for _, lockPath := range locks {
+		name := strings.TrimSuffix(filepath.Base(lockPath), ".lock")
+		if _, err := os.Stat(r.metadataPath(name)); err == nil {
+			continue
+		}
+		// An empty body is the common case: every lock left by a closed
+		// session, and every lock written before descriptors were
+		// recorded here at all.
+		if info, err := os.Stat(lockPath); err != nil || info.Size() == 0 {
+			continue
+		}
+		data, err := os.ReadFile(lockPath)
+		if err != nil {
+			continue
+		}
+		var metadata SessionMetadata
+		if json.Unmarshal(data, &metadata) != nil || metadata.MetadataVersion != metadataVersion || metadata.Name != name || metadata.Socket == "" {
+			continue
+		}
+		if locked, err := r.isLocked(name); err != nil || !locked {
+			continue
+		}
+		conn, err := net.DialTimeout("unix", metadata.Socket, registryRepairDialTimeout)
+		if err != nil {
+			continue
+		}
+		_ = conn.Close()
+		_ = atomicJSON(r.metadataPath(name), metadata)
+	}
 }
 
 func (r *Registry) existingSessionLive(name string) (bool, string) {
@@ -266,7 +322,29 @@ func (h *SessionHandle) Publish() error {
 	if err := atomicJSON(h.registry.metadataPath(h.meta.Name), h.meta); err != nil {
 		return err
 	}
+	if err := h.recordLockDescriptor(); err != nil {
+		return err
+	}
 	return h.UpdateOwnership(nil)
+}
+
+// recordLockDescriptor copies the metadata into the lock file this session
+// already holds, so the answer to "who owns this name" and the answer to
+// "what is it" live in one place. Losing the descriptor file alone then
+// costs nothing: the lock body outlives it and listing restores it. The
+// body is only ever written by the owner, which holds the lock exclusively.
+func (h *SessionHandle) recordLockDescriptor() error {
+	encoded, err := json.Marshal(h.meta)
+	if err != nil {
+		return err
+	}
+	if err := h.lock.Truncate(int64(len(encoded))); err != nil {
+		return err
+	}
+	if _, err := h.lock.WriteAt(encoded, 0); err != nil {
+		return err
+	}
+	return h.lock.Sync()
 }
 
 // UpdateOwnership replaces the recovery snapshot without recording commands,
@@ -316,6 +394,9 @@ func (h *SessionHandle) Close() error {
 		_ = os.Remove(h.registry.metadataPath(h.meta.Name))
 		_ = os.Remove(h.registry.ownershipPath(h.meta.Name))
 	}
+	// Lock files outlive the sessions that used them, so a shutdown must
+	// leave no descriptor behind for recovery to find.
+	_ = h.lock.Truncate(0)
 	err := syscall.Flock(int(h.lock.Fd()), syscall.LOCK_UN)
 	return errors.Join(err, h.lock.Close())
 }
@@ -378,6 +459,7 @@ func (r *Registry) ListForSwitcher(ctx context.Context, clientVersion, selfSurfa
 }
 
 func (r *Registry) list(ctx context.Context, clientVersion string, includeStale bool, excludeSurface string, excludePID int) ([]SessionRecord, error) {
+	r.repairLostDescriptors()
 	paths, err := filepath.Glob(filepath.Join(r.root, "*.json"))
 	if err != nil {
 		return nil, err

--- a/internal/runtime/registry_test.go
+++ b/internal/runtime/registry_test.go
@@ -383,3 +383,135 @@ func TestAcquireDoesNotReplaceLiveSessionAfterLockPathReplacement(t *testing.T) 
 		t.Fatal(err)
 	}
 }
+
+// TestListRecoversDescriptorLostUnderALiveRuntime covers the failure that
+// leaves a healthy runtime unreachable: its descriptor is gone, but the
+// process still holds the lock. Discovery then reports nothing running
+// while a fresh start under the same name is refused as already active,
+// and nothing recreates the descriptor because only ownership snapshots
+// are rewritten while a runtime lives. Listing must repair it instead.
+func TestListRecoversDescriptorLostUnderALiveRuntime(t *testing.T) {
+	registry, err := NewRegistry(filepath.Join(t.TempDir(), "registry"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	handle, err := registry.Acquire("shop")
+	if err != nil {
+		t.Fatal(err)
+	}
+	metadata, err := handle.Prepare("Shop", "dev", "background", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{Project: "Shop", Services: map[string]config.Service{"web": {Command: "true"}}}
+	supervisor := NewSupervisor(app.NewLocal(cfg, nil, app.Options{}))
+	if err := supervisor.Listen(metadata.Socket); err != nil {
+		t.Fatal(err)
+	}
+	if err := handle.Publish(); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- supervisor.Serve() }()
+	defer func() { _ = supervisor.Close(); <-done; _ = handle.Close() }()
+
+	if err := os.Remove(registry.metadataPath("shop")); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	records, err := registry.List(ctx, "dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 || records[0].State != SessionRunning || records[0].ID != metadata.ID {
+		t.Fatalf("List = %+v, want the live runtime recovered", records)
+	}
+	if _, err := os.Stat(registry.metadataPath("shop")); err != nil {
+		t.Fatalf("descriptor was not restored on disk: %v", err)
+	}
+	assertMode(t, registry.metadataPath("shop"), 0o600)
+}
+
+// TestListDoesNotResurrectAClosedRuntimeFromItsLock is the other half of
+// the contract: lock files outlive the runtimes that used them, so a
+// descriptor left in a lock body must never bring a dead runtime back.
+func TestListDoesNotResurrectAClosedRuntimeFromItsLock(t *testing.T) {
+	registry, err := NewRegistry(filepath.Join(t.TempDir(), "registry"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	handle, err := registry.Acquire("gone")
+	if err != nil {
+		t.Fatal(err)
+	}
+	metadata, err := handle.Prepare("Gone", "dev", "background", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	listener, err := listenUnix(metadata.Socket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := handle.Publish(); err != nil {
+		t.Fatal(err)
+	}
+	if err := listener.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := handle.Close(); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	records, err := registry.List(ctx, "dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("List = %+v, want nothing after a clean shutdown", records)
+	}
+	if _, err := os.Stat(registry.metadataPath("gone")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("a closed runtime was republished: %v", err)
+	}
+}
+
+// TestAcquireConflictRestoresTheStrandedOwnersDescriptor pins the promise
+// the conflict error makes: it tells the caller to inspect or stop the
+// runtime that holds the name, so that runtime must be discoverable by
+// the time the error is returned.
+func TestAcquireConflictRestoresTheStrandedOwnersDescriptor(t *testing.T) {
+	registry, err := NewRegistry(filepath.Join(t.TempDir(), "registry"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	owner, err := registry.Acquire("shop")
+	if err != nil {
+		t.Fatal(err)
+	}
+	metadata, err := owner.Prepare("Shop", "dev", "background", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	listener, err := listenUnix(metadata.Socket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = listener.Close() }()
+	if err := owner.Publish(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = owner.Close() }()
+	if err := os.Remove(registry.metadataPath("shop")); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = registry.Acquire("shop")
+	var conflict *SessionConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("Acquire = %T %v, want conflict", err, err)
+	}
+	if _, err := os.Stat(registry.metadataPath("shop")); err != nil {
+		t.Fatalf("conflict left the owner undiscoverable: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- persist runtime metadata in the held lock file
- restore missing live runtime descriptors during discovery and conflicts
- cover registry recovery and bare-launch reattachment

## Verification
- make fmt-check vet test homebrew-formula-check release-notes-check packages-script-check
- development/build via project runtime