### PR TITLE
Fix TUI run history affordances

### DIFF
--- a/internal/ui/model_appearance_test.go
+++ b/internal/ui/model_appearance_test.go
@@ -488,7 +488,7 @@ func TestThemeSaveConfirmationCanCancelWithoutWriting(t *testing.T) {
 	}
 }
 
-func TestBackdropBlendsForegroundAndBackgroundWithBlack(t *testing.T) {
+func TestBackdropBlendsForegroundAndBackgroundWithTint(t *testing.T) {
 	previousProfile := lipgloss.ColorProfile()
 	lipgloss.SetColorProfile(termenv.TrueColor)
 	defer lipgloss.SetColorProfile(previousProfile)
@@ -497,7 +497,7 @@ func TestBackdropBlendsForegroundAndBackgroundWithBlack(t *testing.T) {
 		Foreground(lipgloss.Color("#C0392B")).
 		Background(lipgloss.Color("#FDF6E3")).
 		Render("colour")
-	darkened := darkenANSIColors(painted, 0.18)
+	darkened := blendANSIColors(painted, "#000000", 0.18)
 	if ansi.Strip(darkened) != "colour" {
 		t.Fatalf("colour blending changed text: %q", ansi.Strip(darkened))
 	}
@@ -506,6 +506,29 @@ func TestBackdropBlendsForegroundAndBackgroundWithBlack(t *testing.T) {
 	}
 	if !strings.Contains(darkened, "48;2;207;202;186") {
 		t.Fatalf("background was not blended with black: %q", darkened)
+	}
+}
+
+func TestBlackCanvasBackdropUsesVisibleGreyTint(t *testing.T) {
+	restoreDefaultTheme(t)
+	if _, err := ApplyTheme("high-contrast", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := string(ColorOverlay), "#1E232A"; got != want {
+		t.Fatalf("black canvas overlay = %s, want visible grey %s", got, want)
+	}
+	if modalOverlayTint == "#000000" {
+		t.Fatal("black canvas overlay still uses an invisible black tint")
+	}
+
+	previousProfile := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.ANSI256)
+	defer lipgloss.SetColorProfile(previousProfile)
+	backdrop := lipgloss.NewStyle().Background(ColorOverlay).Render(" ")
+	black := lipgloss.NewStyle().Background(lipgloss.Color("#000000")).Render(" ")
+	if backdrop == black {
+		t.Fatal("black canvas overlay collapses to black in the 256-colour profile")
 	}
 }
 

--- a/internal/ui/run_view.go
+++ b/internal/ui/run_view.go
@@ -326,6 +326,7 @@ func (m *Model) renderPinnedActionRunPanel(target app.RunTarget, width, height i
 
 func (m *Model) openRunList() {
 	if !m.syncRunTarget() || len(m.runsForTarget(m.runTarget)) == 0 {
+		m.mode = ModeRunList
 		return
 	}
 	m.normalizeRunStatusFilter()
@@ -413,6 +414,12 @@ func (m *Model) normalizeRunStatusFilter() {
 }
 
 func (m *Model) handleRunListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if len(m.runsForTarget(m.runTarget)) == 0 {
+		if msg.String() == "enter" || msg.String() == "esc" {
+			m.mode = ModeNormal
+		}
+		return m, nil
+	}
 	runs := m.filteredRunList()
 	switch {
 	case key.Matches(msg, m.keys.Up):
@@ -533,11 +540,18 @@ func renderRunListColumns(layout []runListColumn, values map[string]string) stri
 }
 
 func (m *Model) renderRunListView() string {
+	if len(m.runsForTarget(m.runTarget)) == 0 {
+		return m.placeOverlay(renderConfirmationModal(
+			"No runs",
+			[]string{"There are no runs for the selected target yet."},
+			"[Enter / Esc] Close",
+		))
+	}
 	runs := m.filteredRunList()
 	contentWidth := flushModalContentWidth(m.width, 104)
 	rowWidth := max(3, contentWidth-2)
 	layout := newRunListLayout(rowWidth)
-	shortcutGroups := []string{"[↑/↓] Select", "[Enter] Open run", "[d] Delete"}
+	shortcutGroups := []string{"[↑/↓] [j/k] Select", "[Enter] Open run", "[d] Delete"}
 	if filters := m.runStatusFilters(); len(filters) > 1 {
 		filter := m.runStatusFilter
 		if filter == "" {

--- a/internal/ui/run_view_test.go
+++ b/internal/ui/run_view_test.go
@@ -123,12 +123,44 @@ func TestRunListIncludesRetentionAndProvenanceFields(t *testing.T) {
 	model.width, model.height, model.ready = 140, 30, true
 	finishTestServiceRun(t, model, "api", 7, "failed output")
 	model.refreshServices()
-	model.openRunList()
+	if !model.handleLogKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'v'}}) {
+		t.Fatal("v was not handled")
+	}
 	plain := ansi.Strip(model.renderRunListView())
-	for _, expected := range []string{"RUN", "STATUS", "START", "DURATION", "EXIT", "REASON", "INITIATOR", "OUTPUT", "#1", "7", "runtime", "complete", "Run history · api"} {
+	for _, expected := range []string{"RUN", "STATUS", "START", "DURATION", "EXIT", "REASON", "INITIATOR", "OUTPUT", "#1", "7", "runtime", "complete", "Run history · api", "[↑/↓] [j/k] Select"} {
 		if !strings.Contains(plain, expected) {
 			t.Fatalf("run list missing %q:\n%s", expected, plain)
 		}
+	}
+}
+
+func TestRunListShowsDismissibleAlertWhenTargetHasNoRuns(t *testing.T) {
+	model := newTestModel()
+	defer model.Shutdown()
+	model.width, model.height, model.ready = 100, 24, true
+
+	if !model.handleLogKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'v'}}) {
+		t.Fatal("v was not handled")
+	}
+	if model.mode != ModeRunList {
+		t.Fatalf("opening empty run list left mode = %v, want ModeRunList", model.mode)
+	}
+	plain := ansi.Strip(model.renderRunListView())
+	for _, expected := range []string{"No runs", "There are no runs for the selected target yet.", "[Enter / Esc] Close"} {
+		if !strings.Contains(plain, expected) {
+			t.Fatalf("empty run alert is missing %q:\n%s", expected, plain)
+		}
+	}
+
+	_, _ = model.handleRunListKeys(tea.KeyMsg{Type: tea.KeyEnter})
+	if model.mode != ModeNormal {
+		t.Fatalf("Enter left empty run alert mode = %v, want ModeNormal", model.mode)
+	}
+
+	model.openRunList()
+	_, _ = model.handleRunListKeys(tea.KeyMsg{Type: tea.KeyEsc})
+	if model.mode != ModeNormal {
+		t.Fatalf("Esc left empty run alert mode = %v, want ModeNormal", model.mode)
 	}
 }
 

--- a/internal/ui/runtime_rows.go
+++ b/internal/ui/runtime_rows.go
@@ -171,7 +171,7 @@ type runtimeTableLayout struct {
 func newRuntimeTableLayout(width int) runtimeTableLayout {
 	layout := runtimeTableLayout{
 		nameWidth: runtimeRowNameWidth, statusWidth: 12, clientsWidth: 16,
-		servicesWidth: 8, uptimeWidth: 7, showClients: true, showUptime: true,
+		servicesWidth: 8, uptimeWidth: 8, showClients: true, showUptime: true,
 	}
 	coreWidth := func() int {
 		widths := []int{layout.nameWidth, layout.statusWidth, layout.servicesWidth}

--- a/internal/ui/runtime_switcher_test.go
+++ b/internal/ui/runtime_switcher_test.go
@@ -141,6 +141,14 @@ func TestRuntimeTableSeparatesStatusClientsAndServices(t *testing.T) {
 	}
 }
 
+func TestRuntimeTableKeepsJustNowComplete(t *testing.T) {
+	row := rowFor("s", "shop", time.Now(), false, kranzruntime.SessionRunning)
+	line := runtimeRowLine(row, 100)
+	if !strings.Contains(line, "just now") || strings.Contains(line, "just n…") {
+		t.Fatalf("runtime uptime was truncated: %q", line)
+	}
+}
+
 func TestRuntimeSwitcherFitsNarrowTerminalWithoutLosingCoreControls(t *testing.T) {
 	model := newTestModel()
 	defer model.Shutdown()
@@ -154,7 +162,7 @@ func TestRuntimeSwitcherFitsNarrowTerminalWithoutLosingCoreControls(t *testing.T
 
 	rendered := model.renderRuntimeSwitcherView()
 	plain := ansi.Strip(rendered)
-	for _, expected := range []string{"RUNTIME", "STATUS", "CLIENTS", "SERVICES", "shop", "started", "MCP", "3/5", "[Enter] Connect", "[Esc] Cancel"} {
+	for _, expected := range []string{"RUNTIME", "STATUS", "CLIENTS", "SERVICES", "shop", "started", "MCP", "3/5", "[↑/↓] [j/k] Select", "[Enter] Connect", "[Esc] Cancel"} {
 		if !strings.Contains(plain, expected) {
 			t.Fatalf("narrow runtime modal lost %q:\n%s", expected, plain)
 		}

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -18,6 +18,7 @@ var (
 	ColorDarkBg         lipgloss.Color
 	ColorSurfaceAlt     lipgloss.Color
 	ColorOverlay        lipgloss.Color
+	modalOverlayTint    string
 	modalOverlayOpacity float64
 	ColorBorder         lipgloss.Color
 	ColorDim            lipgloss.Color
@@ -84,11 +85,21 @@ func applyPalette(theme Theme) {
 	ColorBackground = lipgloss.Color(theme.Background)
 	ColorDarkBg = lipgloss.Color(theme.Surface)
 	ColorSurfaceAlt = lipgloss.Color(theme.SurfaceAlt)
+	modalOverlayTint = "#000000"
 	modalOverlayOpacity = 0.42
-	if background, ok := parseHex(theme.Background); ok && relativeLuminance(background) > 0.45 {
-		modalOverlayOpacity = 0.18
+	if background, ok := parseHex(theme.Background); ok {
+		switch luminance := relativeLuminance(background); {
+		case luminance < 0.015:
+			// A black scrim is invisible on a black terminal canvas. Lift nearly
+			// black canvases toward a neutral grey so the inactive dashboard still
+			// reads as a distinct layer behind the modal.
+			modalOverlayTint = "#64748B"
+			modalOverlayOpacity = 0.30
+		case luminance > 0.45:
+			modalOverlayOpacity = 0.18
+		}
 	}
-	ColorOverlay = lipgloss.Color(mixHex(theme.Background, "#000000", modalOverlayOpacity))
+	ColorOverlay = lipgloss.Color(mixHex(theme.Background, modalOverlayTint, modalOverlayOpacity))
 	ColorBorder = lipgloss.Color(theme.Border)
 	ColorDim = lipgloss.Color(theme.Muted)
 	stopped := "#94A3B8"

--- a/internal/ui/view_modals.go
+++ b/internal/ui/view_modals.go
@@ -1049,11 +1049,11 @@ func (m *Model) placeOverlay(content string) string {
 	}
 	top := max(0, (m.height-len(contentLines))/2)
 	left := max(0, (m.width-contentWidth)/2)
-	// Emulate a translucent black layer by mixing every ANSI colour with black.
+	// Emulate a translucent layer by mixing every ANSI colour with its tint.
 	// The explicit background applies the same blend to otherwise empty cells.
 	dim := lipgloss.NewStyle().Background(ColorOverlay)
 	dimBackground := func(fragment string) string {
-		fragment = darkenANSIColors(fragment, modalOverlayOpacity)
+		fragment = blendANSIColors(fragment, modalOverlayTint, modalOverlayOpacity)
 		return dim.Render(preserveStyleAfterReset(fragment, dim))
 	}
 
@@ -1073,9 +1073,13 @@ func (m *Model) placeOverlay(content string) string {
 	return strings.Join(result, "\n")
 }
 
-// darkenANSIColors emulates a translucent black overlay for true-colour SGR
-// foregrounds, backgrounds, and underline colours without changing their hue.
-func darkenANSIColors(value string, opacity float64) string {
+// blendANSIColors emulates a translucent overlay for true-colour SGR
+// foregrounds, backgrounds, and underline colours.
+func blendANSIColors(value, tint string, opacity float64) string {
+	tintColor, ok := parseHex(tint)
+	if !ok {
+		return value
+	}
 	var result strings.Builder
 	for len(value) > 0 {
 		start := strings.Index(value, "\x1b[")
@@ -1103,8 +1107,8 @@ func darkenANSIColors(value string, opacity float64) string {
 						kept = append(kept, params[component])
 						continue
 					}
-					darkened := int(math.Round(float64(componentValue) * (1 - opacity)))
-					kept = append(kept, strconv.Itoa(max(0, min(255, darkened))))
+					blended := float64(componentValue) + (tintColor[component-index-2]-float64(componentValue))*opacity
+					kept = append(kept, strconv.Itoa(max(0, min(255, int(math.Round(blended))))))
 				}
 				index += 4
 				continue

--- a/internal/ui/view_runtime.go
+++ b/internal/ui/view_runtime.go
@@ -12,7 +12,7 @@ import (
 // runtime, current first, live-refreshing while open (PRD 3.2).
 func (m *Model) renderRuntimeSwitcherView() string {
 	contentWidth := flushModalContentWidth(m.width, 110)
-	shortcutGroups := []string{"[↑/↓ · j/k] Select", "[Enter] Connect", "[Esc] Cancel"}
+	shortcutGroups := []string{"[↑/↓] [j/k] Select", "[Enter] Connect", "[Esc] Cancel"}
 	if m.switcherConnecting != "" {
 		shortcutGroups = append(shortcutGroups, "Connecting…")
 	}


### PR DESCRIPTION
## Summary
- keep the `just now` uptime label from truncating
- align runtime and run-history navigation hints for arrows and j/k
- show a dismissible alert when `v` is pressed without runs

## Testing
- `go test ./...`