### PR TITLE
Release 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-09-07
+
 ### Fixed
 
 - A running runtime can no longer be stranded by the loss of its registry
@@ -13,6 +15,15 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
   now records its descriptor in the lock file it already holds, and
   discovery restores a missing descriptor from there whenever the lock is
   still held and the runtime still answers.
+- Modal dialogs remain visually distinct from the dashboard on black and
+  near-black terminal backgrounds.
+- Opening Run history for a service or action with no runs now shows a
+  dismissible explanation instead of appearing to do nothing. The Run history
+  footer also advertises both arrow-key and `j`/`k` navigation.
+- The runtime switcher now includes the current dashboard's `TUI` connection
+  in `CLIENTS`, so concurrent `MCP` and `CLI` use stays visible on the current
+  row. Client surfaces use a compact space-separated form such as
+  `CLI MCP TUI` that fits in the 11-cell column.
 
 ## [0.13.0] - 2026-09-06
 
@@ -728,7 +739,8 @@ artifacts.
 - Explicit global-user and project-config save destinations in the live theme picker.
 - Native compatibility for common Process Compose configurations.
 
-[Unreleased]: https://github.com/kranz-org/kranz/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/kranz-org/kranz/compare/v0.13.1...HEAD
+[0.13.1]: https://github.com/kranz-org/kranz/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/kranz-org/kranz/compare/v0.12.1...v0.13.0
 [0.12.1]: https://github.com/kranz-org/kranz/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/kranz-org/kranz/compare/v0.11.1...v0.12.0

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -42,7 +42,7 @@ workflow; generated binaries are never checked into the repository.
    make verify
    make lint
    make release-check
-   make snapshot RELEASE_VERSION=0.13.0 # use the release being prepared
+   make snapshot RELEASE_VERSION=0.13.1 # use the release being prepared
    ./dist/kranz_darwin_arm64_v8.0/kranz --version # choose the local platform build
    make packages-verify
    PACKAGE_ARCH=arm64 make packages-verify
@@ -59,9 +59,9 @@ workflow; generated binaries are never checked into the repository.
 4. Create an annotated tag without pushing it automatically:
 
    ```bash
-   make tag RELEASE_VERSION=0.13.0 # use the release being published
-   git show v0.13.0
-   git push origin v0.13.0
+   make tag RELEASE_VERSION=0.13.1 # use the release being published
+   git show v0.13.1
+   git push origin v0.13.1
    ```
 
 ## Verify the published release
@@ -73,8 +73,8 @@ replaces generated commit notes with the matching version section from
 the release before announcing it:
 
 ```bash
-gh release view v0.13.0
-gh release download v0.13.0 \
+gh release view v0.13.1
+gh release download v0.13.1 \
   --pattern 'checksums.txt' \
   --pattern '*.tar.gz' \
   --pattern '*.deb' \

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -24,7 +24,7 @@ go install github.com/kranz-org/kranz/cmd/kranz@latest
 ## Debian and Ubuntu
 
 ```bash
-VERSION=0.13.0
+VERSION=0.13.1
 ARCH=amd64  # use arm64 on an ARM machine
 curl -fLO "https://github.com/kranz-org/kranz/releases/download/v${VERSION}/kranz_${VERSION}_linux_${ARCH}.deb"
 sudo apt install "./kranz_${VERSION}_linux_${ARCH}.deb"
@@ -40,7 +40,7 @@ Remove it with `sudo apt remove kranz`.
 ## Fedora, RHEL, and Rocky
 
 ```bash
-VERSION=0.13.0
+VERSION=0.13.1
 ARCH=amd64  # use arm64 on an ARM machine
 sudo dnf install "https://github.com/kranz-org/kranz/releases/download/v${VERSION}/kranz_${VERSION}_linux_${ARCH}.rpm"
 kranz --version

--- a/docs/guide/logs-and-ports.md
+++ b/docs/guide/logs-and-ports.md
@@ -88,6 +88,8 @@ In the TUI, `v` opens the run history for the focused service or action. `x`
 switches between all runs and a single run, `[` and `]` step through history,
 `Shift+F` jumps to the previous failed run, and `l` returns to the latest.
 `Shift+3` pins a run so it stays frozen while the live panel keeps moving.
+If the target has never run, `v` opens a dismissible explanation instead of an
+empty table.
 See [Controls](../reference/controls) for the complete list.
 
 Retention is per session. A run summary and its output can also be dropped

--- a/docs/reference/controls.md
+++ b/docs/reference/controls.md
@@ -127,7 +127,10 @@ appears or disappears without reopening the modal.
 The table has separate `RUNTIME`, `STATUS`, `CLIENTS`, `SERVICES`, `UPTIME`,
 and `DIRECTORY` columns. `STATUS` is `current` for the runtime already open
 and `started` for another available runtime. `CLIENTS` lists the unique client
-surfaces connected to it (for example `TUI · MCP`) without counts, while
+surfaces connected to it (for example `CLI MCP TUI`) without counts. The
+current row includes the dashboard's own `TUI` connection, so another `MCP` or
+`CLI` client remains visible beside it. The compact labels fit three standard
+surfaces in the 11-cell column, while
 `SERVICES` shows running/total in the same `3/5` form as `kranz ps`. A runtime
 running an incompatible protocol version, or one the switcher cannot currently
 reach, is shown greyed out and cannot be selected; selecting it spells the

--- a/internal/runtime/registry.go
+++ b/internal/runtime/registry.go
@@ -444,21 +444,10 @@ const backgroundOwnerSurface = "background"
 const registryProbeConcurrency = 8
 
 func (r *Registry) List(ctx context.Context, clientVersion string) ([]SessionRecord, error) {
-	return r.list(ctx, clientVersion, false, "", 0)
+	return r.list(ctx, clientVersion, false)
 }
 
-// ListForSwitcher lists sessions the same way List does, additionally
-// excluding one caller connection identified by (selfSurface, selfPID) from
-// the computed client surfaces of whichever session it happens to be
-// connected to. A TUI passes its own surface and PID so its own dashboard
-// connection to the current runtime does not inflate that runtime's own row;
-// the exclusion is a no-op for every other session, since a caller can only
-// ever be connected, under its own PID, to the one runtime it is attached to.
-func (r *Registry) ListForSwitcher(ctx context.Context, clientVersion, selfSurface string, selfPID int) ([]SessionRecord, error) {
-	return r.list(ctx, clientVersion, false, selfSurface, selfPID)
-}
-
-func (r *Registry) list(ctx context.Context, clientVersion string, includeStale bool, excludeSurface string, excludePID int) ([]SessionRecord, error) {
+func (r *Registry) list(ctx context.Context, clientVersion string, includeStale bool) ([]SessionRecord, error) {
 	r.repairLostDescriptors()
 	paths, err := filepath.Glob(filepath.Join(r.root, "*.json"))
 	if err != nil {
@@ -486,7 +475,7 @@ func (r *Registry) list(ctx context.Context, clientVersion string, includeStale 
 			defer probes.Done()
 			probeSlots <- struct{}{}
 			defer func() { <-probeSlots }()
-			record, keep := r.probeRecord(ctx, path, metadata, locked, clientVersion, includeStale, excludeSurface, excludePID)
+			record, keep := r.probeRecord(ctx, path, metadata, locked, clientVersion, includeStale)
 			if !keep {
 				return
 			}
@@ -500,7 +489,7 @@ func (r *Registry) list(ctx context.Context, clientVersion string, includeStale 
 	return records, nil
 }
 
-func (r *Registry) probeRecord(ctx context.Context, path string, metadata SessionMetadata, locked bool, clientVersion string, includeStale bool, excludeSurface string, excludePID int) (SessionRecord, bool) {
+func (r *Registry) probeRecord(ctx context.Context, path string, metadata SessionMetadata, locked bool, clientVersion string, includeStale bool) (SessionRecord, bool) {
 	record := SessionRecord{SessionMetadata: metadata, State: SessionUnreachable}
 	client, dialErr := DialContextWithIdentity(ctx, metadata.Socket, clientVersion,
 		ClientIdentity{Surface: registryProbeSurface, Label: "Kranz runtime discovery"})
@@ -533,9 +522,6 @@ func (r *Registry) probeRecord(ctx context.Context, path string, metadata Sessio
 			surfaces := make([]string, 0, len(connected))
 			for _, info := range connected {
 				if info.Surface == registryProbeSurface || info.Surface == backgroundOwnerSurface {
-					continue
-				}
-				if excludeSurface != "" && info.Surface == excludeSurface && info.PID == excludePID {
 					continue
 				}
 				others++
@@ -581,7 +567,7 @@ func (r *Registry) Resolve(ctx context.Context, reference, clientVersion string)
 // fallback for that launch instead of silently converting stale evidence into
 // "not found" and racing an unproven supervisor.
 func (r *Registry) ResolveForAttach(ctx context.Context, reference, clientVersion string) (SessionRecord, error) {
-	records, err := r.list(ctx, clientVersion, true, "", 0)
+	records, err := r.list(ctx, clientVersion, true)
 	if err != nil {
 		return SessionRecord{}, err
 	}

--- a/internal/ui/runtime_integration_test.go
+++ b/internal/ui/runtime_integration_test.go
@@ -428,7 +428,7 @@ func TestClientSurfacesIncludeCurrentTUIAndOtherClients(t *testing.T) {
 			t.Fatalf("client surfaces leaked the discovery probe: %v", row.Record.ClientSurfaces)
 		}
 	}
-	if got := runtimeRowSurfaceLabel(row); got != "MCP · TUI" {
-		t.Fatalf("current runtime client surfaces = %q, want %q", got, "MCP · TUI")
+	if got := runtimeRowSurfaceLabel(row); got != "MCP TUI" {
+		t.Fatalf("current runtime client surfaces = %q, want %q", got, "MCP TUI")
 	}
 }

--- a/internal/ui/runtime_integration_test.go
+++ b/internal/ui/runtime_integration_test.go
@@ -394,13 +394,18 @@ func TestRuntimeLossRecoveryRestartSameProject(t *testing.T) {
 	}
 }
 
-// TestClientSurfacesExcludeProbeAndSelf is the protocol-level check PRD 9
-// asks for: the switcher's client-surface list never counts the transient
-// discovery probe, and never counts the viewer's own connection to the
-// runtime it is currently attached to.
-func TestClientSurfacesExcludeProbeAndSelf(t *testing.T) {
+// TestClientSurfacesIncludeCurrentTUIAndOtherClients checks that the current
+// runtime describes every user-facing connection while keeping the transient
+// discovery probe out of the modal.
+func TestClientSurfacesIncludeCurrentTUIAndOtherClients(t *testing.T) {
 	registry := testRegistry(t)
 	alpha := startTestRuntime(t, registry, "surfaces-alpha", emptyProjectConfig("Alpha"), t.TempDir())
+	mcpClient, err := kranzruntime.DialWithIdentity(alpha.record.Socket, "test",
+		kranzruntime.ClientIdentity{Surface: "mcp", Label: "test-agent"})
+	if err != nil {
+		t.Fatalf("dial MCP client: %v", err)
+	}
+	defer func() { _ = mcpClient.Close() }()
 
 	model := newSwitchableTestModel(t, registry, alpha, ModelOptions{})
 	fireOnce(model, model.openRuntimeSwitcher())
@@ -423,9 +428,7 @@ func TestClientSurfacesExcludeProbeAndSelf(t *testing.T) {
 			t.Fatalf("client surfaces leaked the discovery probe: %v", row.Record.ClientSurfaces)
 		}
 	}
-	// The model's own dashboard connection to its current runtime must not
-	// inflate that runtime's own surface list (PRD 3.2).
-	if len(row.Record.ClientSurfaces) != 0 {
-		t.Fatalf("current runtime's own connection was counted as a client surface: %v", row.Record.ClientSurfaces)
+	if got := runtimeRowSurfaceLabel(row); got != "MCP · TUI" {
+		t.Fatalf("current runtime client surfaces = %q, want %q", got, "MCP · TUI")
 	}
 }

--- a/internal/ui/runtime_rows.go
+++ b/internal/ui/runtime_rows.go
@@ -112,7 +112,7 @@ func runtimeRowUptime(record kranzruntime.SessionRecord) string {
 }
 
 // runtimeRowSurfaceLabel joins the deduplicated client surfaces a row is
-// reporting into the compact form the modal shows, for example "TUI · MCP".
+// reporting into the compact form the modal shows, for example "TUI MCP CLI".
 // It never repeats a surface and never shows a count.
 func runtimeRowSurfaceLabel(row runtimeRow) string {
 	if row.Record.State != kranzruntime.SessionRunning || len(row.Record.ClientSurfaces) == 0 {
@@ -122,7 +122,7 @@ func runtimeRowSurfaceLabel(row runtimeRow) string {
 	for i, surface := range row.Record.ClientSurfaces {
 		labels[i] = strings.ToUpper(surface)
 	}
-	return strings.Join(labels, " · ")
+	return strings.Join(labels, " ")
 }
 
 // runtimeRowStatusLabel is the row's status word on its own, never merged
@@ -170,7 +170,7 @@ type runtimeTableLayout struct {
 
 func newRuntimeTableLayout(width int) runtimeTableLayout {
 	layout := runtimeTableLayout{
-		nameWidth: runtimeRowNameWidth, statusWidth: 12, clientsWidth: 16,
+		nameWidth: runtimeRowNameWidth, statusWidth: 12, clientsWidth: 11,
 		servicesWidth: 8, uptimeWidth: 8, showClients: true, showUptime: true,
 	}
 	coreWidth := func() int {

--- a/internal/ui/runtime_rows.go
+++ b/internal/ui/runtime_rows.go
@@ -3,7 +3,6 @@ package ui
 import (
 	"context"
 	"fmt"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -43,10 +42,11 @@ type runtimeListMsg struct {
 
 // discoverRuntimeRows lists every locally registered runtime and classifies
 // each one for display. currentSessionID marks (and always sorts first) the
-// runtime the caller is already attached to; this process's own PID excludes
-// its dashboard connection from that runtime's reported client surfaces.
+// runtime the caller is already attached to. All user-facing connections,
+// including this dashboard's TUI connection, remain visible in the client
+// surfaces so the current row describes every way the runtime is being used.
 func discoverRuntimeRows(ctx context.Context, registry *kranzruntime.Registry, clientVersion, currentSessionID string) ([]runtimeRow, error) {
-	records, err := registry.ListForSwitcher(ctx, clientVersion, "tui", os.Getpid())
+	records, err := registry.List(ctx, clientVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ui/runtime_switcher_test.go
+++ b/internal/ui/runtime_switcher_test.go
@@ -104,12 +104,12 @@ func TestRuntimeRowStatusLabelsMatchPRDStates(t *testing.T) {
 		t.Fatalf("no-other-clients row label = %q, want started", label)
 	}
 	withClients := started
-	withClients.Record.ClientSurfaces = []string{"mcp", "tui"}
+	withClients.Record.ClientSurfaces = []string{"mcp", "tui", "cli"}
 	if label := runtimeRowStatusLabel(withClients); label != "started" {
 		t.Fatalf("client row status = %q, want started", label)
 	}
-	if label := runtimeRowSurfaceLabel(withClients); label != "MCP · TUI" {
-		t.Fatalf("client-surface label = %q, want %q", label, "MCP · TUI")
+	if label := runtimeRowSurfaceLabel(withClients); label != "MCP TUI CLI" {
+		t.Fatalf("client-surface label = %q, want %q", label, "MCP TUI CLI")
 	}
 	incompatible := rowFor("i", "incompatible", now, false, kranzruntime.SessionIncompatible)
 	if label := runtimeRowStatusLabel(incompatible); label != "incompatible" {
@@ -123,7 +123,7 @@ func TestRuntimeRowStatusLabelsMatchPRDStates(t *testing.T) {
 
 func TestRuntimeTableSeparatesStatusClientsAndServices(t *testing.T) {
 	row := rowFor("s", "shop", time.Now(), false, kranzruntime.SessionRunning)
-	row.Record.ClientSurfaces = []string{"mcp", "tui"}
+	row.Record.ClientSurfaces = []string{"mcp", "tui", "cli"}
 	services, running := 5, 3
 	row.Record.Services, row.Record.Running = &services, &running
 
@@ -134,7 +134,7 @@ func TestRuntimeTableSeparatesStatusClientsAndServices(t *testing.T) {
 			t.Fatalf("runtime table header is missing %q: %q", column, header)
 		}
 	}
-	for _, value := range []string{"shop", "started", "MCP · TUI", "3/5"} {
+	for _, value := range []string{"shop", "started", "MCP TUI CLI", "3/5"} {
 		if !strings.Contains(line, value) {
 			t.Fatalf("runtime row is missing %q: %q", value, line)
 		}
@@ -155,7 +155,7 @@ func TestRuntimeSwitcherFitsNarrowTerminalWithoutLosingCoreControls(t *testing.T
 	model.width, model.height, model.ready = 62, 18, true
 	model.mode = ModeRuntimeSwitcher
 	row := rowFor("s", "shop", time.Now(), false, kranzruntime.SessionRunning)
-	row.Record.ClientSurfaces = []string{"mcp", "tui"}
+	row.Record.ClientSurfaces = []string{"mcp", "tui", "cli"}
 	services, running := 5, 3
 	row.Record.Services, row.Record.Running = &services, &running
 	model.switcherRows = []runtimeRow{row}


### PR DESCRIPTION
## Summary

- show TUI, MCP, and CLI client surfaces for the current runtime
- compact the runtime client column to fit the standard surfaces
- prepare the 0.13.1 changelog and release documentation

## Validation

- race-enabled Go tests and coverage
- golangci-lint
- GoReleaser configuration check
- exact-version 0.13.1 snapshot and binary version check
- local Linux package installation checks unavailable because Docker is not installed; the release workflow runs both architectures before publishing