### PR TITLE
Prepare 0.14.0 CLI, init, and TUI workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 - `ps`, `clients`, and `status` accept exact, repeatable `--filter` values and
   interruptible `--watch` refreshes. `--interval` controls refresh frequency,
   and `--count` bounds snapshots for automation.
+- The TUI quit confirmation offers `c` for **Close & choose**: it stops the
+  current runtime and opens the live runtime chooser without leaving the TUI.
+  The chooser remains usable when no other runtime is available.
 
 ### Changed
 
@@ -56,6 +59,8 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
   and the TUI Runtimes window. `kranz ps` now shows the owning supervisor's PID
   directly.
 - The canonical action table shows whether each action requires confirmation.
+- Root help keeps `actions` beside `services` and `tags`, matching the command
+  model users configure and operate in the TUI.
 
 ## [0.13.1] - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
   including a `table ` prefix for aligned output with headers.
 - `status`, `ports`, `doctor`, `config explain`, `action list`, and the
   `list services/actions/tags` views support the same row formatter.
+- `kranz plan --operation start|stop|restart` previews every service a
+  lifecycle operation would affect; bare `plan` remains a start preview.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
   runtime's background ownership connection as a client, matching `kranz ps`
   and the TUI Runtimes window. `kranz ps` now shows the owning supervisor's PID
   directly.
+- `list actions` is now an exact compatibility alias of `action list`; the
+  canonical action table also shows whether each action requires confirmation.
 
 ## [0.13.1] - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 
 ### Changed
 
+- Interactive `kranz init` is now a draft-based terminal wizard. It supports
+  any number of editable and removable services and actions, independent
+  project appearance controls with a live theme preview, and a final YAML or
+  replacement diff before the only write. Init no longer scans `package.json`
+  or implicitly imports nearby files; conversion requires explicit `--from`.
+
 - The obsolete MCP `--attach-only` compatibility flag now emits a deprecation
   warning instead of being silently ignored. It remains accepted until the
   next major release. Version-specific future-command wording in CLI help is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 - `kranz runs` supports target, status, time-window, and newest-count filters,
   plus Docker-style row templates. `kranz runs retention` now owns the
   separate per-target retention table and its formatter fields.
+- `ps`, `clients`, and `status` accept exact, repeatable `--filter` values and
+  interruptible `--watch` refreshes. `--interval` controls refresh frequency,
+  and `--count` bounds snapshots for automation.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 
 ### Changed
 
+- Conflicting `graph --format` and `--output=json` selections now fail instead
+  of silently choosing JSON. Help and shell-completion generation explicitly
+  reject JSON output because their products are text artifacts.
+
 - `kranz clients` now presents each connection in one compact `CLIENT` column,
   such as `TUI`, `CLI: foreground`, or `MCP: codex`. It no longer reports the
   runtime's background ownership connection as a client, matching `kranz ps`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 
 ## [Unreleased]
 
+### Added
+
+- `kranz ps` and `kranz clients` accept Docker-style `--format` Go templates,
+  including a `table ` prefix for aligned output with headers.
+
+### Changed
+
+- `kranz clients` now presents each connection in one compact `CLIENT` column,
+  such as `TUI`, `CLI: foreground`, or `MCP: codex`. It no longer reports the
+  runtime's background ownership connection as a client, matching `kranz ps`
+  and the TUI Runtimes window. `kranz ps` now shows the owning supervisor's PID
+  directly.
+
 ## [0.13.1] - 2026-09-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 
 ### Changed
 
+- The obsolete MCP `--attach-only` compatibility flag now emits a deprecation
+  warning instead of being silently ignored. It remains accepted until the
+  next major release. Version-specific future-command wording in CLI help is
+  now release-neutral.
 - `kranz init --name NAME` is now the unambiguous project-name option.
   `-p/--project` remains accepted by `init` as a compatibility alias, and
   combining both forms is an explicit usage error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 
 - `kranz ps` and `kranz clients` accept Docker-style `--format` Go templates,
   including a `table ` prefix for aligned output with headers.
+- `status`, `ports`, `doctor`, `config explain`, `action list`, and the
+  `list services/actions/tags` views support the same row formatter.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
   `list services/actions/tags` views support the same row formatter.
 - `kranz plan --operation start|stop|restart` previews every service a
   lifecycle operation would affect; bare `plan` remains a start preview.
+- `kranz runs` supports target, status, time-window, and newest-count filters,
+  plus Docker-style row templates. `kranz runs retention` now owns the
+  separate per-target retention table and its formatter fields.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 
 - `kranz ps` and `kranz clients` accept Docker-style `--format` Go templates,
   including a `table ` prefix for aligned output with headers.
-- `status`, `ports`, `doctor`, `config explain`, `action list`, and the
-  `list services/actions/tags` views support the same row formatter.
+- `status`, `ports`, `doctor`, `config explain`, `services`, `actions`, and
+  `tags` support the same row formatter.
+- Top-level `kranz services`, `kranz actions`, and `kranz tags` commands give
+  every inspectable collection a direct noun. The `actions` group defaults to
+  listing and also owns `run` and `info`. The old `list` command and singular
+  `action` group have been removed.
 - `kranz plan --operation start|stop|restart` previews every service a
   lifecycle operation would affect; bare `plan` remains a start preview.
 - `kranz runs` supports target, status, time-window, and newest-count filters,
@@ -21,19 +25,27 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 
 ### Changed
 
+- `kranz up` now creates a runtime without starting services, matching the TUI
+  and MCP surfaces. Selectors still start the named services; `--start`
+  explicitly starts every enabled service. Foreground ownership, log streaming,
+  project exit codes, and `-d` behavior are unchanged. The redundant
+  `--no-start` flag has been removed.
+
 - Interactive `kranz init` is now a draft-based terminal wizard. It supports
   any number of editable and removable services and actions, independent
   project appearance controls with a live theme preview, and a final YAML or
   replacement diff before the only write. Init no longer scans `package.json`
   or implicitly imports nearby files; conversion requires explicit `--from`.
 
-- The obsolete MCP `--attach-only` compatibility flag now emits a deprecation
-  warning instead of being silently ignored. It remains accepted until the
-  next major release. Version-specific future-command wording in CLI help is
-  now release-neutral.
-- `kranz init --name NAME` is now the unambiguous project-name option.
-  `-p/--project` remains accepted by `init` as a compatibility alias, and
-  combining both forms is an explicit usage error.
+- The obsolete MCP `--attach-only` flag has been removed. Version-specific
+  future-command wording in CLI help is now release-neutral.
+- `kranz init --name NAME` is now the only project-name option. Global
+  `-p/--project` consistently addresses a runtime and is rejected by `init`.
+- Project, service, and port inspection now follow their entities explicitly:
+  `kranz project`, `kranz services info SERVICE`, and
+  `kranz ports inspect PORT`. Bare `services` and `ports` select their `list`
+  operations. The overloaded `info` command and singular `port` group have
+  been removed.
 - Conflicting `graph --format` and `--output=json` selections now fail instead
   of silently choosing JSON. Help and shell-completion generation explicitly
   reject JSON output because their products are text artifacts.
@@ -43,8 +55,7 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
   runtime's background ownership connection as a client, matching `kranz ps`
   and the TUI Runtimes window. `kranz ps` now shows the owning supervisor's PID
   directly.
-- `list actions` is now an exact compatibility alias of `action list`; the
-  canonical action table also shows whether each action requires confirmation.
+- The canonical action table shows whether each action requires confirmation.
 
 ## [0.13.1] - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ All notable changes to Kranz are documented here. The project follows [Semantic 
 
 ### Changed
 
+- `kranz init --name NAME` is now the unambiguous project-name option.
+  `-p/--project` remains accepted by `init` as a compatibility alias, and
+  combining both forms is an explicit usage error.
 - Conflicting `graph --format` and `--output=json` selections now fail instead
   of silently choosing JSON. Help and shell-completion generation explicitly
   reject JSON output because their products are text artifacts.

--- a/cmd/kranz/action_commands.go
+++ b/cmd/kranz/action_commands.go
@@ -73,9 +73,9 @@ func runActionList(options kranzcli.GlobalOptions, args []string, stdout io.Writ
 		return nil
 	}
 	w := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintln(w, "ACTION\tOWNER\tKIND\tINTERACTIVE\tDESCRIPTION")
+	_, _ = fmt.Fprintln(w, "ACTION\tOWNER\tKIND\tINTERACTIVE\tCONFIRM\tDESCRIPTION")
 	for _, item := range entries {
-		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%t\t%s\n", item.ID, item.Owner, item.OwnerKind, item.Interactive, orDash(item.Description))
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%t\t%t\t%s\n", item.ID, item.Owner, item.OwnerKind, item.Interactive, item.Confirm, orDash(item.Description))
 	}
 	return w.Flush()
 }

--- a/cmd/kranz/action_commands.go
+++ b/cmd/kranz/action_commands.go
@@ -19,7 +19,20 @@ import (
 // execution slot, and running it anywhere else would let two callers run the
 // same action at once.
 
+type actionListEntry struct {
+	ID          string `json:"id"`
+	Owner       string `json:"owner"`
+	OwnerKind   string `json:"owner_kind"`
+	Description string `json:"description"`
+	Interactive bool   `json:"interactive"`
+	Confirm     bool   `json:"confirm"`
+}
+
 func runActionList(options kranzcli.GlobalOptions, args []string, stdout io.Writer) error {
+	formatter, args, err := extractRowFormat("action list", options.Output, args)
+	if err != nil {
+		return err
+	}
 	if len(args) > 1 {
 		return &kranzcli.Error{Code: "invalid_arguments", Message: "action list accepts at most one owner", ExitCode: kranzcli.ExitUsage}
 	}
@@ -31,32 +44,7 @@ func runActionList(options kranzcli.GlobalOptions, args []string, stdout io.Writ
 	if len(args) == 1 {
 		owner = args[0]
 	}
-	type entry struct {
-		ID          string `json:"id"`
-		Owner       string `json:"owner"`
-		OwnerKind   string `json:"owner_kind"`
-		Description string `json:"description"`
-		Interactive bool   `json:"interactive"`
-		Confirm     bool   `json:"confirm"`
-	}
-	entries := make([]entry, 0)
-	for _, id := range cfg.ActionIDs() {
-		if owner != "" && id.Owner != owner {
-			continue
-		}
-		action, ok := cfg.ResolveAction(id)
-		if !ok {
-			continue
-		}
-		entries = append(entries, entry{
-			ID:          actionIDString(id),
-			Owner:       id.Owner,
-			OwnerKind:   string(id.OwnerKind),
-			Description: action.Description,
-			Interactive: action.Interactive != nil && *action.Interactive,
-			Confirm:     action.Confirm != nil && *action.Confirm,
-		})
-	}
+	entries := actionListEntries(cfg, owner)
 	if owner != "" && len(entries) == 0 {
 		return &kranzcli.Error{
 			Code:     "owner_not_found",
@@ -67,6 +55,45 @@ func runActionList(options kranzcli.GlobalOptions, args []string, stdout io.Writ
 	}
 	if options.Output == kranzcli.OutputJSON {
 		return kranzcli.WriteJSON(stdout, entries)
+	}
+	return writeActionList(stdout, entries, formatter)
+}
+
+func actionListEntries(cfg *config.Config, owner string) []actionListEntry {
+	entries := make([]actionListEntry, 0)
+	for _, id := range cfg.ActionIDs() {
+		if owner != "" && id.Owner != owner {
+			continue
+		}
+		action, ok := cfg.ResolveAction(id)
+		if !ok {
+			continue
+		}
+		entries = append(entries, actionListEntry{
+			ID:          actionIDString(id),
+			Owner:       id.Owner,
+			OwnerKind:   string(id.OwnerKind),
+			Description: action.Description,
+			Interactive: action.Interactive != nil && *action.Interactive,
+			Confirm:     action.Confirm != nil && *action.Confirm,
+		})
+	}
+	return entries
+}
+
+func writeActionList(stdout io.Writer, entries []actionListEntry, formatter *rowTemplate) error {
+	if formatter != nil {
+		rows := make([]map[string]any, 0, len(entries))
+		for _, item := range entries {
+			rows = append(rows, map[string]any{
+				"Action": item.ID, "Owner": item.Owner, "Kind": item.OwnerKind,
+				"Interactive": item.Interactive, "Confirm": item.Confirm, "Description": item.Description,
+			})
+		}
+		return formatter.write(stdout, map[string]any{
+			"Action": "ACTION", "Owner": "OWNER", "Kind": "KIND",
+			"Interactive": "INTERACTIVE", "Confirm": "CONFIRM", "Description": "DESCRIPTION",
+		}, rows)
 	}
 	if len(entries) == 0 {
 		_, _ = fmt.Fprintln(stdout, "This project defines no actions.")

--- a/cmd/kranz/action_commands.go
+++ b/cmd/kranz/action_commands.go
@@ -29,12 +29,12 @@ type actionListEntry struct {
 }
 
 func runActionList(options kranzcli.GlobalOptions, args []string, stdout io.Writer) error {
-	formatter, args, err := extractRowFormat("action list", options.Output, args)
+	formatter, args, err := extractRowFormat("actions", options.Output, args)
 	if err != nil {
 		return err
 	}
 	if len(args) > 1 {
-		return &kranzcli.Error{Code: "invalid_arguments", Message: "action list accepts at most one owner", ExitCode: kranzcli.ExitUsage}
+		return &kranzcli.Error{Code: "invalid_arguments", Message: "actions accepts at most one owner", ExitCode: kranzcli.ExitUsage}
 	}
 	cfg, _, err := loadProject(options)
 	if err != nil {
@@ -49,7 +49,7 @@ func runActionList(options kranzcli.GlobalOptions, args []string, stdout io.Writ
 		return &kranzcli.Error{
 			Code:     "owner_not_found",
 			Message:  fmt.Sprintf("no service or action group named %q defines actions", owner),
-			Hint:     "Run `kranz action list` to see every action this project defines.",
+			Hint:     "Run `kranz actions` to see every action this project defines.",
 			ExitCode: kranzcli.ExitNotFound,
 		}
 	}
@@ -122,13 +122,13 @@ func resolveActionID(cfg *config.Config, reference string) (config.ActionID, con
 		action, _ := cfg.ResolveAction(matches[0])
 		return matches[0], action, nil
 	case 0:
-		hint := "Run `kranz action list` to see every action this project defines."
+		hint := "Run `kranz actions` to see every action this project defines."
 		if !strings.Contains(reference, "/") {
 			hint = "Actions are named OWNER/ACTION."
 			if ids := cfg.ActionIDs(); len(ids) > 0 {
-				hint += fmt.Sprintf(" For example: `kranz action info %s`.", actionIDString(ids[0]))
+				hint += fmt.Sprintf(" For example: `kranz actions info %s`.", actionIDString(ids[0]))
 			} else {
-				hint += " Run `kranz action list` to see what this project defines."
+				hint += " Run `kranz actions` to see what this project defines."
 			}
 		}
 		return config.ActionID{}, config.Action{}, &kranzcli.Error{

--- a/cmd/kranz/action_commands_test.go
+++ b/cmd/kranz/action_commands_test.go
@@ -18,6 +18,7 @@ services:
       seed:
         description: Load fixtures.
         command: echo seeded
+        confirm: true
       migrate:
         command: echo migrated
         interactive: true
@@ -45,6 +46,9 @@ func TestActionListAndFilterByOwner(t *testing.T) {
 		if !strings.Contains(all, id) {
 			t.Errorf("action list omits %q: %q", id, all)
 		}
+	}
+	if !strings.Contains(all, "CONFIRM") || !strings.Contains(all, "true") {
+		t.Errorf("action list omits confirmation requirements: %q", all)
 	}
 
 	owned := runInspection(t, directory, "action", "list", "toolbox")

--- a/cmd/kranz/action_commands_test.go
+++ b/cmd/kranz/action_commands_test.go
@@ -41,7 +41,7 @@ func actionDirectory(t *testing.T) string {
 func TestActionListAndFilterByOwner(t *testing.T) {
 	directory := actionDirectory(t)
 
-	all := runInspection(t, directory, "action", "list")
+	all := runInspection(t, directory, "actions")
 	for _, id := range []string{"api/seed", "api/migrate", "toolbox/seed"} {
 		if !strings.Contains(all, id) {
 			t.Errorf("action list omits %q: %q", id, all)
@@ -51,14 +51,14 @@ func TestActionListAndFilterByOwner(t *testing.T) {
 		t.Errorf("action list omits confirmation requirements: %q", all)
 	}
 
-	owned := runInspection(t, directory, "action", "list", "toolbox")
+	owned := runInspection(t, directory, "actions", "toolbox")
 	if !strings.Contains(owned, "toolbox/seed") || strings.Contains(owned, "api/seed") {
 		t.Errorf("action list toolbox = %q", owned)
 	}
 }
 
 func TestActionListFormat(t *testing.T) {
-	output := runInspection(t, actionDirectory(t), "action", "list", "api", "--format", "{{.Action}}:{{.Confirm}}")
+	output := runInspection(t, actionDirectory(t), "actions", "api", "--format", "{{.Action}}:{{.Confirm}}")
 	if !strings.Contains(output, "api/seed:true") || strings.Contains(output, "toolbox/seed") {
 		t.Fatalf("formatted action list = %q", output)
 	}
@@ -66,7 +66,7 @@ func TestActionListFormat(t *testing.T) {
 
 func TestActionListRejectsAnUnknownOwner(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	if code := execute([]string{"-C", actionDirectory(t), "action", "list", "nope"}, &stdout, &stderr); code != kranzcli.ExitNotFound {
+	if code := execute([]string{"-C", actionDirectory(t), "actions", "nope"}, &stdout, &stderr); code != kranzcli.ExitNotFound {
 		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
 	}
 }
@@ -76,11 +76,11 @@ func TestActionListRejectsAnUnknownOwner(t *testing.T) {
 func TestActionInfoDistinguishesOwnersOfTheSameName(t *testing.T) {
 	directory := actionDirectory(t)
 
-	service := runInspection(t, directory, "action", "info", "api/seed")
+	service := runInspection(t, directory, "actions", "info", "api/seed")
 	if !strings.Contains(service, "(service)") || !strings.Contains(service, "echo seeded") {
 		t.Errorf("api/seed = %q", service)
 	}
-	group := runInspection(t, directory, "action", "info", "toolbox/seed")
+	group := runInspection(t, directory, "actions", "info", "toolbox/seed")
 	if !strings.Contains(group, "(group)") || !strings.Contains(group, "echo group seeded") {
 		t.Errorf("toolbox/seed = %q", group)
 	}
@@ -90,13 +90,13 @@ func TestActionInfoDistinguishesOwnersOfTheSameName(t *testing.T) {
 // the user learns the OWNER/ACTION shape.
 func TestActionInfoOnABareNameTeachesTheShape(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	if code := execute([]string{"-C", actionDirectory(t), "action", "info", "seed"}, &stdout, &stderr); code != kranzcli.ExitNotFound {
+	if code := execute([]string{"-C", actionDirectory(t), "actions", "info", "seed"}, &stdout, &stderr); code != kranzcli.ExitNotFound {
 		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
 	}
 	if !strings.Contains(stderr.String(), "OWNER/ACTION") {
 		t.Errorf("error does not teach the shape: %q", stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "kranz action info api/seed") {
+	if !strings.Contains(stderr.String(), "kranz actions info api/seed") {
 		t.Errorf("error does not use a real project action as its example: %q", stderr.String())
 	}
 }
@@ -106,7 +106,7 @@ func TestActionInfoOnABareNameTeachesTheShape(t *testing.T) {
 // refused before any runtime is contacted.
 func TestActionRunRefusesAnInteractiveAction(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	if code := execute([]string{"-C", actionDirectory(t), "action", "run", "api/migrate"}, &stdout, &stderr); code != kranzcli.ExitUsage {
+	if code := execute([]string{"-C", actionDirectory(t), "actions", "run", "api/migrate"}, &stdout, &stderr); code != kranzcli.ExitUsage {
 		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
 	}
 	if !strings.Contains(stderr.String(), "interactive") || !strings.Contains(stderr.String(), "kranz attach") {
@@ -116,13 +116,13 @@ func TestActionRunRefusesAnInteractiveAction(t *testing.T) {
 
 func TestActionRunNeedsARuntime(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	code := execute([]string{"-C", actionDirectory(t), "action", "run", "api/seed"}, &stdout, &stderr)
+	code := execute([]string{"-C", actionDirectory(t), "actions", "run", "api/seed"}, &stdout, &stderr)
 	if code != kranzcli.ExitNotFound {
 		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
 	}
 }
 
-// `kranz action run --output=json` promises an array of output lines. A pipe
+// `kranz actions run --output=json` promises an array of output lines. A pipe
 // hands Kranz whatever chunk it read, so without splitting, a consumer counting
 // array elements and a human counting printed lines disagree.
 func TestActionOutputLinesAreOneLineEach(t *testing.T) {

--- a/cmd/kranz/action_commands_test.go
+++ b/cmd/kranz/action_commands_test.go
@@ -57,6 +57,13 @@ func TestActionListAndFilterByOwner(t *testing.T) {
 	}
 }
 
+func TestActionListFormat(t *testing.T) {
+	output := runInspection(t, actionDirectory(t), "action", "list", "api", "--format", "{{.Action}}:{{.Confirm}}")
+	if !strings.Contains(output, "api/seed:true") || strings.Contains(output, "toolbox/seed") {
+		t.Fatalf("formatted action list = %q", output)
+	}
+}
+
 func TestActionListRejectsAnUnknownOwner(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	if code := execute([]string{"-C", actionDirectory(t), "action", "list", "nope"}, &stdout, &stderr); code != kranzcli.ExitNotFound {

--- a/cmd/kranz/clients.go
+++ b/cmd/kranz/clients.go
@@ -29,80 +29,86 @@ type clientRow struct {
 }
 
 func runClients(options kranzcli.GlobalOptions, args []string, stdout, stderr io.Writer) int {
-	formatter, err := parseRowFormat("clients", options.Output, args)
+	query, err := parseWatchQuery("clients", options.Output, args, "runtime", "project", "client", "surface", "label")
 	if err != nil {
 		return kranzcli.WriteError(stdout, stderr, options.Output, err)
+	}
+	if len(query.args) > 0 {
+		return kranzcli.WriteError(stdout, stderr, options.Output, watchUsageError("clients", fmt.Sprintf("unexpected argument %q", query.args[0])))
 	}
 	registry, err := kranzruntime.DefaultRegistry()
 	if err != nil {
 		return kranzcli.WriteError(stdout, stderr, options.Output, err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	records, err := registry.List(ctx, version)
+	err = runWatch(query, stdout, func() error {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		records, listErr := registry.List(ctx, version)
+		if listErr != nil {
+			return listErr
+		}
+		rows := make([]clientRow, 0)
+		for _, record := range records {
+			if options.Project != "" && !matchesRuntimeReference(record, options.Project) {
+				continue
+			}
+			if record.State != kranzruntime.SessionRunning {
+				continue
+			}
+			client, dialErr := kranzruntime.DialContext(ctx, record.Socket, version)
+			if dialErr != nil {
+				continue
+			}
+			connected, clientsErr := client.Clients()
+			_ = client.Close()
+			if clientsErr != nil {
+				continue
+			}
+			for _, entry := range connected {
+				// Discovery and the background owner are runtime infrastructure,
+				// not clients using the runtime. Keep this command aligned with
+				// the CLIENTS column in `ps` and the TUI runtime switcher.
+				if !listableClient(entry, ownPID()) || !matchesWatchFilters(query.filters, map[string][]string{
+					"runtime": {record.Name}, "project": {record.Project}, "client": {entry.Surface, clientDisplayLabel(entry.Surface, entry.Label)}, "surface": {entry.Surface}, "label": {entry.Label},
+				}) {
+					continue
+				}
+				rows = append(rows, clientRow{
+					Runtime: record.Name, ID: record.ID, Project: record.Project,
+					Surface: entry.Surface, Label: entry.Label, PID: entry.PID,
+					Version: entry.Version, Since: entry.ConnectedAt,
+				})
+			}
+		}
+		return writeClients(options.Output, query.formatter, rows, stdout)
+	})
 	if err != nil {
 		return kranzcli.WriteError(stdout, stderr, options.Output, err)
 	}
-	rows := make([]clientRow, 0)
-	for _, record := range records {
-		if options.Project != "" && !matchesRuntimeReference(record, options.Project) {
-			continue
-		}
-		if record.State != kranzruntime.SessionRunning {
-			continue
-		}
-		client, dialErr := kranzruntime.DialContext(ctx, record.Socket, version)
-		if dialErr != nil {
-			continue
-		}
-		connected, clientsErr := client.Clients()
-		_ = client.Close()
-		if clientsErr != nil {
-			continue
-		}
-		for _, entry := range connected {
-			// Discovery and the background owner are runtime infrastructure,
-			// not clients using the runtime. Keep this command aligned with
-			// the CLIENTS column in `ps` and the TUI runtime switcher.
-			if !listableClient(entry, ownPID()) {
-				continue
-			}
-			rows = append(rows, clientRow{
-				Runtime: record.Name, ID: record.ID, Project: record.Project,
-				Surface: entry.Surface, Label: entry.Label, PID: entry.PID,
-				Version: entry.Version, Since: entry.ConnectedAt,
-			})
-		}
-	}
-	if options.Output == kranzcli.OutputJSON {
-		if err := kranzcli.WriteJSON(stdout, rows); err != nil {
-			return kranzcli.WriteError(stdout, stderr, options.Output, err)
-		}
-		return 0
+	return 0
+}
+
+func writeClients(output kranzcli.OutputFormat, formatter *rowTemplate, rows []clientRow, stdout io.Writer) error {
+	if output == kranzcli.OutputJSON {
+		return kranzcli.WriteJSON(stdout, rows)
 	}
 	if formatter != nil {
 		formatted := make([]map[string]any, 0, len(rows))
 		for _, row := range rows {
 			formatted = append(formatted, clientFormatRow(row))
 		}
-		if err := formatter.write(stdout, clientFormatHeaders(), formatted); err != nil {
-			return kranzcli.WriteError(stdout, stderr, options.Output, err)
-		}
-		return 0
+		return formatter.write(stdout, clientFormatHeaders(), formatted)
 	}
 	if len(rows) == 0 {
 		_, _ = fmt.Fprintln(stdout, "No client is attached to a Kranz runtime.")
-		return 0
+		return nil
 	}
 	w := tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
 	_, _ = fmt.Fprintln(w, "RUNTIME\tPID\tCLIENT\tCONNECTED")
 	for _, row := range rows {
 		_, _ = fmt.Fprintf(w, "%s\t%d\t%s\t%s\n", row.Runtime, row.PID, clientDisplayLabel(row.Surface, row.Label), shortDuration(time.Since(row.Since)))
 	}
-	if err := w.Flush(); err != nil {
-		return kranzcli.WriteError(stdout, stderr, options.Output, err)
-	}
-	return 0
+	return w.Flush()
 }
 
 func clientFormatHeaders() map[string]any {

--- a/cmd/kranz/clients.go
+++ b/cmd/kranz/clients.go
@@ -28,7 +28,11 @@ type clientRow struct {
 	Since   time.Time `json:"connected_at"`
 }
 
-func runClients(options kranzcli.GlobalOptions, stdout, stderr io.Writer) int {
+func runClients(options kranzcli.GlobalOptions, args []string, stdout, stderr io.Writer) int {
+	formatter, err := parseRowFormat("clients", options.Output, args)
+	if err != nil {
+		return kranzcli.WriteError(stdout, stderr, options.Output, err)
+	}
 	registry, err := kranzruntime.DefaultRegistry()
 	if err != nil {
 		return kranzcli.WriteError(stdout, stderr, options.Output, err)
@@ -57,9 +61,10 @@ func runClients(options kranzcli.GlobalOptions, stdout, stderr io.Writer) int {
 			continue
 		}
 		for _, entry := range connected {
-			// This listing holds a connection of its own; reporting it would
-			// mean every runtime always has at least one client.
-			if entry.PID == ownPID() {
+			// Discovery and the background owner are runtime infrastructure,
+			// not clients using the runtime. Keep this command aligned with
+			// the CLIENTS column in `ps` and the TUI runtime switcher.
+			if !listableClient(entry, ownPID()) {
 				continue
 			}
 			rows = append(rows, clientRow{
@@ -75,18 +80,24 @@ func runClients(options kranzcli.GlobalOptions, stdout, stderr io.Writer) int {
 		}
 		return 0
 	}
+	if formatter != nil {
+		formatted := make([]map[string]any, 0, len(rows))
+		for _, row := range rows {
+			formatted = append(formatted, clientFormatRow(row))
+		}
+		if err := formatter.write(stdout, clientFormatHeaders(), formatted); err != nil {
+			return kranzcli.WriteError(stdout, stderr, options.Output, err)
+		}
+		return 0
+	}
 	if len(rows) == 0 {
 		_, _ = fmt.Fprintln(stdout, "No client is attached to a Kranz runtime.")
 		return 0
 	}
 	w := tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
-	_, _ = fmt.Fprintln(w, "RUNTIME\tSURFACE\tCLIENT\tPID\tCONNECTED")
+	_, _ = fmt.Fprintln(w, "RUNTIME\tPID\tCLIENT\tCONNECTED")
 	for _, row := range rows {
-		label := row.Label
-		if label == "" {
-			label = "-"
-		}
-		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\n", row.Runtime, surfaceLabel(row.Surface), label, row.PID, shortDuration(time.Since(row.Since)))
+		_, _ = fmt.Fprintf(w, "%s\t%d\t%s\t%s\n", row.Runtime, row.PID, clientDisplayLabel(row.Surface, row.Label), shortDuration(time.Since(row.Since)))
 	}
 	if err := w.Flush(); err != nil {
 		return kranzcli.WriteError(stdout, stderr, options.Output, err)
@@ -94,14 +105,55 @@ func runClients(options kranzcli.GlobalOptions, stdout, stderr io.Writer) int {
 	return 0
 }
 
+func clientFormatHeaders() map[string]any {
+	return map[string]any{
+		"Runtime": "RUNTIME", "ID": "ID", "FullID": "FULL ID", "Project": "PROJECT", "PID": "PID",
+		"Client": "CLIENT", "Surface": "SURFACE", "Label": "LABEL",
+		"Version": "VERSION", "Connected": "CONNECTED", "ConnectedAt": "CONNECTED AT",
+	}
+}
+
+func clientFormatRow(row clientRow) map[string]any {
+	return map[string]any{
+		"Runtime": row.Runtime, "ID": shortID(row.ID), "FullID": row.ID, "Project": row.Project,
+		"PID": row.PID, "Client": clientDisplayLabel(row.Surface, row.Label),
+		"Surface": row.Surface, "Label": row.Label, "Version": row.Version,
+		"Connected": shortDuration(time.Since(row.Since)), "ConnectedAt": row.Since.Format(time.RFC3339),
+	}
+}
+
 // ownPID names this process so the listing can exclude its own probe.
 func ownPID() int { return os.Getpid() }
+
+func listableClient(client kranzruntime.ClientInfo, listingPID int) bool {
+	return client.PID != listingPID && client.Surface != "background"
+}
 
 func surfaceLabel(surface string) string {
 	if surface == "" {
 		return "unknown"
 	}
 	return surface
+}
+
+// clientDisplayLabel keeps the stable surface visible without repeating the
+// product name carried by built-in labels. A meaningful label still identifies
+// the particular client, for example "MCP: codex" or "TUI: attach".
+func clientDisplayLabel(surface, label string) string {
+	kind := strings.ToUpper(surfaceLabel(surface))
+	switch label {
+	case "", "Kranz dashboard", "Kranz CLI", "Kranz MCP":
+		return kind
+	case "Kranz attach":
+		return kind + ": attach"
+	case "Kranz foreground":
+		return kind + ": foreground"
+	}
+	prefix := kind + ":"
+	if len(label) >= len(prefix) && strings.EqualFold(label[:len(prefix)], prefix) {
+		return kind + label[len(kind):]
+	}
+	return kind + ": " + label
 }
 
 func matchesRuntimeReference(record kranzruntime.SessionRecord, reference string) bool {

--- a/cmd/kranz/clients_test.go
+++ b/cmd/kranz/clients_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"testing"
+
+	kranzruntime "github.com/kranz-org/kranz/internal/runtime"
+)
+
+func TestListableClientExcludesInfrastructureConnections(t *testing.T) {
+	const listingPID = 42
+	for _, test := range []struct {
+		name   string
+		client kranzruntime.ClientInfo
+		want   bool
+	}{
+		{name: "TUI", client: kranzruntime.ClientInfo{Surface: "tui", PID: 7}, want: true},
+		{name: "listing probe", client: kranzruntime.ClientInfo{Surface: "cli", PID: listingPID}, want: false},
+		{name: "background owner", client: kranzruntime.ClientInfo{Surface: "background", PID: 8}, want: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := listableClient(test.client, listingPID); got != test.want {
+				t.Fatalf("listableClient() = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
+func TestClientDisplayLabelCombinesSurfaceAndIdentity(t *testing.T) {
+	for _, test := range []struct {
+		surface string
+		label   string
+		want    string
+	}{
+		{surface: "tui", label: "Kranz dashboard", want: "TUI"},
+		{surface: "tui", label: "Kranz attach", want: "TUI: attach"},
+		{surface: "cli", label: "Kranz CLI", want: "CLI"},
+		{surface: "cli", label: "Kranz foreground", want: "CLI: foreground"},
+		{surface: "mcp", label: "Kranz MCP", want: "MCP"},
+		{surface: "mcp", label: "MCP: codex", want: "MCP: codex"},
+		{surface: "mcp", label: "build agent", want: "MCP: build agent"},
+		{surface: "", label: "", want: "UNKNOWN"},
+	} {
+		t.Run(test.want, func(t *testing.T) {
+			if got := clientDisplayLabel(test.surface, test.label); got != test.want {
+				t.Fatalf("clientDisplayLabel(%q, %q) = %q, want %q", test.surface, test.label, got, test.want)
+			}
+		})
+	}
+}

--- a/cmd/kranz/config_commands.go
+++ b/cmd/kranz/config_commands.go
@@ -206,6 +206,10 @@ func recordSources(node *yaml.Node, path []string, file string, sources map[stri
 }
 
 func runConfigExplain(options kranzcli.GlobalOptions, args []string, stdout io.Writer) error {
+	formatter, args, err := extractRowFormat("config explain", options.Output, args)
+	if err != nil {
+		return err
+	}
 	all := false
 	positional := make([]string, 0, len(args))
 	for _, arg := range args {
@@ -259,6 +263,13 @@ func runConfigExplain(options kranzcli.GlobalOptions, args []string, stdout io.W
 
 	if options.Output == kranzcli.OutputJSON {
 		return kranzcli.WriteJSON(stdout, entries)
+	}
+	if formatter != nil {
+		rows := make([]map[string]any, 0, len(entries))
+		for _, item := range entries {
+			rows = append(rows, map[string]any{"Field": item.Field, "Source": item.Source})
+		}
+		return formatter.write(stdout, map[string]any{"Field": "FIELD", "Source": "SET BY"}, rows)
 	}
 	if len(entries) == 0 {
 		_, _ = fmt.Fprintln(stdout, "No layered fields to explain.")

--- a/cmd/kranz/config_commands.go
+++ b/cmd/kranz/config_commands.go
@@ -241,7 +241,7 @@ func runConfigExplain(options kranzcli.GlobalOptions, args []string, stdout io.W
 			return &kranzcli.Error{
 				Code:     "service_not_found",
 				Message:  fmt.Sprintf("service %q was not found", args[0]),
-				Hint:     "Run `kranz list services` to see what this project defines.",
+				Hint:     "Run `kranz services` to see what this project defines.",
 				ExitCode: kranzcli.ExitNotFound,
 			}
 		}

--- a/cmd/kranz/config_commands_test.go
+++ b/cmd/kranz/config_commands_test.go
@@ -72,6 +72,13 @@ func TestConfigShowRejectsUnknownOptions(t *testing.T) {
 	}
 }
 
+func TestConfigExplainFormatBypassesSingleLayerSummary(t *testing.T) {
+	output := runInspection(t, secretsDirectory(t), "config", "explain", "--format", "{{.Field}}")
+	if !strings.Contains(output, "services.zulu.command") || strings.Contains(output, "one configuration layer") {
+		t.Fatalf("formatted config explanation = %q", output)
+	}
+}
+
 // Provenance is a question about the files, so a field set by a later layer has
 // to be attributed to that layer rather than to the base.
 func TestConfigExplainAttributesFieldsToTheLayerThatSetThem(t *testing.T) {

--- a/cmd/kranz/help_options_test.go
+++ b/cmd/kranz/help_options_test.go
@@ -163,6 +163,6 @@ func TestCompletionValuesAreAcceptedByTheirCommand(t *testing.T) {
 	// A global option belongs to no command, so it is checked through one that
 	// only reads.
 	for _, option := range kranzcli.GlobalFlags() {
-		check(t, []string{"list"}, option)
+		check(t, []string{"services"}, option)
 	}
 }

--- a/cmd/kranz/init_command.go
+++ b/cmd/kranz/init_command.go
@@ -38,6 +38,7 @@ type initOptions struct {
 	from       string
 	fromSet    bool
 	project    string
+	projectSet bool
 	service    string
 	command    string
 	outputPath string
@@ -75,14 +76,21 @@ func parseInitOptions(args []string) (initOptions, error) {
 			options.from, options.fromSet = source, true
 		case strings.HasPrefix(arg, "--from="):
 			options.from, options.fromSet = strings.TrimPrefix(arg, "--from="), true
-		case arg == "--project":
-			project, err := value(&index, "--project")
+		case arg == "--name" || arg == "--project":
+			if options.projectSet {
+				return initOptions{}, &kranzcli.Error{Code: "invalid_arguments", Message: "the project name may be specified only once", Hint: "Use the canonical `--name NAME` option.", ExitCode: kranzcli.ExitUsage}
+			}
+			project, err := value(&index, arg)
 			if err != nil {
 				return initOptions{}, err
 			}
-			options.project = project
-		case strings.HasPrefix(arg, "--project="):
-			options.project = strings.TrimPrefix(arg, "--project=")
+			options.project, options.projectSet = project, true
+		case strings.HasPrefix(arg, "--name=") || strings.HasPrefix(arg, "--project="):
+			if options.projectSet {
+				return initOptions{}, &kranzcli.Error{Code: "invalid_arguments", Message: "the project name may be specified only once", Hint: "Use the canonical `--name NAME` option.", ExitCode: kranzcli.ExitUsage}
+			}
+			_, project, _ := strings.Cut(arg, "=")
+			options.project, options.projectSet = project, true
 		case arg == "--service":
 			service, err := value(&index, "--service")
 			if err != nil {
@@ -119,6 +127,9 @@ func parseInitOptions(args []string) (initOptions, error) {
 	if options.fromSet && options.from == "" {
 		return initOptions{}, &kranzcli.Error{Code: "missing_option_value", Message: "--from requires a path", ExitCode: kranzcli.ExitUsage}
 	}
+	if options.projectSet && options.project == "" {
+		return initOptions{}, &kranzcli.Error{Code: "missing_option_value", Message: "--name requires a project name", ExitCode: kranzcli.ExitUsage}
+	}
 	return options, nil
 }
 
@@ -127,9 +138,11 @@ func runInit(globals kranzcli.GlobalOptions, args []string, stdout io.Writer) er
 	if err != nil {
 		return err
 	}
-	// `--project NAME` is parsed as the global runtime selector before init
-	// ever sees it. init addresses no runtime, so the global value is the
-	// project name here, which is also the spelling the CLI reference documents.
+	if options.projectSet && globals.Project != "" {
+		return &kranzcli.Error{Code: "invalid_arguments", Message: "init project name was specified with both --name and -p/--project", Hint: "Use `kranz init --name NAME`; -p/--project remains a compatibility alias.", ExitCode: kranzcli.ExitUsage}
+	}
+	// Older invocations used the global runtime selector as init's project
+	// name. Preserve that behavior while keeping new commands unambiguous.
 	if options.project == "" {
 		options.project = globals.Project
 	}

--- a/cmd/kranz/init_command.go
+++ b/cmd/kranz/init_command.go
@@ -2,12 +2,10 @@ package main
 
 import (
 	"bufio"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -18,6 +16,10 @@ import (
 
 // stdin is a variable so tests can drive the wizard without a terminal.
 var stdin io.Reader = os.Stdin
+
+// interactiveInitWizard is replaceable in command-level tests; the model
+// itself is exercised directly without requiring a real terminal.
+var interactiveInitWizard = runInitWizard
 
 // isTerminal reports whether the wizard may prompt. It is a variable for the
 // same reason: a test needs to exercise both the interactive and the
@@ -30,10 +32,6 @@ var isTerminal = func() bool {
 	return info.Mode()&os.ModeCharDevice != 0
 }
 
-// importableSources are the configuration formats init can convert, in the
-// order it offers them.
-var importableSources = []string{"kranz.yaml", "kranz.yml", "process-compose.yaml", "process-compose.yml", "Procfile.dev", "Procfile"}
-
 type initOptions struct {
 	from       string
 	fromSet    bool
@@ -41,8 +39,11 @@ type initOptions struct {
 	projectSet bool
 	service    string
 	command    string
+	directory  string
+	dirSet     bool
 	outputPath string
 	assumeYes  bool
+	force      bool
 }
 
 type initResult struct {
@@ -68,6 +69,8 @@ func parseInitOptions(args []string) (initOptions, error) {
 		switch {
 		case arg == "--yes" || arg == "-y":
 			options.assumeYes = true
+		case arg == "--force":
+			options.force = true
 		case arg == "--from":
 			source, err := value(&index, "--from")
 			if err != nil {
@@ -115,6 +118,8 @@ func parseInitOptions(args []string) (initOptions, error) {
 			options.outputPath = path
 		case strings.HasPrefix(arg, "--output-file="):
 			options.outputPath = strings.TrimPrefix(arg, "--output-file=")
+		case !strings.HasPrefix(arg, "-") && !options.dirSet:
+			options.directory, options.dirSet = arg, true
 		default:
 			return initOptions{}, &kranzcli.Error{
 				Code:     "unknown_option",
@@ -147,28 +152,49 @@ func runInit(globals kranzcli.GlobalOptions, args []string, stdout io.Writer) er
 		options.project = globals.Project
 	}
 	directory := globals.Directory
-	target := options.outputPath
-	if !filepath.IsAbs(target) {
-		target = filepath.Join(directory, target)
+	if options.dirSet {
+		directory = options.directory
+		if !filepath.IsAbs(directory) {
+			directory = filepath.Join(globals.Directory, directory)
+		}
+		directory = filepath.Clean(directory)
 	}
-
 	prompt := bufio.NewReader(stdin)
 	// JSON is a machine contract: prompts and the human-readable preview would
 	// corrupt the single envelope. With JSON selected, init follows the same
 	// deterministic non-interactive path as a pipe and reports any missing
 	// inputs as a structured error.
 	interactive := globals.Output == kranzcli.OutputText && isTerminal() && !options.assumeYes
-
-	document, err := buildInitDocument(directory, options, interactive, prompt, stdout)
+	wizardApproved := false
+	var document *yaml.Node
+	if interactive && !options.fromSet {
+		draft, approved, wizardErr := interactiveInitWizard(directory, options.outputPath, options, stdin, stdout)
+		if wizardErr != nil {
+			return wizardErr
+		}
+		if !approved {
+			_, _ = fmt.Fprintln(stdout, "Nothing was written.")
+			return nil
+		}
+		directory = draft.Directory
+		document, err = draft.document()
+		wizardApproved = true
+	} else {
+		document, err = buildInitDocument(directory, options)
+	}
 	if err != nil {
 		return err
+	}
+	target := options.outputPath
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(directory, target)
 	}
 	rendered, err := renderDocument(document)
 	if err != nil {
 		return err
 	}
 
-	if globals.Output == kranzcli.OutputText {
+	if globals.Output == kranzcli.OutputText && !wizardApproved {
 		// The preview is the point of the wizard: the user approves a file they
 		// have actually read, not a description of one.
 		_, _ = fmt.Fprintf(stdout, "\n%s\n%s\n", relativeTo(directory, target), strings.Repeat("-", len(relativeTo(directory, target))))
@@ -176,12 +202,12 @@ func runInit(globals kranzcli.GlobalOptions, args []string, stdout io.Writer) er
 	}
 
 	if _, err := os.Stat(target); err == nil {
-		if !options.assumeYes {
+		if !wizardApproved && !options.force {
 			if !interactive {
 				return &kranzcli.Error{
 					Code:     "file_exists",
 					Message:  fmt.Sprintf("%s already exists", relativeTo(directory, target)),
-					Hint:     "Pass --yes to overwrite it, or -o PATH to write somewhere else.",
+					Hint:     "Run the interactive wizard to review a replacement, pass --force, or use -o PATH.",
 					ExitCode: kranzcli.ExitConflict,
 				}
 			}
@@ -196,7 +222,7 @@ func runInit(globals kranzcli.GlobalOptions, args []string, stdout io.Writer) er
 		}
 	} else if !os.IsNotExist(err) {
 		return err
-	} else if interactive {
+	} else if interactive && !wizardApproved {
 		confirmed, err := confirm(prompt, stdout, fmt.Sprintf("\nWrite %s?", relativeTo(directory, target)))
 		if err != nil {
 			return err
@@ -207,6 +233,9 @@ func runInit(globals kranzcli.GlobalOptions, args []string, stdout io.Writer) er
 		}
 	}
 
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return err
+	}
 	if err := config.WriteFileAtomically(target, []byte(rendered)); err != nil {
 		return err
 	}
@@ -246,40 +275,14 @@ func relativeTo(directory, path string) string {
 	return path
 }
 
-// buildInitDocument produces the configuration to write, either by converting
-// an existing source or by asking for the minimum a valid project needs.
-func buildInitDocument(directory string, options initOptions, interactive bool, prompt *bufio.Reader, stdout io.Writer) (*yaml.Node, error) {
-	source := options.from
-	if !options.fromSet && options.project == "" && options.service == "" && options.command == "" {
-		source = detectImportableSource(directory, options.outputPath)
-		if source != "" && interactive {
-			confirmed, err := confirm(prompt, stdout, fmt.Sprintf("Found %s. Import it?", source))
-			if err != nil {
-				return nil, err
-			}
-			if !confirmed {
-				source = ""
-			}
-		}
+// buildInitDocument produces a deterministic non-interactive configuration.
+// Import is always explicit: discovery belongs to the future `kranz scan`
+// workflow and init never infers authoring intent from nearby registry files.
+func buildInitDocument(directory string, options initOptions) (*yaml.Node, error) {
+	if options.fromSet {
+		return importDocument(directory, options.from)
 	}
-	if source != "" {
-		return importDocument(directory, source)
-	}
-	return wizardDocument(directory, options, interactive, prompt, stdout)
-}
-
-// detectImportableSource finds a configuration worth converting, skipping the
-// file init is about to write so init never offers to import its own output.
-func detectImportableSource(directory, outputPath string) string {
-	for _, candidate := range importableSources {
-		if candidate == outputPath {
-			continue
-		}
-		if info, err := os.Stat(filepath.Join(directory, candidate)); err == nil && !info.IsDir() {
-			return candidate
-		}
-	}
-	return ""
+	return flagInitDocument(directory, options)
 }
 
 // importDocument converts a supported source by loading it through the same
@@ -375,32 +378,10 @@ func lifecycleStartAddsNothing(start config.Action, svc config.Service, projectD
 	return true
 }
 
-func wizardDocument(directory string, options initOptions, interactive bool, prompt *bufio.Reader, stdout io.Writer) (*yaml.Node, error) {
+func flagInitDocument(directory string, options initOptions) (*yaml.Node, error) {
 	project := options.project
 	serviceName := options.service
 	command := options.command
-
-	if interactive {
-		var err error
-		if project == "" {
-			project, err = ask(prompt, stdout, "Project name", filepath.Base(mustAbs(directory)))
-			if err != nil {
-				return nil, err
-			}
-		}
-		if serviceName == "" {
-			serviceName, err = ask(prompt, stdout, "First service name", "app")
-			if err != nil {
-				return nil, err
-			}
-		}
-		if command == "" {
-			command, err = ask(prompt, stdout, "Command to run it", "")
-			if err != nil {
-				return nil, err
-			}
-		}
-	}
 	if project == "" {
 		project = filepath.Base(mustAbs(directory))
 	}
@@ -424,34 +405,6 @@ func wizardDocument(directory string, options initOptions, interactive bool, pro
 		ServiceOrder: []string{serviceName},
 	}
 
-	// package.json scripts become actions rather than services: they are things
-	// the user runs on demand, and nothing here executes them to find out.
-	if scripts := packageScripts(directory); len(scripts) > 0 {
-		accepted := scripts
-		if interactive {
-			confirmed, err := confirm(prompt, stdout, fmt.Sprintf("Found %d package.json script(s). Add them as actions?", len(scripts)))
-			if err != nil {
-				return nil, err
-			}
-			if !confirmed {
-				accepted = nil
-			}
-		}
-		if len(accepted) > 0 {
-			service := cfg.Services[serviceName]
-			service.Actions = make(map[string]config.Action, len(accepted))
-			names := make([]string, 0, len(accepted))
-			for name := range accepted {
-				names = append(names, name)
-			}
-			sort.Strings(names)
-			for _, name := range names {
-				service.Actions[name] = config.Action{Command: "npm run " + name}
-			}
-			service.ActionOrder = names
-			cfg.Services[serviceName] = service
-		}
-	}
 	return effectiveDocument(cfg)
 }
 
@@ -461,23 +414,6 @@ func mustAbs(directory string) string {
 		return directory
 	}
 	return absolute
-}
-
-// packageScripts reads the scripts a package.json declares. It parses the file
-// and never runs anything: discovering what a project can do must not have the
-// side effects of doing it.
-func packageScripts(directory string) map[string]string {
-	data, err := os.ReadFile(filepath.Join(directory, "package.json"))
-	if err != nil {
-		return nil
-	}
-	var manifest struct {
-		Scripts map[string]string `json:"scripts"`
-	}
-	if err := json.Unmarshal(data, &manifest); err != nil {
-		return nil
-	}
-	return manifest.Scripts
 }
 
 func renderDocument(document *yaml.Node) (string, error) {
@@ -491,26 +427,6 @@ func renderDocument(document *yaml.Node) (string, error) {
 		return "", err
 	}
 	return buffer.String(), nil
-}
-
-func ask(prompt *bufio.Reader, stdout io.Writer, question, fallback string) (string, error) {
-	if fallback != "" {
-		_, _ = fmt.Fprintf(stdout, "%s [%s]: ", question, fallback)
-	} else {
-		_, _ = fmt.Fprintf(stdout, "%s: ", question)
-	}
-	line, err := prompt.ReadString('\n')
-	if err != nil && line == "" {
-		if err == io.EOF {
-			return fallback, nil
-		}
-		return "", err
-	}
-	answer := strings.TrimSpace(line)
-	if answer == "" {
-		return fallback, nil
-	}
-	return answer, nil
 }
 
 func confirm(prompt *bufio.Reader, stdout io.Writer, question string) (bool, error) {

--- a/cmd/kranz/init_command.go
+++ b/cmd/kranz/init_command.go
@@ -143,13 +143,8 @@ func runInit(globals kranzcli.GlobalOptions, args []string, stdout io.Writer) er
 	if err != nil {
 		return err
 	}
-	if options.projectSet && globals.Project != "" {
-		return &kranzcli.Error{Code: "invalid_arguments", Message: "init project name was specified with both --name and -p/--project", Hint: "Use `kranz init --name NAME`; -p/--project remains a compatibility alias.", ExitCode: kranzcli.ExitUsage}
-	}
-	// Older invocations used the global runtime selector as init's project
-	// name. Preserve that behavior while keeping new commands unambiguous.
-	if options.project == "" {
-		options.project = globals.Project
+	if globals.Project != "" {
+		return &kranzcli.Error{Code: "invalid_arguments", Message: "-p/--project addresses a runtime and is not valid for init", Hint: "Use `kranz init --name NAME` to set the new project's name.", ExitCode: kranzcli.ExitUsage}
 	}
 	directory := globals.Directory
 	if options.dirSet {
@@ -394,7 +389,7 @@ func flagInitDocument(directory string, options initOptions) (*yaml.Node, error)
 		return nil, &kranzcli.Error{
 			Code:     "missing_command",
 			Message:  "a service needs a command",
-			Hint:     "Run `kranz init --project NAME --service NAME --command COMMAND`, or run init in a terminal to be asked.",
+			Hint:     "Run `kranz init --name NAME --service NAME --command COMMAND`, or run init in a terminal to be asked.",
 			ExitCode: kranzcli.ExitUsage,
 		}
 	}

--- a/cmd/kranz/init_command_test.go
+++ b/cmd/kranz/init_command_test.go
@@ -35,7 +35,7 @@ func TestInitWritesAValidConfigurationFromFlags(t *testing.T) {
 	withoutTerminal(t)
 	directory := t.TempDir()
 
-	output := runInspection(t, directory, "init", "--project", "Demo", "--service", "api", "--command", "sleep 60", "--yes")
+	output := runInspection(t, directory, "init", "--name", "Demo", "--service", "api", "--command", "sleep 60", "--yes")
 	if !strings.Contains(output, "Wrote kranz.yaml") {
 		t.Fatalf("init output = %q", output)
 	}
@@ -58,7 +58,7 @@ func TestInitJSONWritesOneUsefulEnvelopeWithoutHumanPreview(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	if code := execute([]string{
 		"-C", directory, "--output=json", "init",
-		"--project", "Demo", "--service", "api", "--command", "sleep 60", "--yes",
+		"--name", "Demo", "--service", "api", "--command", "sleep 60", "--yes",
 	}, &stdout, &stderr); code != 0 {
 		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
 	}
@@ -88,10 +88,9 @@ func TestInitJSONWritesOneUsefulEnvelopeWithoutHumanPreview(t *testing.T) {
 	}
 }
 
-// --project is consumed by the global runtime selector before init sees it, so
-// init has to read the project name from there or silently ignore the flag its
-// own reference documents.
-func TestInitReadsProjectNameFromTheGlobalFlag(t *testing.T) {
+// -p/--project was the original spelling and is still accepted for scripts,
+// while --name is the unambiguous init-local option shown in help.
+func TestInitPreservesGlobalProjectNameCompatibility(t *testing.T) {
 	withoutTerminal(t)
 	directory := t.TempDir()
 	var stdout, stderr bytes.Buffer
@@ -104,6 +103,15 @@ func TestInitReadsProjectNameFromTheGlobalFlag(t *testing.T) {
 	}
 	if cfg.Project != "Named" {
 		t.Errorf("project = %q, want Named", cfg.Project)
+	}
+}
+
+func TestInitRejectsAmbiguousProjectNames(t *testing.T) {
+	withoutTerminal(t)
+	var stdout, stderr bytes.Buffer
+	code := execute([]string{"-C", t.TempDir(), "-p", "Legacy", "init", "--name", "Current", "--service", "api", "--command", "sleep 60", "--yes"}, &stdout, &stderr)
+	if code != kranzcli.ExitUsage || !strings.Contains(stderr.String(), "both --name and -p/--project") {
+		t.Fatalf("exit=%d stdout/stderr=%q/%q", code, stdout.String(), stderr.String())
 	}
 }
 

--- a/cmd/kranz/init_command_test.go
+++ b/cmd/kranz/init_command_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,14 +13,20 @@ import (
 	"github.com/kranz-org/kranz/internal/config"
 )
 
-// withWizardInput drives the interactive path deterministically, without a
-// terminal, by replacing the two seams init reads the user through.
-func withWizardInput(t *testing.T, answers string) {
+// withWizardResult exercises command integration without asking Bubble Tea to
+// take over the test process terminal. The wizard model has focused state and
+// rendering tests of its own.
+func withWizardResult(t *testing.T, draft initDraft, approved bool) {
 	t.Helper()
-	previousStdin, previousTerminal := stdin, isTerminal
-	stdin = strings.NewReader(answers)
+	previousStdin, previousTerminal, previousWizard := stdin, isTerminal, interactiveInitWizard
+	stdin = strings.NewReader("")
 	isTerminal = func() bool { return true }
-	t.Cleanup(func() { stdin, isTerminal = previousStdin, previousTerminal })
+	interactiveInitWizard = func(_ string, _ string, _ initOptions, _ io.Reader, _ io.Writer) (initDraft, bool, error) {
+		return draft, approved, nil
+	}
+	t.Cleanup(func() {
+		stdin, isTerminal, interactiveInitWizard = previousStdin, previousTerminal, previousWizard
+	})
 }
 
 // withoutTerminal forces the non-interactive path.
@@ -49,6 +56,30 @@ func TestInitWritesAValidConfigurationFromFlags(t *testing.T) {
 	}
 	if cfg.Services["api"].Command != "sleep 60" {
 		t.Errorf("api command = %q", cfg.Services["api"].Command)
+	}
+}
+
+func TestInitCreatesPositionalProjectDirectory(t *testing.T) {
+	withoutTerminal(t)
+	base := t.TempDir()
+	output := runInspection(t, base, "init", "shop", "--name", "Demo", "--service", "api", "--command", "sleep 60", "--yes")
+	if !strings.Contains(output, "Wrote kranz.yaml") {
+		t.Fatalf("init output = %q", output)
+	}
+	cfg, err := config.LoadFiles([]string{filepath.Join(base, "shop", "kranz.yaml")})
+	if err != nil {
+		t.Fatalf("configuration in positional directory does not load: %v", err)
+	}
+	if cfg.Project != "Demo" {
+		t.Errorf("project = %q, want Demo", cfg.Project)
+	}
+}
+
+func TestInitRejectsMoreThanOneDirectory(t *testing.T) {
+	withoutTerminal(t)
+	var stdout, stderr bytes.Buffer
+	if code := execute([]string{"-C", t.TempDir(), "init", "one", "two", "--yes"}, &stdout, &stderr); code != kranzcli.ExitUsage {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
 	}
 }
 
@@ -152,11 +183,50 @@ func TestInitDoesNotOverwriteWithoutConsent(t *testing.T) {
 	}
 }
 
+func TestInitYesDoesNotImplyOverwrite(t *testing.T) {
+	withoutTerminal(t)
+	directory := t.TempDir()
+	existing := filepath.Join(directory, "kranz.yaml")
+	original := "project: Original\nservices:\n  api:\n    command: sleep 1\n"
+	if err := os.WriteFile(existing, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := execute([]string{"-C", directory, "init", "--service", "other", "--command", "sleep 2", "--yes"}, &stdout, &stderr)
+	if code != kranzcli.ExitConflict {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
+	}
+	data, err := os.ReadFile(existing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != original {
+		t.Fatalf("--yes overwrote the existing file:\n%s", data)
+	}
+}
+
+func TestInitForceAllowsNonInteractiveOverwrite(t *testing.T) {
+	withoutTerminal(t)
+	directory := t.TempDir()
+	existing := filepath.Join(directory, "kranz.yaml")
+	if err := os.WriteFile(existing, []byte("project: Original\nservices:\n  api:\n    command: sleep 1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runInspection(t, directory, "init", "--name", "Replacement", "--service", "other", "--command", "sleep 2", "--yes", "--force")
+	cfg, err := config.LoadFiles([]string{existing})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Project != "Replacement" {
+		t.Fatalf("project = %q, want Replacement", cfg.Project)
+	}
+}
+
 // The wizard exists so the user approves a file they have read. Declining the
 // write must leave the directory untouched.
 func TestInitWizardDeclineWritesNothing(t *testing.T) {
-	withWizardInput(t, "Interactive\napi\nsleep 60\nn\n")
 	directory := t.TempDir()
+	withWizardResult(t, newInitDraft(directory, initOptions{}), false)
 
 	output := runInspection(t, directory, "init")
 	if !strings.Contains(output, "Nothing was written") {
@@ -168,13 +238,15 @@ func TestInitWizardDeclineWritesNothing(t *testing.T) {
 }
 
 func TestInitWizardAcceptsAnswersAndPreviewsTheFile(t *testing.T) {
-	withWizardInput(t, "Interactive\nweb\nnpm start\ny\n")
 	directory := t.TempDir()
+	draft := newInitDraft(directory, initOptions{})
+	draft.Project = "Interactive"
+	draft.Services = []initServiceDraft{{Name: "web", Dir: ".", Command: "npm start"}}
+	withWizardResult(t, draft, true)
 
 	output := runInspection(t, directory, "init")
-	// The preview has to show the actual content, not a summary of it.
-	if !strings.Contains(output, "project: Interactive") || !strings.Contains(output, "npm start") {
-		t.Errorf("preview does not show the file:\n%s", output)
+	if !strings.Contains(output, "Wrote kranz.yaml") {
+		t.Errorf("output does not report the saved draft:\n%s", output)
 	}
 	cfg, err := config.LoadFiles([]string{filepath.Join(directory, "kranz.yaml")})
 	if err != nil {
@@ -197,7 +269,7 @@ func TestInitImportProducesAPortableLoadableFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	runInspection(t, directory, "init", "--yes")
+	runInspection(t, directory, "init", "--from", "Procfile", "--yes")
 
 	target := filepath.Join(directory, "kranz.yaml")
 	data, err := os.ReadFile(target)
@@ -226,9 +298,9 @@ func TestInitImportRejectsAMissingSource(t *testing.T) {
 	}
 }
 
-// Discovering what a project can do must not have the side effects of doing it,
-// so scripts are read from the manifest and never executed.
-func TestInitOffersPackageScriptsAsActions(t *testing.T) {
+// Discovery is a separate future workflow. Init must not infer authoring intent
+// from what happens to be present in a package registry.
+func TestInitIgnoresPackageScripts(t *testing.T) {
 	withoutTerminal(t)
 	directory := t.TempDir()
 	manifest := `{"name":"web","scripts":{"build":"vite build","test":"vitest"}}`
@@ -242,11 +314,8 @@ func TestInitOffersPackageScriptsAsActions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	actions := cfg.Services["web"].Actions
-	for _, name := range []string{"build", "test"} {
-		if actions[name].Command != "npm run "+name {
-			t.Errorf("action %q = %q", name, actions[name].Command)
-		}
+	if actions := cfg.Services["web"].Actions; len(actions) != 0 {
+		t.Fatalf("init inferred package scripts as actions: %#v", actions)
 	}
 }
 

--- a/cmd/kranz/init_command_test.go
+++ b/cmd/kranz/init_command_test.go
@@ -119,30 +119,18 @@ func TestInitJSONWritesOneUsefulEnvelopeWithoutHumanPreview(t *testing.T) {
 	}
 }
 
-// -p/--project was the original spelling and is still accepted for scripts,
-// while --name is the unambiguous init-local option shown in help.
-func TestInitPreservesGlobalProjectNameCompatibility(t *testing.T) {
+func TestInitRejectsRuntimeProjectSelector(t *testing.T) {
 	withoutTerminal(t)
-	directory := t.TempDir()
-	var stdout, stderr bytes.Buffer
-	if code := execute([]string{"-C", directory, "--project", "Named", "init", "--service", "api", "--command", "sleep 60", "--yes"}, &stdout, &stderr); code != 0 {
-		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
-	}
-	cfg, err := config.LoadFiles([]string{filepath.Join(directory, "kranz.yaml")})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.Project != "Named" {
-		t.Errorf("project = %q, want Named", cfg.Project)
-	}
-}
-
-func TestInitRejectsAmbiguousProjectNames(t *testing.T) {
-	withoutTerminal(t)
-	var stdout, stderr bytes.Buffer
-	code := execute([]string{"-C", t.TempDir(), "-p", "Legacy", "init", "--name", "Current", "--service", "api", "--command", "sleep 60", "--yes"}, &stdout, &stderr)
-	if code != kranzcli.ExitUsage || !strings.Contains(stderr.String(), "both --name and -p/--project") {
-		t.Fatalf("exit=%d stdout/stderr=%q/%q", code, stdout.String(), stderr.String())
+	for _, args := range [][]string{
+		{"-C", t.TempDir(), "--project", "Named", "init", "--service", "api", "--command", "sleep 60", "--yes"},
+		{"-C", t.TempDir(), "init", "--project", "Named", "--service", "api", "--command", "sleep 60", "--yes"},
+		{"-C", t.TempDir(), "-p", "Named", "init", "--name", "Current", "--service", "api", "--command", "sleep 60", "--yes"},
+	} {
+		var stdout, stderr bytes.Buffer
+		code := execute(args, &stdout, &stderr)
+		if code != kranzcli.ExitUsage || !strings.Contains(stderr.String(), "addresses a runtime") {
+			t.Fatalf("args=%q exit=%d stdout/stderr=%q/%q", args, code, stdout.String(), stderr.String())
+		}
 	}
 }
 

--- a/cmd/kranz/init_wizard.go
+++ b/cmd/kranz/init_wizard.go
@@ -1,0 +1,1304 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"gopkg.in/yaml.v3"
+
+	"github.com/kranz-org/kranz/internal/config"
+	"github.com/kranz-org/kranz/internal/ui"
+)
+
+const projectActionOwner = "project"
+
+type initServiceDraft struct {
+	Name    string
+	Dir     string
+	Command string
+	Port    int
+}
+
+type initActionDraft struct {
+	Name    string
+	Owner   string
+	Dir     string
+	Command string
+}
+
+type initDraft struct {
+	Project              string
+	Directory            string
+	AppearanceConfigured bool
+	Theme                string
+	ThemeSet             bool
+	AccentSource         string
+	CustomAccent         string
+	AccentSet            bool
+	BackgroundSource     string
+	CustomBackground     string
+	BackgroundSet        bool
+	ColorMode            string
+	ColorModeSet         bool
+	Services             []initServiceDraft
+	Actions              []initActionDraft
+}
+
+func newInitDraft(directory string, options initOptions) initDraft {
+	project := options.project
+	if project == "" {
+		project = filepath.Base(mustAbs(directory))
+	}
+	draft := initDraft{
+		Project:          project,
+		Directory:        mustAbs(directory),
+		Theme:            ui.DefaultTheme,
+		AccentSource:     "theme",
+		BackgroundSource: config.UIBackgroundTerminal,
+		ColorMode:        config.UIColorModeAuto,
+	}
+	if options.service != "" || options.command != "" {
+		draft.Services = append(draft.Services, initServiceDraft{
+			Name:    defaultString(options.service, "app"),
+			Dir:     ".",
+			Command: options.command,
+		})
+	}
+	return draft
+}
+
+func defaultString(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}
+
+func (d initDraft) target(outputPath string) string {
+	if filepath.IsAbs(outputPath) {
+		return filepath.Clean(outputPath)
+	}
+	return filepath.Join(d.Directory, outputPath)
+}
+
+func (d initDraft) config() (*config.Config, error) {
+	cfg := &config.Config{
+		Project:      strings.TrimSpace(d.Project),
+		Services:     make(map[string]config.Service, len(d.Services)),
+		ServiceOrder: make([]string, 0, len(d.Services)),
+	}
+	if d.AppearanceConfigured {
+		if d.ThemeSet {
+			cfg.UI.Theme = d.Theme
+		}
+		if d.AccentSet && d.AccentSource == "custom" {
+			cfg.UI.Accent = strings.ToUpper(d.CustomAccent)
+		}
+		if d.BackgroundSet {
+			switch d.BackgroundSource {
+			case "custom":
+				cfg.UI.Background = strings.ToUpper(d.CustomBackground)
+			default:
+				cfg.UI.Background = d.BackgroundSource
+			}
+		}
+		if d.ColorModeSet {
+			cfg.UI.ColorMode = d.ColorMode
+		}
+	}
+	for _, item := range d.Services {
+		service := config.Service{Command: strings.TrimSpace(item.Command)}
+		if dir := cleanDraftDir(item.Dir); dir != "." {
+			service.Dir = dir
+		}
+		if item.Port != 0 {
+			service.Ports = []int{item.Port}
+		}
+		name := strings.TrimSpace(item.Name)
+		cfg.Services[name] = service
+		cfg.ServiceOrder = append(cfg.ServiceOrder, name)
+	}
+	for _, item := range d.Actions {
+		action := config.Action{Command: strings.TrimSpace(item.Command)}
+		if dir := cleanDraftDir(item.Dir); dir != "." {
+			action.Dir = dir
+		}
+		name, owner := strings.TrimSpace(item.Name), strings.TrimSpace(item.Owner)
+		if owner == "" || owner == projectActionOwner {
+			if cfg.ActionGroups == nil {
+				cfg.ActionGroups = make(map[string]config.ActionGroup)
+			}
+			group, exists := cfg.ActionGroups[projectActionOwner]
+			if !exists {
+				group.Actions = make(map[string]config.Action)
+				cfg.ActionGroupOrder = append(cfg.ActionGroupOrder, projectActionOwner)
+			}
+			group.Actions[name] = action
+			group.ActionOrder = append(group.ActionOrder, name)
+			cfg.ActionGroups[projectActionOwner] = group
+			continue
+		}
+		service, exists := cfg.Services[owner]
+		if !exists {
+			return nil, fmt.Errorf("action %q names unknown service owner %q", name, owner)
+		}
+		if service.Actions == nil {
+			service.Actions = make(map[string]config.Action)
+		}
+		service.Actions[name] = action
+		service.ActionOrder = append(service.ActionOrder, name)
+		cfg.Services[owner] = service
+	}
+	if err := config.Validate(cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func cleanDraftDir(dir string) string {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return "."
+	}
+	return filepath.Clean(dir)
+}
+
+func (d initDraft) document() (*yaml.Node, error) {
+	cfg, err := d.config()
+	if err != nil {
+		return nil, err
+	}
+	return effectiveDocument(cfg)
+}
+
+type initWizardScreen int
+
+const (
+	initWizardReplace initWizardScreen = iota
+	initWizardProject
+	initWizardBuilder
+	initWizardService
+	initWizardAction
+	initWizardAppearance
+	initWizardColor
+	initWizardReview
+)
+
+type initWizardRowKind int
+
+const (
+	initRowAppearance initWizardRowKind = iota
+	initRowService
+	initRowAction
+	initRowAddService
+	initRowAddAction
+	initRowReview
+)
+
+type initWizardRow struct {
+	Kind  initWizardRowKind
+	Index int
+}
+
+type initWizardModel struct {
+	draft         initDraft
+	outputPath    string
+	screen        initWizardScreen
+	cursor        int
+	fields        []textinput.Model
+	fieldCursor   int
+	formButton    int
+	editingIndex  int
+	editingColor  string
+	themeCursor   int
+	errorMessage  string
+	statusMessage string
+	baseDirectory string
+	initialTarget string
+	initialExists bool
+	replaceCursor int
+	hoverRow      int
+	hoverAction   string
+	width         int
+	height        int
+	reviewOffset  int
+	finished      bool
+	cancelled     bool
+}
+
+func newInitWizardModel(directory, outputPath string, options initOptions) initWizardModel {
+	draft := newInitDraft(directory, options)
+	target := draft.target(outputPath)
+	_, err := os.Stat(target)
+	exists := err == nil
+	model := initWizardModel{
+		draft:         draft,
+		outputPath:    outputPath,
+		screen:        initWizardProject,
+		baseDirectory: mustAbs(directory),
+		initialTarget: target,
+		initialExists: exists,
+		editingIndex:  -1,
+		formButton:    -1,
+		hoverRow:      -1,
+	}
+	if exists {
+		model.screen = initWizardReplace
+	}
+	model.openProjectForm()
+	return model
+}
+
+func (m initWizardModel) Init() tea.Cmd { return textinput.Blink }
+
+func (m initWizardModel) Update(message tea.Msg) (tea.Model, tea.Cmd) {
+	if size, ok := message.(tea.WindowSizeMsg); ok {
+		m.width, m.height = size.Width, size.Height
+		for index := range m.fields {
+			m.fields[index].Width = max(20, min(60, size.Width-8))
+		}
+		return m, nil
+	}
+	if msg, ok := message.(tea.MouseMsg); ok {
+		return m.updateMouse(msg)
+	}
+	msg, ok := message.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+	if msg.String() == "ctrl+c" {
+		m.cancelled = true
+		return m, tea.Quit
+	}
+	if m.screen == initWizardBuilder {
+		m.hoverRow, m.hoverAction = -1, ""
+	}
+	switch m.screen {
+	case initWizardReplace:
+		return m.updateReplace(msg)
+	case initWizardProject, initWizardService, initWizardAction, initWizardColor:
+		return m.updateForm(msg)
+	case initWizardBuilder:
+		return m.updateBuilder(msg)
+	case initWizardAppearance:
+		return m.updateAppearance(msg)
+	case initWizardReview:
+		return m.updateReview(msg)
+	default:
+		return m, nil
+	}
+}
+
+func (m initWizardModel) updateMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	if m.screen != initWizardBuilder {
+		return m, nil
+	}
+	rendered := ansi.Strip(m.View())
+	lines := strings.Split(rendered, "\n")
+	if msg.Y < 0 || msg.Y >= len(lines) {
+		return m, nil
+	}
+	line := lines[msg.Y]
+	rows := m.builderRows()
+	for index, row := range rows {
+		if !strings.Contains(line, m.builderRowIdentity(row)) {
+			continue
+		}
+		m.cursor = index
+		m.hoverRow = index
+		m.hoverAction = "open"
+		if (row.Kind == initRowService || row.Kind == initRowAction) && wizardTextHit(line, msg.X, "Delete") {
+			m.hoverAction = "delete"
+		}
+		if msg.Action != tea.MouseActionPress || msg.Button != tea.MouseButtonLeft {
+			return m, nil
+		}
+		if m.hoverAction == "delete" {
+			return m.updateBuilder(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+		}
+		return m.updateBuilder(tea.KeyMsg{Type: tea.KeyEnter})
+	}
+	m.hoverRow, m.hoverAction = -1, ""
+	return m, nil
+}
+
+func wizardTextHit(line string, x int, label string) bool {
+	start := strings.Index(line, label)
+	if start < 0 {
+		return false
+	}
+	left := lipgloss.Width(line[:start])
+	return x >= left && x < left+lipgloss.Width(label)
+}
+
+func (m initWizardModel) builderRowIdentity(row initWizardRow) string {
+	switch row.Kind {
+	case initRowAppearance:
+		return "Appearance"
+	case initRowService:
+		return m.draft.Services[row.Index].Name
+	case initRowAction:
+		item := m.draft.Actions[row.Index]
+		return item.Owner + "/" + item.Name
+	case initRowAddService:
+		return "Add service"
+	case initRowAddAction:
+		return "Add action"
+	case initRowReview:
+		return "Review and save"
+	default:
+		return ""
+	}
+}
+
+func (m initWizardModel) updateReplace(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "left", "h", "right", "l", "tab":
+		m.replaceCursor = 1 - m.replaceCursor
+	case "enter":
+		if m.replaceCursor == 0 {
+			m.cancelled = true
+			return m, tea.Quit
+		}
+		m.screen = initWizardProject
+	case "esc", "q":
+		m.cancelled = true
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m initWizardModel) updateForm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.formButton >= 0 {
+		switch msg.String() {
+		case "esc":
+			return m.cancelForm()
+		case "enter":
+			if m.formButton == 0 {
+				return m.submitForm()
+			}
+			return m.cancelForm()
+		case "tab", "right", "down":
+			if m.formButton == 0 {
+				m.formButton = 1
+				return m, nil
+			}
+			return m.focusFormField(0)
+		case "shift+tab", "left", "up":
+			if m.formButton == 1 {
+				m.formButton = 0
+				return m, nil
+			}
+			return m.focusFormField(len(m.fields) - 1)
+		}
+		return m, nil
+	}
+	switch msg.String() {
+	case "esc":
+		return m.cancelForm()
+	case "tab", "down":
+		return m.moveField(1)
+	case "shift+tab", "up":
+		return m.moveField(-1)
+	case "enter":
+		if m.fieldCursor < len(m.fields)-1 {
+			return m.moveField(1)
+		}
+		return m.focusFormButton(0)
+	}
+	var cmd tea.Cmd
+	m.fields[m.fieldCursor], cmd = m.fields[m.fieldCursor].Update(msg)
+	return m, cmd
+}
+
+func (m initWizardModel) moveField(delta int) (tea.Model, tea.Cmd) {
+	if delta > 0 && m.fieldCursor == len(m.fields)-1 {
+		return m.focusFormButton(0)
+	}
+	if delta < 0 && m.fieldCursor == 0 {
+		return m.focusFormButton(1)
+	}
+	m.fields[m.fieldCursor].Blur()
+	m.fieldCursor += delta
+	return m, m.fields[m.fieldCursor].Focus()
+}
+
+func (m initWizardModel) focusFormButton(index int) (tea.Model, tea.Cmd) {
+	m.fields[m.fieldCursor].Blur()
+	m.formButton = index
+	return m, nil
+}
+
+func (m initWizardModel) focusFormField(index int) (tea.Model, tea.Cmd) {
+	m.formButton, m.fieldCursor = -1, index
+	return m, m.fields[index].Focus()
+}
+
+func (m initWizardModel) cancelForm() (tea.Model, tea.Cmd) {
+	m.errorMessage = ""
+	if m.screen == initWizardProject {
+		m.cancelled = true
+		return m, tea.Quit
+	}
+	if m.screen == initWizardColor {
+		m.screen = initWizardAppearance
+	} else {
+		m.screen = initWizardBuilder
+	}
+	return m, nil
+}
+
+func (m initWizardModel) submitForm() (tea.Model, tea.Cmd) {
+	m.errorMessage = ""
+	switch m.screen {
+	case initWizardProject:
+		directory, project := strings.TrimSpace(m.fields[0].Value()), strings.TrimSpace(m.fields[1].Value())
+		if project == "" || directory == "" {
+			m.errorMessage = "Project name and directory are required."
+			return m, nil
+		}
+		if !filepath.IsAbs(directory) {
+			directory = filepath.Join(m.baseDirectory, directory)
+		}
+		m.draft.Project, m.draft.Directory = project, filepath.Clean(directory)
+		m.screen = initWizardBuilder
+		m.cursor = 0
+		return m, nil
+	case initWizardService:
+		return m.submitService()
+	case initWizardAction:
+		return m.submitAction()
+	case initWizardColor:
+		value := strings.ToUpper(strings.TrimSpace(m.fields[0].Value()))
+		if !validHexColor(value) {
+			m.errorMessage = "Use a six-digit color such as #7AA2F7."
+			return m, nil
+		}
+		if m.editingColor == "accent" {
+			m.draft.CustomAccent = value
+			m.draft.AccentSet = true
+		} else {
+			m.draft.CustomBackground = value
+			m.draft.BackgroundSet = true
+		}
+		m.draft.AppearanceConfigured = true
+		m.screen = initWizardAppearance
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m initWizardModel) submitService() (tea.Model, tea.Cmd) {
+	name := strings.TrimSpace(m.fields[0].Value())
+	dir := cleanDraftDir(m.fields[1].Value())
+	command := strings.TrimSpace(m.fields[2].Value())
+	if name == "" || command == "" {
+		m.errorMessage = "Service name and command are required."
+		return m, nil
+	}
+	port := 0
+	if value := strings.TrimSpace(m.fields[3].Value()); value != "" {
+		parsed, err := strconv.Atoi(value)
+		if err != nil || parsed < 1 || parsed > 65535 {
+			m.errorMessage = "Port must be between 1 and 65535."
+			return m, nil
+		}
+		port = parsed
+	}
+	for index, item := range m.draft.Services {
+		if item.Name == name && index != m.editingIndex {
+			m.errorMessage = "A service with this name already exists."
+			return m, nil
+		}
+	}
+	item := initServiceDraft{Name: name, Dir: dir, Command: command, Port: port}
+	if m.editingIndex >= 0 {
+		oldName := m.draft.Services[m.editingIndex].Name
+		m.draft.Services[m.editingIndex] = item
+		if oldName != name {
+			for index := range m.draft.Actions {
+				if m.draft.Actions[index].Owner == oldName {
+					m.draft.Actions[index].Owner = name
+				}
+			}
+		}
+		m.statusMessage = "Service updated in the draft."
+	} else {
+		m.draft.Services = append(m.draft.Services, item)
+		m.statusMessage = "Service added to the draft."
+	}
+	m.screen, m.editingIndex = initWizardBuilder, -1
+	return m, nil
+}
+
+func (m initWizardModel) submitAction() (tea.Model, tea.Cmd) {
+	name := strings.TrimSpace(m.fields[0].Value())
+	owner := strings.TrimSpace(m.fields[1].Value())
+	dir := cleanDraftDir(m.fields[2].Value())
+	command := strings.TrimSpace(m.fields[3].Value())
+	if owner == "" {
+		owner = projectActionOwner
+	}
+	if name == "" || command == "" {
+		m.errorMessage = "Action name and command are required."
+		return m, nil
+	}
+	if owner != projectActionOwner && !m.hasService(owner) {
+		m.errorMessage = fmt.Sprintf("Owner must be %q or an existing service.", projectActionOwner)
+		return m, nil
+	}
+	for index, item := range m.draft.Actions {
+		if item.Name == name && item.Owner == owner && index != m.editingIndex {
+			m.errorMessage = "An action with this owner and name already exists."
+			return m, nil
+		}
+	}
+	item := initActionDraft{Name: name, Owner: owner, Dir: dir, Command: command}
+	if m.editingIndex >= 0 {
+		m.draft.Actions[m.editingIndex] = item
+		m.statusMessage = "Action updated in the draft."
+	} else {
+		m.draft.Actions = append(m.draft.Actions, item)
+		m.statusMessage = "Action added to the draft."
+	}
+	m.screen, m.editingIndex = initWizardBuilder, -1
+	return m, nil
+}
+
+func (m initWizardModel) hasService(name string) bool {
+	for _, item := range m.draft.Services {
+		if item.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (m initWizardModel) updateBuilder(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	rows := m.builderRows()
+	if len(rows) == 0 {
+		return m, nil
+	}
+	switch msg.String() {
+	case "up", "k":
+		m.cursor = (m.cursor - 1 + len(rows)) % len(rows)
+	case "down", "j":
+		m.cursor = (m.cursor + 1) % len(rows)
+	case "esc", "backspace":
+		m.openProjectForm()
+		m.screen = initWizardProject
+	case "d", "delete":
+		row := rows[m.cursor]
+		switch row.Kind {
+		case initRowService:
+			name := m.draft.Services[row.Index].Name
+			m.draft.Services = append(m.draft.Services[:row.Index], m.draft.Services[row.Index+1:]...)
+			filtered := m.draft.Actions[:0]
+			for _, action := range m.draft.Actions {
+				if action.Owner != name {
+					filtered = append(filtered, action)
+				}
+			}
+			m.draft.Actions = filtered
+			m.statusMessage = "Service and its actions removed from the draft."
+		case initRowAction:
+			m.draft.Actions = append(m.draft.Actions[:row.Index], m.draft.Actions[row.Index+1:]...)
+			m.statusMessage = "Action removed from the draft."
+		}
+		if m.cursor >= len(m.builderRows()) {
+			m.cursor = max(0, len(m.builderRows())-1)
+		}
+	case "enter":
+		row := rows[m.cursor]
+		switch row.Kind {
+		case initRowAppearance:
+			m.openAppearance()
+		case initRowService:
+			m.openServiceForm(row.Index)
+		case initRowAction:
+			m.openActionForm(row.Index)
+		case initRowAddService:
+			m.openServiceForm(-1)
+		case initRowAddAction:
+			m.openActionForm(-1)
+		case initRowReview:
+			if _, err := m.draft.document(); err != nil {
+				m.errorMessage = err.Error()
+				return m, nil
+			}
+			m.screen, m.reviewOffset = initWizardReview, 0
+		}
+	}
+	return m, nil
+}
+
+func (m initWizardModel) builderRows() []initWizardRow {
+	rows := []initWizardRow{{Kind: initRowAppearance}}
+	for index := range m.draft.Services {
+		rows = append(rows, initWizardRow{Kind: initRowService, Index: index})
+	}
+	rows = append(rows, initWizardRow{Kind: initRowAddService})
+	for index := range m.draft.Actions {
+		rows = append(rows, initWizardRow{Kind: initRowAction, Index: index})
+	}
+	return append(rows,
+		initWizardRow{Kind: initRowAddAction},
+		initWizardRow{Kind: initRowReview},
+	)
+}
+
+func (m initWizardModel) updateAppearance(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "up", "k":
+		m.cursor = (m.cursor + 5) % 6
+	case "down", "j", "tab":
+		m.cursor = (m.cursor + 1) % 6
+	case "left", "h":
+		m.changeAppearance(-1)
+	case "right", "l":
+		m.changeAppearance(1)
+	case "enter":
+		switch m.cursor {
+		case 2:
+			if m.draft.AccentSource == "custom" {
+				m.openColorForm("accent")
+			}
+		case 3:
+			if m.draft.BackgroundSource == "custom" {
+				m.openColorForm("background")
+			}
+		case 5:
+			m.screen, m.cursor = initWizardBuilder, 0
+		}
+	case "esc":
+		m.screen, m.cursor = initWizardBuilder, 0
+	}
+	return m, nil
+}
+
+func (m *initWizardModel) changeAppearance(delta int) {
+	switch m.cursor {
+	case 0:
+		m.draft.AppearanceConfigured = !m.draft.AppearanceConfigured
+	case 1:
+		names := ui.ThemeNames()
+		m.themeCursor = (m.themeCursor + delta + len(names)) % len(names)
+		m.draft.Theme = names[m.themeCursor]
+		m.draft.ThemeSet = true
+		m.draft.AppearanceConfigured = true
+	case 2:
+		if m.draft.AccentSource == "theme" {
+			m.draft.AccentSource = "custom"
+			if m.draft.CustomAccent == "" {
+				if theme, ok := ui.LookupTheme(m.draft.Theme); ok {
+					m.draft.CustomAccent = theme.Accent
+				}
+			}
+		} else {
+			m.draft.AccentSource = "theme"
+		}
+		m.draft.AccentSet = true
+		m.draft.AppearanceConfigured = true
+	case 3:
+		values := []string{config.UIBackgroundTerminal, config.UIBackgroundTheme, "custom"}
+		m.draft.BackgroundSource = cycleString(values, m.draft.BackgroundSource, delta)
+		if m.draft.BackgroundSource == "custom" && m.draft.CustomBackground == "" {
+			if theme, ok := ui.LookupTheme(m.draft.Theme); ok {
+				m.draft.CustomBackground = theme.Background
+			}
+		}
+		m.draft.BackgroundSet = true
+		m.draft.AppearanceConfigured = true
+	case 4:
+		values := []string{config.UIColorModeAuto, config.UIColorModeDark, config.UIColorModeLight}
+		m.draft.ColorMode = cycleString(values, m.draft.ColorMode, delta)
+		m.draft.ColorModeSet = true
+		m.draft.AppearanceConfigured = true
+	}
+}
+
+func cycleString(values []string, current string, delta int) string {
+	index := 0
+	for candidate, value := range values {
+		if value == current {
+			index = candidate
+			break
+		}
+	}
+	return values[(index+delta+len(values))%len(values)]
+}
+
+func (m initWizardModel) updateReview(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "up", "k":
+		m.reviewOffset = max(0, m.reviewOffset-1)
+	case "down", "j":
+		m.reviewOffset = min(m.maxReviewOffset(), m.reviewOffset+1)
+	case "pgup", "ctrl+u":
+		m.reviewOffset = max(0, m.reviewOffset-max(1, m.reviewPageHeight()/2))
+	case "pgdown", "ctrl+d":
+		m.reviewOffset = min(m.maxReviewOffset(), m.reviewOffset+max(1, m.reviewPageHeight()/2))
+	case "esc", "backspace":
+		m.screen = initWizardBuilder
+	case "enter", "y":
+		m.finished = true
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m *initWizardModel) openProjectForm() {
+	m.errorMessage, m.statusMessage = "", ""
+	m.formButton = -1
+	m.fields = []textinput.Model{
+		newInitInput(m.draft.Directory, "Directory"),
+		newInitInput(m.draft.Project, "Project name"),
+	}
+	m.fieldCursor = 0
+	_ = m.fields[0].Focus()
+}
+
+func (m *initWizardModel) openServiceForm(index int) {
+	m.errorMessage, m.statusMessage = "", ""
+	item := initServiceDraft{}
+	if index >= 0 {
+		item = m.draft.Services[index]
+	}
+	port := ""
+	if item.Port != 0 {
+		port = strconv.Itoa(item.Port)
+	}
+	m.fields = []textinput.Model{
+		newInitInput(item.Name, "Service name"),
+		newInitInput(item.Dir, "."),
+		newInitInput(item.Command, "Command"),
+		newInitInput(port, "Port (optional)"),
+	}
+	m.fieldCursor, m.formButton, m.editingIndex, m.screen = 0, -1, index, initWizardService
+	_ = m.fields[0].Focus()
+}
+
+func (m *initWizardModel) openActionForm(index int) {
+	m.errorMessage, m.statusMessage = "", ""
+	item := initActionDraft{Owner: projectActionOwner}
+	if index >= 0 {
+		item = m.draft.Actions[index]
+	}
+	m.fields = []textinput.Model{
+		newInitInput(item.Name, "Action name"),
+		newInitInput(item.Owner, "Owner"),
+		newInitInput(item.Dir, "."),
+		newInitInput(item.Command, "Command"),
+	}
+	m.fieldCursor, m.formButton, m.editingIndex, m.screen = 0, -1, index, initWizardAction
+	_ = m.fields[0].Focus()
+}
+
+func (m *initWizardModel) openAppearance() {
+	m.errorMessage, m.statusMessage = "", ""
+	m.screen, m.cursor = initWizardAppearance, 0
+	for index, name := range ui.ThemeNames() {
+		if name == m.draft.Theme {
+			m.themeCursor = index
+			break
+		}
+	}
+}
+
+func (m *initWizardModel) openColorForm(kind string) {
+	m.errorMessage, m.statusMessage = "", ""
+	value := m.draft.CustomBackground
+	if kind == "accent" {
+		value = m.draft.CustomAccent
+	}
+	m.editingColor = kind
+	m.fields = []textinput.Model{newInitInput(value, "#RRGGBB")}
+	m.fieldCursor, m.formButton, m.screen = 0, -1, initWizardColor
+	_ = m.fields[0].Focus()
+}
+
+func newInitInput(value, placeholder string) textinput.Model {
+	input := textinput.New()
+	input.Prompt = ""
+	input.Placeholder = placeholder
+	input.CharLimit = 512
+	input.Width = 60
+	input.SetValue(value)
+	input.CursorEnd()
+	return input
+}
+
+func validHexColor(value string) bool {
+	if len(value) != 7 || value[0] != '#' {
+		return false
+	}
+	_, err := strconv.ParseUint(value[1:], 16, 24)
+	return err == nil
+}
+
+func (m initWizardModel) View() string {
+	var body string
+	switch m.screen {
+	case initWizardReplace:
+		body = m.viewReplace()
+	case initWizardProject:
+		body = m.viewForm("Create a Kranz project", []string{"Directory", "Project name"})
+	case initWizardBuilder:
+		body = m.viewBuilder()
+	case initWizardService:
+		body = m.viewForm(formTitle("service", m.editingIndex), []string{"Name", "Directory", "Command", "Port (optional)"})
+	case initWizardAction:
+		body = m.viewForm(formTitle("action", m.editingIndex), []string{"Name", "Owner (project or service)", "Directory", "Command"})
+	case initWizardAppearance:
+		body = m.viewAppearance()
+	case initWizardColor:
+		body = m.viewForm("Custom "+m.editingColor, []string{"Color"})
+	case initWizardReview:
+		body = m.viewReview()
+	}
+	return lipgloss.NewStyle().Padding(1, 2).Render(body)
+}
+
+func formTitle(kind string, index int) string {
+	if index >= 0 {
+		return "Edit " + kind
+	}
+	return "Add " + kind
+}
+
+func (m initWizardModel) viewReplace() string {
+	buttons := []string{"Cancel", "Create replacement draft"}
+	for index := range buttons {
+		buttons[index] = button(buttons[index], index == m.replaceCursor)
+	}
+	warning := panelStyle().BorderForeground(lipgloss.Color("#F59E0B")).Render(
+		sectionTitle("EXISTING CONFIGURATION") + "\n" +
+			filepath.Base(m.initialTarget) + " will remain untouched until the final review.")
+	return titleStyle().Render("Configuration already exists") + "\n\n" + warning + "\n\n" +
+		strings.Join(buttons, "  ") + "\n\n" + controls(
+		control("←/→", "choose"), control("Enter", "continue"), control("Esc", "cancel"),
+	)
+}
+
+func (m initWizardModel) viewForm(title string, labels []string) string {
+	lines := []string{titleStyle().Render(title), mutedStyle().Render("Enter or Tab moves forward. From the last field, choose Save or Cancel.")}
+	fieldWidth := 64
+	if m.width > 0 {
+		fieldWidth = max(24, min(fieldWidth, m.width-8))
+	}
+	for index, label := range labels {
+		focused := m.formButton < 0 && index == m.fieldCursor
+		labelStyle := mutedStyle()
+		if focused {
+			labelStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#38BDF8"))
+		}
+		lines = append(lines, labelStyle.Render(label), fieldBox(m.fields[index].View(), focused, fieldWidth))
+	}
+	saveLabel := "Save"
+	switch m.screen {
+	case initWizardProject:
+		saveLabel = "Continue"
+	case initWizardColor:
+		saveLabel = "Apply"
+	}
+	actions := button(saveLabel, m.formButton == 0) + "  " + button("Cancel", m.formButton == 1)
+	hint := controls(control("Tab", "next"), control("Shift+Tab", "previous"))
+	if m.formButton >= 0 {
+		hint = controls(control("←/→", "choose"), control("Enter", "confirm"), control("Esc", "cancel"))
+	}
+	return m.withMessages(strings.Join(lines, "\n") + "\n\n" + actions + "\n\n" + hint)
+}
+
+func (m initWizardModel) viewBuilder() string {
+	rows := m.builderRows()
+	project := panelStyle().Padding(0, 2).Render(
+		sectionTitle("PROJECT") + "\n" +
+			lipgloss.NewStyle().Bold(true).Render(m.draft.Project) + "\n" + mutedStyle().Render(m.draft.Directory),
+	)
+	lines := []string{project, ""}
+	available := len(rows)
+	if m.height > 0 {
+		available = max(3, (m.height-13)/2)
+	}
+	start := 0
+	if m.cursor >= available {
+		start = m.cursor - available + 1
+	}
+	end := min(len(rows), start+available)
+	if start > 0 {
+		lines = append(lines, mutedStyle().Render(fmt.Sprintf("  ↑ %d more", start)))
+	}
+	previousSection := ""
+	for index := start; index < end; index++ {
+		row := rows[index]
+		section := m.builderSection(row)
+		if section != previousSection {
+			if previousSection != "" {
+				lines = append(lines, "")
+			}
+			lines = append(lines, sectionTitle(section))
+			previousSection = section
+		}
+		lines = append(lines, m.renderBuilderRow(row, index, index == m.cursor))
+	}
+	if end < len(rows) {
+		lines = append(lines, mutedStyle().Render(fmt.Sprintf("  ↓ %d more", len(rows)-end)))
+	}
+	return m.withMessages(strings.Join(lines, "\n") + "\n\n" + controls(
+		control("↑/↓", "select"), control("Enter", "open"), control("D", "delete"), control("Esc", "project"),
+	))
+}
+
+func (m initWizardModel) builderSection(row initWizardRow) string {
+	switch row.Kind {
+	case initRowAppearance:
+		return "APPEARANCE"
+	case initRowService, initRowAddService:
+		return fmt.Sprintf("SERVICES  %d", len(m.draft.Services))
+	case initRowAction, initRowAddAction:
+		return fmt.Sprintf("ACTIONS  %d", len(m.draft.Actions))
+	default:
+		return "FINISH"
+	}
+}
+
+func (m initWizardModel) renderBuilderRow(row initWizardRow, index int, selected bool) string {
+	label := m.builderRowLabel(row)
+	actions := ""
+	switch row.Kind {
+	case initRowService, initRowAction:
+		deleteHovered := selected && m.hoverRow == index && m.hoverAction == "delete"
+		actions = "  " + button("Edit", selected && !deleteHovered) + " " + button("Delete", deleteHovered)
+	case initRowAppearance:
+		actions = "  " + button("Configure", selected)
+	case initRowAddService, initRowAddAction:
+		actions = "  " + button("Add", selected)
+	case initRowReview:
+		actions = "  " + button("Open", selected)
+	}
+	content := "  " + label + actions
+	width := max(40, lipgloss.Width(content)+2)
+	if m.width > 0 {
+		width = max(28, min(84, m.width-6))
+	}
+	label = ansi.Truncate(label, max(8, width-lipgloss.Width(actions)-5), "…")
+	content = "  " + label + actions
+	style := lipgloss.NewStyle().Padding(0, 1).Width(width)
+	if selected {
+		style = style.Bold(true).
+			Foreground(lipgloss.AdaptiveColor{Light: "#0C4A6E", Dark: "#E0F2FE"}).
+			Background(lipgloss.AdaptiveColor{Light: "#BAE6FD", Dark: "#164E63"})
+		content = "› " + label + actions
+	}
+	return style.Render(content)
+}
+
+func (m initWizardModel) builderRowLabel(row initWizardRow) string {
+	switch row.Kind {
+	case initRowAppearance:
+		if !m.draft.AppearanceConfigured {
+			return "Appearance   Inherit global defaults"
+		}
+		return fmt.Sprintf("Appearance   %s · %s · %s", m.draft.Theme, m.draft.BackgroundSource, m.draft.ColorMode)
+	case initRowService:
+		item := m.draft.Services[row.Index]
+		port := ""
+		if item.Port != 0 {
+			port = fmt.Sprintf(" · :%d", item.Port)
+		}
+		return fmt.Sprintf("%s   %s · %s%s", item.Name, cleanDraftDir(item.Dir), item.Command, port)
+	case initRowAction:
+		item := m.draft.Actions[row.Index]
+		return fmt.Sprintf("%s/%s   %s", item.Owner, item.Name, item.Command)
+	case initRowAddService:
+		return "+ Add service"
+	case initRowAddAction:
+		return "+ Add action"
+	case initRowReview:
+		return "Review and save"
+	default:
+		return ""
+	}
+}
+
+func (m initWizardModel) viewAppearance() string {
+	accent := m.draft.AccentSource
+	if accent == "custom" {
+		accent += " " + m.draft.CustomAccent
+	}
+	background := m.draft.BackgroundSource
+	if background == "custom" {
+		background += " " + m.draft.CustomBackground
+	}
+	configured := "inherit defaults"
+	if m.draft.AppearanceConfigured {
+		configured = "project"
+	}
+	values := [][2]string{
+		{"Save appearance", configured},
+		{"Theme", m.draft.Theme},
+		{"Accent", accent},
+		{"Background", background},
+		{"Color mode", m.draft.ColorMode},
+		{"Done", "Return to project"},
+	}
+	lines := []string{sectionTitle("PROJECT APPEARANCE")}
+	for index, value := range values {
+		lines = append(lines, renderSettingRow(value[0], value[1], index == m.cursor))
+	}
+	settings := strings.Join(lines, "\n")
+	preview := m.appearancePreview()
+	content := settings + "\n\n" + preview
+	if m.width >= 104 {
+		content = lipgloss.JoinHorizontal(lipgloss.Top, settings, "    ", preview)
+	}
+	return m.withMessages(titleStyle().Render("Appearance") + "\n\n" + content + "\n\n" + controls(
+		control("←/→", "change"), control("Enter", "edit / done"), control("Esc", "back"),
+	))
+}
+
+func renderSettingRow(label, value string, selected bool) string {
+	label = strings.ToUpper(label)
+	content := fmt.Sprintf("%-16s │ %s", label, value)
+	style := lipgloss.NewStyle().Padding(0, 1).Width(46)
+	if selected {
+		return style.Bold(true).
+			Foreground(lipgloss.AdaptiveColor{Light: "#0C4A6E", Dark: "#E0F2FE"}).
+			Background(lipgloss.AdaptiveColor{Light: "#BAE6FD", Dark: "#164E63"}).
+			Render("› " + content)
+	}
+	labelCell := lipgloss.NewStyle().Bold(true).
+		Foreground(lipgloss.AdaptiveColor{Light: "#64748B", Dark: "#94A3B8"}).
+		Render(fmt.Sprintf("%-16s", label))
+	separator := mutedStyle().Render(" │ ")
+	valueCell := lipgloss.NewStyle().Bold(true).
+		Foreground(lipgloss.AdaptiveColor{Light: "#0F172A", Dark: "#F1F5F9"}).
+		Render(value)
+	return style.Render("  " + labelCell + separator + valueCell)
+}
+
+func (m initWizardModel) appearancePreview() string {
+	accent, background := "", ""
+	if m.draft.AccentSource == "custom" {
+		accent = m.draft.CustomAccent
+	}
+	if m.draft.BackgroundSource == "custom" {
+		background = m.draft.CustomBackground
+	}
+	dark := m.draft.ColorMode != config.UIColorModeLight
+	theme, err := ui.BuildTheme(m.draft.Theme, accent, background, dark)
+	if err != nil {
+		return errorStyle().Render(err.Error())
+	}
+	previewWidth := 54
+	if m.width > 0 {
+		previewWidth = max(28, min(previewWidth, m.width-8))
+	}
+	canvas := lipgloss.NewStyle().
+		Foreground(lipgloss.Color(theme.Text)).
+		Background(lipgloss.Color(theme.Background)).
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color(theme.Border)).
+		Padding(0, 1).
+		Width(previewWidth)
+	header := lipgloss.NewStyle().Foreground(lipgloss.Color(theme.AccentText)).Bold(true).Render("KRANZ  PROJECT PREVIEW")
+	running := lipgloss.NewStyle().Foreground(lipgloss.Color(theme.Green)).Render("● running")
+	stopped := lipgloss.NewStyle().Foreground(lipgloss.Color(theme.Muted)).Render("○ stopped")
+	separator := lipgloss.NewStyle().
+		Foreground(lipgloss.Color(theme.Text)).
+		Background(lipgloss.Color(theme.Background)).
+		Render(" ")
+	port := lipgloss.NewStyle().
+		Foreground(lipgloss.Color(theme.Data)).
+		Background(lipgloss.Color(theme.Background)).
+		Render(":3000")
+	content := strings.Join([]string{
+		header,
+		"",
+		"web       " + running + separator + port,
+		fmt.Sprintf("worker    %s", stopped),
+		"",
+		lipgloss.NewStyle().Foreground(lipgloss.Color(theme.Info)).Render("Ready to start local services"),
+	}, "\n")
+	mode := m.draft.ColorMode
+	if mode == config.UIColorModeAuto {
+		mode += " (dark terminal preview)"
+	}
+	caption := "Preview: background " + m.draft.BackgroundSource + " · " + mode
+	if !m.draft.AppearanceConfigured {
+		caption += " · not saved (project inherits)"
+	}
+	caption = ansi.Truncate(caption, previewWidth+2, "…")
+	return canvas.Render(content) + "\n" + mutedStyle().Render(caption)
+}
+
+func (m initWizardModel) viewReview() string {
+	document, err := m.draft.document()
+	if err != nil {
+		return titleStyle().Render("Cannot review draft") + "\n\n" + errorStyle().Render(err.Error()) + "\n\n" + controls(control("Esc", "back"))
+	}
+	rendered, err := renderDocument(document)
+	if err != nil {
+		return errorStyle().Render(err.Error())
+	}
+	target := m.draft.target(m.outputPath)
+	heading := "Create " + filepath.Base(target)
+	content := rendered
+	if previous, readErr := os.ReadFile(target); readErr == nil {
+		heading = "Replace " + filepath.Base(target)
+		content = renderLineDiff(string(previous), rendered)
+	}
+	contentLines := strings.Split(strings.TrimSuffix(content, "\n"), "\n")
+	pageHeight := m.reviewPageHeight()
+	maxOffset := max(0, len(contentLines)-pageHeight)
+	m.reviewOffset = min(m.reviewOffset, maxOffset)
+	end := min(len(contentLines), m.reviewOffset+pageHeight)
+	visible := contentLines[m.reviewOffset:end]
+	scroll := ""
+	if len(contentLines) > pageHeight {
+		scroll = fmt.Sprintf(" · ↑/↓ scroll %d-%d/%d", m.reviewOffset+1, end, len(contentLines))
+	}
+	documentPanel := panelStyle().Render(strings.Join(visible, "\n"))
+	return titleStyle().Render(heading) + "\n" + mutedStyle().Render("Review the exact configuration before it is written.") +
+		"\n\n" + documentPanel + "\n\n" + button("Save configuration  Enter", true) + "  " + button("Back  Esc", false) +
+		"\n\n" + controls(control("↑/↓", "scroll"), control("Ctrl+C", "cancel")) + mutedStyle().Render(scroll)
+}
+
+func (m initWizardModel) reviewPageHeight() int {
+	if m.height <= 0 {
+		return 18
+	}
+	return max(4, m.height-12)
+}
+
+func (m initWizardModel) maxReviewOffset() int {
+	document, err := m.draft.document()
+	if err != nil {
+		return 0
+	}
+	rendered, err := renderDocument(document)
+	if err != nil {
+		return 0
+	}
+	if previous, readErr := os.ReadFile(m.draft.target(m.outputPath)); readErr == nil {
+		rendered = renderLineDiff(string(previous), rendered)
+	}
+	return max(0, len(strings.Split(strings.TrimSuffix(rendered, "\n"), "\n"))-m.reviewPageHeight())
+}
+
+func renderLineDiff(before, after string) string {
+	left, right := strings.Split(strings.TrimSuffix(before, "\n"), "\n"), strings.Split(strings.TrimSuffix(after, "\n"), "\n")
+	rows, columns := len(left)+1, len(right)+1
+	lcs := make([][]int, rows)
+	for index := range lcs {
+		lcs[index] = make([]int, columns)
+	}
+	for i := len(left) - 1; i >= 0; i-- {
+		for j := len(right) - 1; j >= 0; j-- {
+			if left[i] == right[j] {
+				lcs[i][j] = lcs[i+1][j+1] + 1
+			} else {
+				lcs[i][j] = max(lcs[i+1][j], lcs[i][j+1])
+			}
+		}
+	}
+	lines := []string{"--- current", "+++ proposed"}
+	for i, j := 0, 0; i < len(left) || j < len(right); {
+		switch {
+		case i < len(left) && j < len(right) && left[i] == right[j]:
+			lines = append(lines, "  "+left[i])
+			i, j = i+1, j+1
+		case j < len(right) && (i == len(left) || lcs[i][j+1] >= lcs[i+1][j]):
+			lines = append(lines, "+ "+right[j])
+			j++
+		default:
+			lines = append(lines, "- "+left[i])
+			i++
+		}
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func (m initWizardModel) withMessages(body string) string {
+	if m.errorMessage != "" {
+		body += "\n\n" + errorStyle().Render(m.errorMessage)
+	}
+	if m.statusMessage != "" {
+		body += "\n\n" + mutedStyle().Render(m.statusMessage)
+	}
+	return body
+}
+
+func titleStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#38BDF8")).MarginBottom(0)
+}
+func mutedStyle() lipgloss.Style { return lipgloss.NewStyle().Foreground(lipgloss.Color("#8D99A8")) }
+func errorStyle() lipgloss.Style { return lipgloss.NewStyle().Foreground(lipgloss.Color("#FB7185")) }
+
+func panelStyle() lipgloss.Style {
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.AdaptiveColor{Light: "#94A3B8", Dark: "#475569"}).
+		Padding(1, 2)
+}
+
+func sectionTitle(value string) string {
+	return lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.AdaptiveColor{Light: "#475569", Dark: "#94A3B8"}).
+		Render(value)
+}
+
+func fieldBox(value string, focused bool, width int) string {
+	border := lipgloss.AdaptiveColor{Light: "#CBD5E1", Dark: "#475569"}
+	style := lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(border).Padding(0, 1).Width(width)
+	if focused {
+		style = style.BorderForeground(lipgloss.Color("#38BDF8"))
+	}
+	return style.Render(value)
+}
+
+func button(label string, primary bool) string {
+	style := lipgloss.NewStyle().Bold(true).Padding(0, 1).
+		Foreground(lipgloss.AdaptiveColor{Light: "#334155", Dark: "#CBD5E1"}).
+		Background(lipgloss.AdaptiveColor{Light: "#E2E8F0", Dark: "#334155"})
+	if primary {
+		style = style.Foreground(lipgloss.AdaptiveColor{Light: "#082F49", Dark: "#082F49"}).
+			Background(lipgloss.Color("#38BDF8"))
+	}
+	return style.Render(label)
+}
+
+func keyCap(key string) string {
+	return lipgloss.NewStyle().Bold(true).
+		Foreground(lipgloss.Color("#38BDF8")).
+		Render("[" + key + "]")
+}
+
+func control(key, label string) string {
+	return keyCap(key) + " " + mutedStyle().Render(label)
+}
+
+func controls(items ...string) string { return strings.Join(items, "   ") }
+
+func runInitWizard(directory, outputPath string, options initOptions, input io.Reader, output io.Writer) (initDraft, bool, error) {
+	model := newInitWizardModel(directory, outputPath, options)
+	program := tea.NewProgram(model, tea.WithInput(input), tea.WithOutput(output), tea.WithAltScreen(), tea.WithMouseCellMotion())
+	final, err := program.Run()
+	if err != nil {
+		return initDraft{}, false, err
+	}
+	result, ok := final.(initWizardModel)
+	if !ok {
+		return initDraft{}, false, fmt.Errorf("init wizard returned an unexpected model")
+	}
+	return result.draft, result.finished && !result.cancelled, nil
+}

--- a/cmd/kranz/init_wizard_test.go
+++ b/cmd/kranz/init_wizard_test.go
@@ -1,0 +1,278 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+)
+
+func TestInitDraftWritesOnlyChangedAppearanceFields(t *testing.T) {
+	draft := newInitDraft(t.TempDir(), initOptions{})
+	draft.Services = []initServiceDraft{{Name: "web", Dir: ".", Command: "run web"}}
+	draft.AppearanceConfigured = true
+	draft.Theme, draft.ThemeSet = "nord", true
+
+	document, err := draft.document()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rendered, err := renderDocument(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(rendered, "theme: nord") {
+		t.Fatalf("theme missing from draft:\n%s", rendered)
+	}
+	for _, unwanted := range []string{"accent:", "background:", "color_mode:"} {
+		if strings.Contains(rendered, unwanted) {
+			t.Errorf("unchanged appearance field %q was written:\n%s", unwanted, rendered)
+		}
+	}
+}
+
+func TestInitWizardAddsEditsAndDeletesDraftItems(t *testing.T) {
+	model := newInitWizardModel(t.TempDir(), "kranz.yaml", initOptions{})
+	model.screen = initWizardBuilder
+
+	model.openServiceForm(-1)
+	setInitFields(&model, "web", "./frontend", "npm run dev", "3000")
+	updated, _ := model.submitForm()
+	model = updated.(initWizardModel)
+	if len(model.draft.Services) != 1 || model.draft.Services[0].Port != 3000 {
+		t.Fatalf("service draft = %#v", model.draft.Services)
+	}
+
+	model.openActionForm(-1)
+	setInitFields(&model, "test", "web", ".", "npm test")
+	updated, _ = model.submitForm()
+	model = updated.(initWizardModel)
+	if len(model.draft.Actions) != 1 || model.draft.Actions[0].Owner != "web" {
+		t.Fatalf("action draft = %#v", model.draft.Actions)
+	}
+
+	model.openServiceForm(0)
+	setInitFields(&model, "frontend", "./web", "npm run start", "3100")
+	updated, _ = model.submitForm()
+	model = updated.(initWizardModel)
+	if model.draft.Services[0].Name != "frontend" || model.draft.Actions[0].Owner != "frontend" {
+		t.Fatalf("renaming service did not update its draft and action owner: %#v / %#v", model.draft.Services, model.draft.Actions)
+	}
+
+	model.cursor = 1 // appearance is row zero; the service follows it
+	updated, _ = model.updateBuilder(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	model = updated.(initWizardModel)
+	if len(model.draft.Services) != 0 || len(model.draft.Actions) != 0 {
+		t.Fatalf("deleting a service left draft objects behind: %#v / %#v", model.draft.Services, model.draft.Actions)
+	}
+}
+
+func TestInitWizardEnterAdvancesThenFocusesSave(t *testing.T) {
+	model := newInitWizardModel(t.TempDir(), "kranz.yaml", initOptions{})
+	model.openServiceForm(-1)
+	setInitFields(&model, "web", ".", "run web", "3000")
+
+	for want := 1; want < len(model.fields); want++ {
+		updated, _ := model.updateForm(tea.KeyMsg{Type: tea.KeyEnter})
+		model = updated.(initWizardModel)
+		if model.fieldCursor != want || model.screen != initWizardService {
+			t.Fatalf("Enter did not advance to field %d: cursor=%d screen=%v", want, model.fieldCursor, model.screen)
+		}
+	}
+	updated, _ := model.updateForm(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(initWizardModel)
+	if model.screen != initWizardService || model.formButton != 0 || len(model.draft.Services) != 0 {
+		t.Fatalf("Enter on last field did not focus Save: screen=%v button=%d services=%#v", model.screen, model.formButton, model.draft.Services)
+	}
+	updated, _ = model.updateForm(tea.KeyMsg{Type: tea.KeyRight})
+	model = updated.(initWizardModel)
+	if model.formButton != 1 {
+		t.Fatalf("Right did not focus Cancel: button=%d", model.formButton)
+	}
+	updated, _ = model.updateForm(tea.KeyMsg{Type: tea.KeyLeft})
+	model = updated.(initWizardModel)
+	updated, _ = model.updateForm(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(initWizardModel)
+	if model.screen != initWizardBuilder || len(model.draft.Services) != 1 {
+		t.Fatalf("Enter on focused Save did not save service: screen=%v services=%#v", model.screen, model.draft.Services)
+	}
+}
+
+func TestInitWizardBuilderShowsActionsAndSupportsMouseSelectionAndDelete(t *testing.T) {
+	model := newInitWizardModel(t.TempDir(), "kranz.yaml", initOptions{})
+	model.screen = initWizardBuilder
+	model.width, model.height = 100, 40
+	model.draft.Services = []initServiceDraft{{Name: "web", Dir: ".", Command: "run web", Port: 3000}}
+
+	view := ansi.Strip(model.View())
+	for _, want := range []string{"SERVICES", "Edit", "Delete", "APPEARANCE", "ACTIONS"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("builder is missing %q:\n%s", want, view)
+		}
+	}
+	for _, unwanted := range []string{"[Edit]", "[Delete]", "[Add]"} {
+		if strings.Contains(view, unwanted) {
+			t.Fatalf("builder action %q should not use shortcut brackets:\n%s", unwanted, view)
+		}
+	}
+	lines := strings.Split(view, "\n")
+	rowY, deleteX := -1, -1
+	for y, line := range lines {
+		if strings.Contains(line, "web") && strings.Contains(line, "Delete") {
+			rowY, deleteX = y, strings.Index(line, "Delete")
+			break
+		}
+	}
+	if rowY < 0 || deleteX < 0 {
+		t.Fatalf("could not locate service controls:\n%s", view)
+	}
+	updated, _ := model.updateMouse(tea.MouseMsg{X: deleteX, Y: rowY, Action: tea.MouseActionMotion})
+	model = updated.(initWizardModel)
+	if model.cursor != 1 {
+		t.Fatalf("hover selected row %d, want service row 1", model.cursor)
+	}
+	updated, _ = model.updateMouse(tea.MouseMsg{X: deleteX, Y: rowY, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft})
+	model = updated.(initWizardModel)
+	if len(model.draft.Services) != 0 {
+		t.Fatalf("mouse Delete left services behind: %#v", model.draft.Services)
+	}
+}
+
+func TestInitWizardAppearanceRetainsCustomColorsAcrossSourceChanges(t *testing.T) {
+	model := newInitWizardModel(t.TempDir(), "kranz.yaml", initOptions{})
+	model.openAppearance()
+	model.cursor = 2
+	model.changeAppearance(1)
+	model.draft.CustomAccent = "#123456"
+	model.changeAppearance(1)
+	model.changeAppearance(1)
+	if model.draft.AccentSource != "custom" || model.draft.CustomAccent != "#123456" {
+		t.Fatalf("custom accent was not retained: source=%q color=%q", model.draft.AccentSource, model.draft.CustomAccent)
+	}
+
+	model.cursor = 3
+	model.changeAppearance(1) // theme
+	model.changeAppearance(1) // custom
+	model.draft.CustomBackground = "#654321"
+	model.changeAppearance(1) // terminal
+	model.changeAppearance(-1)
+	if model.draft.BackgroundSource != "custom" || model.draft.CustomBackground != "#654321" {
+		t.Fatalf("custom background was not retained: source=%q color=%q", model.draft.BackgroundSource, model.draft.CustomBackground)
+	}
+
+	view := model.viewAppearance()
+	for _, want := range []string{"KRANZ", "COLOR MODE", "auto", "background custom"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("appearance preview is missing %q:\n%s", want, view)
+		}
+	}
+	model.draft.Services = []initServiceDraft{{Name: "web", Dir: ".", Command: "run web"}}
+	document, err := model.draft.document()
+	if err != nil {
+		t.Fatalf("custom background made the init draft invalid: %v", err)
+	}
+	rendered, err := renderDocument(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(rendered, "background: '#654321'") {
+		t.Fatalf("custom background was not serialized:\n%s", rendered)
+	}
+}
+
+func TestInitWizardAppearanceDoneReturnsToValidBuilderSelection(t *testing.T) {
+	model := newInitWizardModel(t.TempDir(), "kranz.yaml", initOptions{})
+	model.openAppearance()
+	model.cursor = 5
+	updated, _ := model.updateAppearance(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(initWizardModel)
+	if model.screen != initWizardBuilder || model.cursor != 0 {
+		t.Fatalf("Done returned to screen=%v cursor=%d, want builder cursor 0", model.screen, model.cursor)
+	}
+	updated, _ = model.updateBuilder(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(initWizardModel)
+	if model.screen != initWizardAppearance {
+		t.Fatalf("returned builder selection did not reopen Appearance: screen=%v", model.screen)
+	}
+}
+
+func TestInitWizardExistingConfigurationStartsSafeAndReviewsDiff(t *testing.T) {
+	directory := t.TempDir()
+	target := filepath.Join(directory, "kranz.yaml")
+	if err := os.WriteFile(target, []byte("project: Before\nservices:\n  old:\n    command: old\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	model := newInitWizardModel(directory, "kranz.yaml", initOptions{})
+	if model.screen != initWizardReplace || model.replaceCursor != 0 {
+		t.Fatalf("existing file did not start on safe cancel choice: screen=%v cursor=%d", model.screen, model.replaceCursor)
+	}
+
+	model.draft.Project = "After"
+	model.draft.Services = []initServiceDraft{{Name: "web", Dir: ".", Command: "new"}}
+	model.screen = initWizardReview
+	view := model.View()
+	for _, want := range []string{"Replace kranz.yaml", "--- current", "+++ proposed", "- project: Before", "+ project: After"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("replacement review is missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestInitWizardProjectActionsRenderAsActionGroup(t *testing.T) {
+	draft := newInitDraft(t.TempDir(), initOptions{})
+	draft.Actions = []initActionDraft{{Name: "test", Owner: projectActionOwner, Dir: ".", Command: "make test"}}
+	document, err := draft.document()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rendered, err := renderDocument(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"action_groups:", "project:", "test:", "command: make test"} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("project action YAML is missing %q:\n%s", want, rendered)
+		}
+	}
+}
+
+func TestInitWizardKeepsLargeDraftAndReviewNavigable(t *testing.T) {
+	model := newInitWizardModel(t.TempDir(), "kranz.yaml", initOptions{})
+	model.screen, model.height = initWizardBuilder, 12
+	for index := 0; index < 12; index++ {
+		model.draft.Services = append(model.draft.Services, initServiceDraft{
+			Name:    "service-" + strconv.Itoa(index),
+			Dir:     ".",
+			Command: "run " + strconv.Itoa(index),
+		})
+	}
+	model.cursor = len(model.builderRows()) - 1
+	view := model.viewBuilder()
+	if !strings.Contains(view, "Review and save") || !strings.Contains(view, "↑") {
+		t.Fatalf("large builder did not keep the selected tail visible:\n%s", view)
+	}
+
+	model.screen, model.reviewOffset = initWizardReview, 0
+	updated, _ := model.updateReview(tea.KeyMsg{Type: tea.KeyDown})
+	model = updated.(initWizardModel)
+	if model.reviewOffset != 1 {
+		t.Fatalf("review offset = %d, want 1", model.reviewOffset)
+	}
+	for index := 0; index < 100; index++ {
+		updated, _ = model.updateReview(tea.KeyMsg{Type: tea.KeyDown})
+		model = updated.(initWizardModel)
+	}
+	if model.reviewOffset != model.maxReviewOffset() {
+		t.Fatalf("review scrolling exceeded its bound: got %d want %d", model.reviewOffset, model.maxReviewOffset())
+	}
+}
+
+func setInitFields(model *initWizardModel, values ...string) {
+	for index, value := range values {
+		model.fields[index].SetValue(value)
+	}
+}

--- a/cmd/kranz/inspect_commands.go
+++ b/cmd/kranz/inspect_commands.go
@@ -419,16 +419,34 @@ func directDependents(cfg *config.Config, name string) []string {
 	return dependents
 }
 
-// runPlan shows the waves a start would use: everything in one wave depends
-// only on earlier waves, which is exactly how the runtime gates readiness.
+// runPlan shows the exact service set a lifecycle operation would affect.
+// Starts can be planned from configuration; stops and restarts consult the
+// live runtime because stopped dependents are not affected by those operations.
 func runPlan(options kranzcli.GlobalOptions, args []string, stdout io.Writer) error {
-	cfg, _, err := loadProject(options)
+	operation, selectors, err := parsePlanOptions(args)
 	if err != nil {
 		return err
 	}
-	local := app.NewLocal(cfg, nil, app.Options{})
-	defer func() { _ = local.Shutdown() }()
-	plan, err := local.Plan(app.PlanRequest{Operation: "start", Selectors: args, IncludeDependencies: true})
+	var planner app.API
+	var cfg *config.Config
+	if operation == "start" {
+		loaded, _, loadErr := loadProject(options)
+		if loadErr != nil {
+			return loadErr
+		}
+		cfg = loaded
+		local := app.NewLocal(cfg, nil, app.Options{})
+		defer func() { _ = local.Shutdown() }()
+		planner = local
+	} else {
+		client, closeClient, dialErr := dialProjectRuntime(options)
+		if dialErr != nil {
+			return dialErr
+		}
+		defer closeClient()
+		planner = client
+	}
+	plan, err := planner.Plan(app.PlanRequest{Operation: operation, Selectors: selectors, IncludeDependencies: operation == "start"})
 	if err != nil {
 		return classifyLogQueryError(err)
 	}
@@ -442,7 +460,20 @@ func runPlan(options kranzcli.GlobalOptions, args []string, stdout io.Writer) er
 		for _, plannedWave := range plan.Waves {
 			entries = append(entries, wave{plannedWave.Wave, plannedWave.Services})
 		}
+		if operation != "start" && len(plan.Targets) > 0 {
+			entries = append(entries, wave{Wave: 1, Services: plan.Targets})
+		}
 		return kranzcli.WriteJSON(stdout, entries)
+	}
+	if operation != "start" {
+		_, _ = fmt.Fprintf(stdout, "%s targets:\n", strings.ToUpper(operation[:1])+operation[1:])
+		for _, name := range plan.Targets {
+			_, _ = fmt.Fprintf(stdout, "  %s\n", name)
+		}
+		if plan.RequiresConfirmation {
+			_, _ = fmt.Fprintln(stdout, "\nRequires confirmation.")
+		}
+		return nil
 	}
 	for _, plannedWave := range plan.Waves {
 		names := plannedWave.Services
@@ -460,6 +491,38 @@ func runPlan(options kranzcli.GlobalOptions, args []string, stdout io.Writer) er
 		}
 	}
 	return nil
+}
+
+func parsePlanOptions(args []string) (string, []string, error) {
+	operation := "start"
+	operationSet := false
+	selectors := make([]string, 0, len(args))
+	for index := 0; index < len(args); index++ {
+		switch {
+		case args[index] == "--operation":
+			if operationSet {
+				return "", nil, &kranzcli.Error{Code: "invalid_arguments", Message: "--operation may be specified only once", ExitCode: kranzcli.ExitUsage}
+			}
+			if index+1 >= len(args) {
+				return "", nil, &kranzcli.Error{Code: "missing_option_value", Message: "--operation requires start, stop, or restart", ExitCode: kranzcli.ExitUsage}
+			}
+			index++
+			operation, operationSet = args[index], true
+		case strings.HasPrefix(args[index], "--operation="):
+			if operationSet {
+				return "", nil, &kranzcli.Error{Code: "invalid_arguments", Message: "--operation may be specified only once", ExitCode: kranzcli.ExitUsage}
+			}
+			operation, operationSet = strings.TrimPrefix(args[index], "--operation="), true
+		case strings.HasPrefix(args[index], "-"):
+			return "", nil, &kranzcli.Error{Code: "unknown_option", Message: fmt.Sprintf("unknown plan option %q", args[index]), Hint: "Use --operation start, stop, or restart.", ExitCode: kranzcli.ExitUsage}
+		default:
+			selectors = append(selectors, args[index])
+		}
+	}
+	if operation != "start" && operation != "stop" && operation != "restart" {
+		return "", nil, &kranzcli.Error{Code: "invalid_arguments", Message: fmt.Sprintf("unknown plan operation %q", operation), Hint: "Use start, stop, or restart.", ExitCode: kranzcli.ExitUsage}
+	}
+	return operation, selectors, nil
 }
 
 func runGraph(options kranzcli.GlobalOptions, args []string, stdout io.Writer) error {

--- a/cmd/kranz/inspect_commands.go
+++ b/cmd/kranz/inspect_commands.go
@@ -115,6 +115,10 @@ func runConfigCheck(options kranzcli.GlobalOptions, stdout io.Writer) error {
 }
 
 func runList(options kranzcli.GlobalOptions, args []string, stdout io.Writer) error {
+	formatter, args, err := extractRowFormat("list", options.Output, args)
+	if err != nil {
+		return err
+	}
 	kind := "services"
 	if len(args) > 0 {
 		kind = args[0]
@@ -128,14 +132,18 @@ func runList(options kranzcli.GlobalOptions, args []string, stdout io.Writer) er
 	}
 	switch kind {
 	case "services":
-		return listServices(cfg, options, stdout)
+		return listServices(cfg, options, stdout, formatter)
 	case "actions":
 		// Keep the legacy `list actions` spelling as an exact alias of the
 		// canonical action command instead of maintaining two subtly different
 		// action tables and JSON contracts.
-		return runActionList(options, nil, stdout)
+		entries := actionListEntries(cfg, "")
+		if options.Output == kranzcli.OutputJSON {
+			return kranzcli.WriteJSON(stdout, entries)
+		}
+		return writeActionList(stdout, entries, formatter)
 	case "tags":
-		return listTags(cfg, options, stdout)
+		return listTags(cfg, options, stdout, formatter)
 	default:
 		return &kranzcli.Error{
 			Code:     "invalid_arguments",
@@ -146,7 +154,7 @@ func runList(options kranzcli.GlobalOptions, args []string, stdout io.Writer) er
 	}
 }
 
-func listServices(cfg *config.Config, options kranzcli.GlobalOptions, stdout io.Writer) error {
+func listServices(cfg *config.Config, options kranzcli.GlobalOptions, stdout io.Writer, formatter *rowTemplate) error {
 	type entry struct {
 		Name        string   `json:"name"`
 		Description string   `json:"description"`
@@ -163,6 +171,19 @@ func listServices(cfg *config.Config, options kranzcli.GlobalOptions, stdout io.
 	if options.Output == kranzcli.OutputJSON {
 		return kranzcli.WriteJSON(stdout, entries)
 	}
+	if formatter != nil {
+		rows := make([]map[string]any, 0, len(entries))
+		for _, item := range entries {
+			rows = append(rows, map[string]any{
+				"Name": item.Name, "Description": item.Description, "Tags": strings.Join(item.Tags, ","),
+				"DependsOn": strings.Join(item.DependsOn, ","), "Ports": joinPortsOrDash(item.Ports), "Disabled": item.Disabled,
+			})
+		}
+		return formatter.write(stdout, map[string]any{
+			"Name": "NAME", "Description": "DESCRIPTION", "Tags": "TAGS",
+			"DependsOn": "DEPENDS ON", "Ports": "PORTS", "Disabled": "DISABLED",
+		}, rows)
+	}
 	w := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
 	_, _ = fmt.Fprintln(w, "NAME\tTAGS\tDEPENDS ON\tPORTS\tDESCRIPTION")
 	for _, item := range entries {
@@ -175,7 +196,7 @@ func listServices(cfg *config.Config, options kranzcli.GlobalOptions, stdout io.
 	return w.Flush()
 }
 
-func listTags(cfg *config.Config, options kranzcli.GlobalOptions, stdout io.Writer) error {
+func listTags(cfg *config.Config, options kranzcli.GlobalOptions, stdout io.Writer, formatter *rowTemplate) error {
 	counts := make(map[string]int)
 	for _, name := range cfg.ServiceNames() {
 		for _, tag := range cfg.Services[name].Tags {
@@ -197,6 +218,13 @@ func listTags(cfg *config.Config, options kranzcli.GlobalOptions, stdout io.Writ
 	}
 	if options.Output == kranzcli.OutputJSON {
 		return kranzcli.WriteJSON(stdout, entries)
+	}
+	if formatter != nil {
+		rows := make([]map[string]any, 0, len(entries))
+		for _, item := range entries {
+			rows = append(rows, map[string]any{"Tag": item.Tag, "Services": item.Services})
+		}
+		return formatter.write(stdout, map[string]any{"Tag": "TAG", "Services": "SERVICES"}, rows)
 	}
 	w := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
 	_, _ = fmt.Fprintln(w, "TAG\tSERVICES")
@@ -484,6 +512,10 @@ func runGraph(options kranzcli.GlobalOptions, args []string, stdout io.Writer) e
 }
 
 func runPorts(options kranzcli.GlobalOptions, args []string, stdout io.Writer) error {
+	formatter, args, err := extractRowFormat("ports", options.Output, args)
+	if err != nil {
+		return err
+	}
 	cfg, _, err := loadProject(options)
 	if err != nil {
 		return err
@@ -556,6 +588,19 @@ func runPorts(options kranzcli.GlobalOptions, args []string, stdout io.Writer) e
 
 	if options.Output == kranzcli.OutputJSON {
 		return kranzcli.WriteJSON(stdout, entries)
+	}
+	if formatter != nil {
+		rows := make([]map[string]any, 0, len(entries))
+		for _, item := range entries {
+			rows = append(rows, map[string]any{
+				"Service": item.Service, "Port": item.Port, "Origin": item.Origin,
+				"State": item.State, "PID": pidLabel(item.PID), "Process": item.Process,
+			})
+		}
+		return formatter.write(stdout, map[string]any{
+			"Service": "SERVICE", "Port": "PORT", "Origin": "ORIGIN",
+			"State": "STATE", "PID": "PID", "Process": "PROCESS",
+		}, rows)
 	}
 	if len(entries) == 0 {
 		_, _ = fmt.Fprintln(stdout, "No ports to report.")
@@ -693,7 +738,11 @@ func protocolOf(info *config.PortInfo) string {
 // runDoctor runs preflight checks that do not start anything. It reports every
 // finding rather than stopping at the first, because a preflight that hides
 // the second problem behind the first costs another run to discover it.
-func runDoctor(options kranzcli.GlobalOptions, stdout io.Writer) error {
+func runDoctor(options kranzcli.GlobalOptions, args []string, stdout io.Writer) error {
+	formatter, err := parseRowFormat("doctor", options.Output, args)
+	if err != nil {
+		return err
+	}
 	cfg, paths, err := loadProject(options)
 	if err != nil {
 		return err
@@ -704,6 +753,18 @@ func runDoctor(options kranzcli.GlobalOptions, stdout io.Writer) error {
 
 	if options.Output == kranzcli.OutputJSON {
 		if err := kranzcli.WriteJSON(stdout, result); err != nil {
+			return err
+		}
+	} else if formatter != nil {
+		rows := make([]map[string]any, 0, len(result.Findings))
+		for _, item := range result.Findings {
+			rows = append(rows, map[string]any{
+				"Check": item.Check, "Subject": item.Subject, "Status": item.Status, "Detail": item.Detail,
+			})
+		}
+		if err := formatter.write(stdout, map[string]any{
+			"Check": "CHECK", "Subject": "SUBJECT", "Status": "STATUS", "Detail": "DETAIL",
+		}, rows); err != nil {
 			return err
 		}
 	} else {

--- a/cmd/kranz/inspect_commands.go
+++ b/cmd/kranz/inspect_commands.go
@@ -527,18 +527,33 @@ func parsePlanOptions(args []string) (string, []string, error) {
 
 func runGraph(options kranzcli.GlobalOptions, args []string, stdout io.Writer) error {
 	format := "text"
+	formatSet := false
 	for index := 0; index < len(args); index++ {
 		switch {
-		case args[index] == "--format" && index+1 < len(args):
+		case args[index] == "--format":
+			if formatSet {
+				return graphFormatError("--format may be specified only once")
+			}
+			if index+1 >= len(args) {
+				return graphFormatError("--format requires text, json, or dot")
+			}
 			format = args[index+1]
+			formatSet = true
 			index++
 		case strings.HasPrefix(args[index], "--format="):
+			if formatSet {
+				return graphFormatError("--format may be specified only once")
+			}
 			format = strings.TrimPrefix(args[index], "--format=")
+			formatSet = true
 		default:
-			return &kranzcli.Error{Code: "invalid_arguments", Message: fmt.Sprintf("unknown graph argument %q", args[index]), Hint: "Use `kranz graph [--format text|json|dot]`.", ExitCode: kranzcli.ExitUsage}
+			return graphFormatError(fmt.Sprintf("unknown graph argument %q", args[index]))
 		}
 	}
 	if options.Output == kranzcli.OutputJSON {
+		if formatSet && format != "json" {
+			return graphFormatError(fmt.Sprintf("--format=%s conflicts with --output=json", format))
+		}
 		format = "json"
 	}
 	cfg, _, err := loadProject(options)
@@ -570,8 +585,12 @@ func runGraph(options kranzcli.GlobalOptions, args []string, stdout io.Writer) e
 		}
 		return kranzcli.WriteJSON(stdout, nodes)
 	default:
-		return &kranzcli.Error{Code: "invalid_arguments", Message: fmt.Sprintf("unknown graph format %q", format), Hint: "Use text, json, or dot.", ExitCode: kranzcli.ExitUsage}
+		return graphFormatError(fmt.Sprintf("unknown graph format %q", format))
 	}
+}
+
+func graphFormatError(message string) error {
+	return &kranzcli.Error{Code: "invalid_graph_format", Message: message, Hint: "Use `kranz graph --format text|json|dot`; --output=json is compatible only with --format=json.", ExitCode: kranzcli.ExitUsage}
 }
 
 func runPorts(options kranzcli.GlobalOptions, args []string, stdout io.Writer) error {

--- a/cmd/kranz/inspect_commands.go
+++ b/cmd/kranz/inspect_commands.go
@@ -130,7 +130,10 @@ func runList(options kranzcli.GlobalOptions, args []string, stdout io.Writer) er
 	case "services":
 		return listServices(cfg, options, stdout)
 	case "actions":
-		return listActions(cfg, options, stdout)
+		// Keep the legacy `list actions` spelling as an exact alias of the
+		// canonical action command instead of maintaining two subtly different
+		// action tables and JSON contracts.
+		return runActionList(options, nil, stdout)
 	case "tags":
 		return listTags(cfg, options, stdout)
 	default:
@@ -168,35 +171,6 @@ func listServices(cfg *config.Config, options kranzcli.GlobalOptions, stdout io.
 			name += " (disabled)"
 		}
 		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", name, joinOrDash(item.Tags), joinOrDash(item.DependsOn), joinPortsOrDash(item.Ports), orDash(item.Description))
-	}
-	return w.Flush()
-}
-
-func listActions(cfg *config.Config, options kranzcli.GlobalOptions, stdout io.Writer) error {
-	type entry struct {
-		ID          string `json:"id"`
-		Owner       string `json:"owner"`
-		OwnerKind   string `json:"owner_kind"`
-		Name        string `json:"name"`
-		Description string `json:"description"`
-		Interactive bool   `json:"interactive"`
-	}
-	ids := cfg.ActionIDs()
-	entries := make([]entry, 0, len(ids))
-	for _, id := range ids {
-		action, ok := cfg.ResolveAction(id)
-		if !ok {
-			continue
-		}
-		entries = append(entries, entry{actionIDString(id), id.Owner, string(id.OwnerKind), id.Name, action.Description, action.Interactive != nil && *action.Interactive})
-	}
-	if options.Output == kranzcli.OutputJSON {
-		return kranzcli.WriteJSON(stdout, entries)
-	}
-	w := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintln(w, "ACTION\tOWNER\tINTERACTIVE\tDESCRIPTION")
-	for _, item := range entries {
-		_, _ = fmt.Fprintf(w, "%s\t%s\t%t\t%s\n", item.ID, item.Owner, item.Interactive, orDash(item.Description))
 	}
 	return w.Flush()
 }

--- a/cmd/kranz/inspect_commands.go
+++ b/cmd/kranz/inspect_commands.go
@@ -114,44 +114,34 @@ func runConfigCheck(options kranzcli.GlobalOptions, stdout io.Writer) error {
 	return nil
 }
 
-func runList(options kranzcli.GlobalOptions, args []string, stdout io.Writer) error {
-	formatter, args, err := extractRowFormat("list", options.Output, args)
+func runServices(options kranzcli.GlobalOptions, args []string, stdout io.Writer) error {
+	formatter, args, err := extractRowFormat("services", options.Output, args)
 	if err != nil {
 		return err
 	}
-	kind := "services"
-	if len(args) > 0 {
-		kind = args[0]
-	}
-	if len(args) > 1 {
-		return &kranzcli.Error{Code: "invalid_arguments", Message: "list accepts one of services, actions, or tags", ExitCode: kranzcli.ExitUsage}
+	if len(args) != 0 {
+		return &kranzcli.Error{Code: "invalid_arguments", Message: "services does not accept selectors", ExitCode: kranzcli.ExitUsage}
 	}
 	cfg, _, err := loadProject(options)
 	if err != nil {
 		return err
 	}
-	switch kind {
-	case "services":
-		return listServices(cfg, options, stdout, formatter)
-	case "actions":
-		// Keep the legacy `list actions` spelling as an exact alias of the
-		// canonical action command instead of maintaining two subtly different
-		// action tables and JSON contracts.
-		entries := actionListEntries(cfg, "")
-		if options.Output == kranzcli.OutputJSON {
-			return kranzcli.WriteJSON(stdout, entries)
-		}
-		return writeActionList(stdout, entries, formatter)
-	case "tags":
-		return listTags(cfg, options, stdout, formatter)
-	default:
-		return &kranzcli.Error{
-			Code:     "invalid_arguments",
-			Message:  fmt.Sprintf("unknown list kind %q", kind),
-			Hint:     "Use `kranz list services`, `kranz list actions`, or `kranz list tags`.",
-			ExitCode: kranzcli.ExitUsage,
-		}
+	return listServices(cfg, options, stdout, formatter)
+}
+
+func runTags(options kranzcli.GlobalOptions, args []string, stdout io.Writer) error {
+	formatter, args, err := extractRowFormat("tags", options.Output, args)
+	if err != nil {
+		return err
 	}
+	if len(args) != 0 {
+		return &kranzcli.Error{Code: "invalid_arguments", Message: "tags does not accept selectors", ExitCode: kranzcli.ExitUsage}
+	}
+	cfg, _, err := loadProject(options)
+	if err != nil {
+		return err
+	}
+	return listTags(cfg, options, stdout, formatter)
 }
 
 func listServices(cfg *config.Config, options kranzcli.GlobalOptions, stdout io.Writer, formatter *rowTemplate) error {
@@ -275,16 +265,24 @@ func orDash(value string) string {
 	return value
 }
 
-func runInfo(options kranzcli.GlobalOptions, args []string, stdout io.Writer) error {
-	if len(args) > 1 {
-		return &kranzcli.Error{Code: "invalid_arguments", Message: "info accepts at most one service", ExitCode: kranzcli.ExitUsage}
+func runProject(options kranzcli.GlobalOptions, args []string, stdout io.Writer) error {
+	if len(args) != 0 {
+		return &kranzcli.Error{Code: "invalid_arguments", Message: "project accepts no arguments", ExitCode: kranzcli.ExitUsage}
 	}
 	cfg, paths, err := loadProject(options)
 	if err != nil {
 		return err
 	}
-	if len(args) == 0 {
-		return projectInfo(cfg, paths, options, stdout)
+	return projectInfo(cfg, paths, options, stdout)
+}
+
+func runServiceInfo(options kranzcli.GlobalOptions, args []string, stdout io.Writer) error {
+	if len(args) != 1 {
+		return &kranzcli.Error{Code: "invalid_arguments", Message: "services info takes exactly one service", Hint: "Run `kranz services info SERVICE`.", ExitCode: kranzcli.ExitUsage}
+	}
+	cfg, _, err := loadProject(options)
+	if err != nil {
+		return err
 	}
 	name := args[0]
 	svc, ok := cfg.Services[name]
@@ -292,7 +290,7 @@ func runInfo(options kranzcli.GlobalOptions, args []string, stdout io.Writer) er
 		return &kranzcli.Error{
 			Code:     "service_not_found",
 			Message:  fmt.Sprintf("service %q was not found", name),
-			Hint:     "Run `kranz list services` to see what this project defines.",
+			Hint:     "Run `kranz services` to see what this project defines.",
 			ExitCode: kranzcli.ExitNotFound,
 		}
 	}
@@ -761,7 +759,7 @@ func detectedPortsByService(options kranzcli.GlobalOptions) map[string][]int {
 
 func runPortInspect(options kranzcli.GlobalOptions, args []string, stdout io.Writer) error {
 	if len(args) != 1 {
-		return &kranzcli.Error{Code: "invalid_arguments", Message: "port inspect takes exactly one port", Hint: "Run `kranz port inspect 8080`.", ExitCode: kranzcli.ExitUsage}
+		return &kranzcli.Error{Code: "invalid_arguments", Message: "ports inspect takes exactly one port", Hint: "Run `kranz ports inspect 8080`.", ExitCode: kranzcli.ExitUsage}
 	}
 	number, err := strconv.Atoi(args[0])
 	if err != nil || number < 1 || number > 65535 {

--- a/cmd/kranz/inspect_commands_test.go
+++ b/cmd/kranz/inspect_commands_test.go
@@ -56,10 +56,10 @@ func runInspection(t *testing.T, directory string, args ...string) string {
 	return stdout.String()
 }
 
-func TestListReportsServicesActionsAndTags(t *testing.T) {
+func TestCollectionCommandsReportServicesActionsAndTags(t *testing.T) {
 	directory := inspectionDirectory(t)
 
-	services := runInspection(t, directory, "list", "services")
+	services := runInspection(t, directory, "services")
 	for _, name := range []string{"db", "migrate", "api"} {
 		if !strings.Contains(services, name) {
 			t.Errorf("list services omits %q: %q", name, services)
@@ -71,10 +71,10 @@ func TestListReportsServicesActionsAndTags(t *testing.T) {
 		t.Errorf("list services lost declaration order: %q", services)
 	}
 
-	if actions := runInspection(t, directory, "list", "actions"); !strings.Contains(actions, "api/seed") {
+	if actions := runInspection(t, directory, "actions"); !strings.Contains(actions, "api/seed") {
 		t.Errorf("list actions omits the service action: %q", actions)
 	}
-	if tags := runInspection(t, directory, "list", "tags"); !strings.Contains(tags, "infra") || !strings.Contains(tags, "backend") {
+	if tags := runInspection(t, directory, "tags"); !strings.Contains(tags, "infra") || !strings.Contains(tags, "backend") {
 		t.Errorf("list tags is incomplete: %q", tags)
 	}
 }
@@ -85,9 +85,9 @@ func TestRowOrientedInspectionCommandsAcceptFormat(t *testing.T) {
 		args []string
 		want string
 	}{
-		{args: []string{"list", "services", "--format", "{{.Name}}"}, want: "api"},
-		{args: []string{"list", "actions", "--format", "{{.Action}}"}, want: "api/seed"},
-		{args: []string{"list", "tags", "--format", "{{.Tag}}"}, want: "backend"},
+		{args: []string{"services", "--format", "{{.Name}}"}, want: "api"},
+		{args: []string{"actions", "--format", "{{.Action}}"}, want: "api/seed"},
+		{args: []string{"tags", "--format", "{{.Tag}}"}, want: "backend"},
 		{args: []string{"ports", "db", "--format", "{{.Service}}:{{.Port}}"}, want: "db:65123"},
 		{args: []string{"doctor", "--format", "{{.Check}}:{{.Status}}"}, want: ":"},
 	} {
@@ -95,16 +95,6 @@ func TestRowOrientedInspectionCommandsAcceptFormat(t *testing.T) {
 		if !strings.Contains(output, test.want) {
 			t.Errorf("%v output = %q, want %q", test.args, output, test.want)
 		}
-	}
-}
-
-func TestListRejectsAnUnknownKind(t *testing.T) {
-	var stdout, stderr bytes.Buffer
-	if code := execute([]string{"-C", inspectionDirectory(t), "list", "widgets"}, &stdout, &stderr); code != kranzcli.ExitUsage {
-		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
-	}
-	if !strings.Contains(stderr.String(), "kranz list services") {
-		t.Errorf("rejection does not name the valid kinds: %q", stderr.String())
 	}
 }
 
@@ -191,14 +181,14 @@ func TestDoctorJSONKeepsAFailedPreflightToOneUsefulEnvelope(t *testing.T) {
 	}
 }
 
-func TestInfoDescribesProjectAndService(t *testing.T) {
+func TestProjectAndServiceInfoDescribeTheirEntities(t *testing.T) {
 	directory := inspectionDirectory(t)
 
-	if project := runInspection(t, directory, "info"); !strings.Contains(project, "Inspection") {
-		t.Errorf("info omits the project: %q", project)
+	if project := runInspection(t, directory, "project"); !strings.Contains(project, "Inspection") {
+		t.Errorf("project omits project details: %q", project)
 	}
 
-	service := runInspection(t, directory, "info", "migrate")
+	service := runInspection(t, directory, "services", "info", "migrate")
 	if !strings.Contains(service, "db") {
 		t.Errorf("info does not report the dependency: %q", service)
 	}
@@ -279,7 +269,7 @@ func TestDoctorFailsOnAMissingServiceDirectory(t *testing.T) {
 }
 
 func TestInspectionCommandsOutsideAProjectExplainThemselves(t *testing.T) {
-	for _, command := range [][]string{{"list"}, {"plan"}, {"graph"}, {"info"}, {"doctor"}, {"config", "check"}} {
+	for _, command := range [][]string{{"services"}, {"plan"}, {"graph"}, {"project"}, {"doctor"}, {"config", "check"}} {
 		var stdout, stderr bytes.Buffer
 		args := append([]string{"-C", t.TempDir()}, command...)
 		if code := execute(args, &stdout, &stderr); code != kranzcli.ExitUsage {
@@ -301,7 +291,7 @@ func withRuntimeSnapshots(t *testing.T, snapshots map[string]*app.ServiceSnapsho
 // What the file says is half of "tell me about this service". When a runtime is
 // up, the other half is what the service is doing right now, and info answered
 // only the first half while status held the rest.
-func TestInfoReportsLiveStateWhenARuntimeIsRunning(t *testing.T) {
+func TestServiceInfoReportsLiveStateWhenARuntimeIsRunning(t *testing.T) {
 	directory := inspectionDirectory(t)
 	withRuntimeSnapshots(t, map[string]*app.ServiceSnapshot{
 		"api": {
@@ -312,7 +302,7 @@ func TestInfoReportsLiveStateWhenARuntimeIsRunning(t *testing.T) {
 		},
 	})
 
-	output := runInspection(t, directory, "info", "api")
+	output := runInspection(t, directory, "services", "info", "api")
 	for _, want := range []string{"Right now", "running", "4242", "Health:    -", "65501"} {
 		if !strings.Contains(output, want) {
 			t.Errorf("info omits %q:\n%s", want, output)
@@ -383,10 +373,10 @@ func TestHealthLabelDistinguishesConfiguredProbesFromAssumedHealth(t *testing.T)
 
 // Without a runtime the command still describes the configuration, and must not
 // invent a state it cannot know.
-func TestInfoOmitsLiveStateWithoutARuntime(t *testing.T) {
+func TestServiceInfoOmitsLiveStateWithoutARuntime(t *testing.T) {
 	withRuntimeSnapshots(t, nil)
 
-	output := runInspection(t, inspectionDirectory(t), "info", "api")
+	output := runInspection(t, inspectionDirectory(t), "services", "info", "api")
 	if strings.Contains(output, "Right now") {
 		t.Errorf("info reported live state with no runtime:\n%s", output)
 	}
@@ -402,7 +392,7 @@ func TestListJSONUsesEmptyArraysNotNull(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(directory, "kranz.yaml"), []byte("project: Bare\nservices:\n  solo:\n    command: sleep 60\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	output := runInspection(t, directory, "list", "services", "--output", "json")
+	output := runInspection(t, directory, "services", "--output", "json")
 	if strings.Contains(output, "null") {
 		t.Errorf("list services JSON contains null:\n%s", output)
 	}

--- a/cmd/kranz/inspect_commands_test.go
+++ b/cmd/kranz/inspect_commands_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -235,6 +236,17 @@ func TestGraphRendersTextDotAndJSON(t *testing.T) {
 	}
 	if len(nodes) != 3 {
 		t.Errorf("json graph has %d nodes", len(nodes))
+	}
+}
+
+func TestGraphRejectsConflictingOutputFormats(t *testing.T) {
+	err := runGraph(kranzcli.GlobalOptions{Output: kranzcli.OutputJSON}, []string{"--format=dot"}, &bytes.Buffer{})
+	var commandErr *kranzcli.Error
+	if !errors.As(err, &commandErr) || commandErr.Code != "invalid_graph_format" {
+		t.Fatalf("runGraph error = %#v", err)
+	}
+	if err := runGraph(kranzcli.GlobalOptions{}, []string{"--format", "dot", "--format", "text"}, &bytes.Buffer{}); err == nil {
+		t.Fatal("duplicate graph format unexpectedly succeeded")
 	}
 }
 

--- a/cmd/kranz/inspect_commands_test.go
+++ b/cmd/kranz/inspect_commands_test.go
@@ -76,6 +76,25 @@ func TestListReportsServicesActionsAndTags(t *testing.T) {
 	}
 }
 
+func TestRowOrientedInspectionCommandsAcceptFormat(t *testing.T) {
+	directory := inspectionDirectory(t)
+	for _, test := range []struct {
+		args []string
+		want string
+	}{
+		{args: []string{"list", "services", "--format", "{{.Name}}"}, want: "api"},
+		{args: []string{"list", "actions", "--format", "{{.Action}}"}, want: "api/seed"},
+		{args: []string{"list", "tags", "--format", "{{.Tag}}"}, want: "backend"},
+		{args: []string{"ports", "db", "--format", "{{.Service}}:{{.Port}}"}, want: "db:65123"},
+		{args: []string{"doctor", "--format", "{{.Check}}:{{.Status}}"}, want: ":"},
+	} {
+		output := runInspection(t, directory, test.args...)
+		if !strings.Contains(output, test.want) {
+			t.Errorf("%v output = %q, want %q", test.args, output, test.want)
+		}
+	}
+}
+
 func TestListRejectsAnUnknownKind(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	if code := execute([]string{"-C", inspectionDirectory(t), "list", "widgets"}, &stdout, &stderr); code != kranzcli.ExitUsage {

--- a/cmd/kranz/inspect_commands_test.go
+++ b/cmd/kranz/inspect_commands_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -123,6 +125,37 @@ func TestPlanGroupsWavesAndIncludesDependencies(t *testing.T) {
 		if !strings.Contains(selected, name) {
 			t.Errorf("plan api omits its dependency %q: %q", name, selected)
 		}
+	}
+}
+
+func TestPlanPreviewsStopAndRestartImpact(t *testing.T) {
+	options, name := writeMCPProjectWithService(t, "db")
+	document := fmt.Sprintf("project: %s\nservices:\n  db:\n    command: sleep 60\n  migrate:\n    command: sleep 60\n    depends_on: [db]\n  api:\n    command: sleep 60\n    depends_on: [migrate]\n", name)
+	if err := os.WriteFile(filepath.Join(options.Directory, "kranz.yaml"), []byte(document), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	startTestRuntime(t, options, name)
+	if err := runLifecycle(options, "start", []string{"api"}, io.Discard); err != nil {
+		t.Fatalf("start dependency chain: %v", err)
+	}
+	for _, operation := range []string{"stop", "restart"} {
+		output := runInspection(t, options.Directory, "plan", "db", "--operation", operation)
+		for _, service := range []string{"db", "migrate", "api"} {
+			if !strings.Contains(output, service) {
+				t.Errorf("%s plan omits affected service %q: %q", operation, service, output)
+			}
+		}
+	}
+	var stdout, stderr bytes.Buffer
+	if code := execute([]string{"-C", t.TempDir(), "-p", name, "plan", "db", "--operation", "stop"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("runtime-addressed plan outside project exit=%d stderr=%q", code, stderr.String())
+	}
+}
+
+func TestPlanRejectsUnknownOperation(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if code := execute([]string{"-C", inspectionDirectory(t), "plan", "--operation", "deploy"}, &stdout, &stderr); code != kranzcli.ExitUsage {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
 	}
 }
 

--- a/cmd/kranz/main.go
+++ b/cmd/kranz/main.go
@@ -105,7 +105,7 @@ func execute(args []string, stdout, stderr io.Writer) int {
 		}
 		return 0
 	case "doctor":
-		if err := runDoctor(invocation.Globals, stdout); err != nil {
+		if err := runDoctor(invocation.Globals, invocation.Args, stdout); err != nil {
 			var requested requestedExitError
 			if errors.As(err, &requested) {
 				return requested.code

--- a/cmd/kranz/main.go
+++ b/cmd/kranz/main.go
@@ -49,15 +49,15 @@ func execute(args []string, stdout, stderr io.Writer) int {
 		}
 		return 0
 	}
-	// A command whose grammar is reserved but whose execution a later feature
-	// stream still has to attach is refused from the tree itself, so help and
+	// A command whose grammar is reserved but whose execution a future change
+	// still has to attach is refused from the tree itself, so help and
 	// dispatch can never disagree about what this build supports.
 	if len(invocation.CommandPath) > 0 {
 		if command, resolveErr := tree.Resolve(invocation.CommandPath); resolveErr == nil && command.IsPlanned() {
 			err := &kranzcli.Error{
 				Code:     "not_implemented",
 				Message:  fmt.Sprintf("command %q is not implemented yet", invocation.Command()),
-				Hint:     "It is planned for v0.8.0. Run `kranz --help` for the commands this build supports.",
+				Hint:     "It is planned for a future release. Run `kranz --help` for the commands this build supports.",
 				ExitCode: kranzcli.ExitUsage,
 			}
 			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)

--- a/cmd/kranz/main.go
+++ b/cmd/kranz/main.go
@@ -133,6 +133,11 @@ func execute(args []string, stdout, stderr io.Writer) int {
 			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
 		}
 		return 0
+	case "runs retention":
+		if err := runRunsRetention(invocation.Globals, invocation.Args, stdout); err != nil {
+			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
+		}
+		return 0
 	case "runs delete":
 		if err := runRunsDelete(invocation.Globals, invocation.Args, stdout); err != nil {
 			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)

--- a/cmd/kranz/main.go
+++ b/cmd/kranz/main.go
@@ -202,16 +202,10 @@ func execute(args []string, stdout, stderr io.Writer) int {
 	}
 
 	if invocation.Command() == "ps" {
-		if len(invocation.Args) != 0 {
-			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, &kranzcli.Error{Code: "invalid_arguments", Message: "ps does not accept arguments", ExitCode: kranzcli.ExitUsage})
-		}
-		return runPS(invocation.Globals, stdout, stderr)
+		return runPS(invocation.Globals, invocation.Args, stdout, stderr)
 	}
 	if invocation.Command() == "clients" {
-		if len(invocation.Args) != 0 {
-			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, &kranzcli.Error{Code: "invalid_arguments", Message: "clients does not accept arguments", ExitCode: kranzcli.ExitUsage})
-		}
-		return runClients(invocation.Globals, stdout, stderr)
+		return runClients(invocation.Globals, invocation.Args, stdout, stderr)
 	}
 	if invocation.Command() == "up" {
 		if err := runUp(invocation.Globals, invocation.Args, stdout); err != nil {
@@ -292,7 +286,11 @@ func containsMCPCommand(args []string) bool {
 	return false
 }
 
-func runPS(options kranzcli.GlobalOptions, stdout, stderr io.Writer) int {
+func runPS(options kranzcli.GlobalOptions, args []string, stdout, stderr io.Writer) int {
+	formatter, err := parseRowFormat("ps", options.Output, args)
+	if err != nil {
+		return kranzcli.WriteError(stdout, stderr, options.Output, err)
+	}
 	registry, err := kranzruntime.DefaultRegistry()
 	if err != nil {
 		return kranzcli.WriteError(stdout, stderr, options.Output, err)
@@ -318,11 +316,21 @@ func runPS(options kranzcli.GlobalOptions, stdout, stderr io.Writer) int {
 		}
 		return 0
 	}
+	if formatter != nil {
+		rows := make([]map[string]any, 0, len(records))
+		for _, record := range records {
+			rows = append(rows, psFormatRow(record))
+		}
+		if err := formatter.write(stdout, psFormatHeaders(), rows); err != nil {
+			return kranzcli.WriteError(stdout, stderr, options.Output, err)
+		}
+		return 0
+	}
 	w := tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
 	// MODE is gone: with the MCP adapter no longer a registry entry, the only
 	// values left describe how a runtime was launched, not what it is. CLIENTS
 	// answers the question the row could not: who is working in this project.
-	_, _ = fmt.Fprintln(w, "ID\tNAME\tPROJECT\tSERVICES\tCLIENTS\tSTATE\tUPTIME")
+	_, _ = fmt.Fprintln(w, "ID\tPID\tNAME\tPROJECT\tSERVICES\tCLIENTS\tSTATE\tUPTIME")
 	for _, record := range records {
 		// A bare total says nothing about whether the project is actually up.
 		// An unreachable runtime reports "-" rather than a count it cannot know.
@@ -338,12 +346,39 @@ func runPS(options kranzcli.GlobalOptions, stdout, stderr io.Writer) int {
 		if len(id) > 8 {
 			id = id[:8]
 		}
-		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", id, record.Name, record.Project, services, clients, record.State, shortDuration(time.Since(record.StartedAt)))
+		_, _ = fmt.Fprintf(w, "%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\n", id, record.PID, record.Name, record.Project, services, clients, record.State, shortDuration(time.Since(record.StartedAt)))
 	}
 	if err := w.Flush(); err != nil {
 		return kranzcli.WriteError(stdout, stderr, options.Output, err)
 	}
 	return 0
+}
+
+func psFormatHeaders() map[string]any {
+	return map[string]any{
+		"ID": "ID", "FullID": "FULL ID", "PID": "PID", "Name": "NAME", "Project": "PROJECT",
+		"Services": "SERVICES", "Clients": "CLIENTS", "State": "STATE",
+		"Uptime": "UPTIME", "Directory": "DIRECTORY", "Mode": "MODE",
+		"Version": "VERSION", "StartedAt": "STARTED AT",
+	}
+}
+
+func psFormatRow(record kranzruntime.SessionRecord) map[string]any {
+	services := "-"
+	if record.Services != nil && record.Running != nil {
+		services = fmt.Sprintf("%d/%d", *record.Running, *record.Services)
+	}
+	clients := "-"
+	if record.Clients != nil {
+		clients = strconv.Itoa(*record.Clients)
+	}
+	return map[string]any{
+		"ID": shortID(record.ID), "FullID": record.ID, "PID": record.PID, "Name": record.Name,
+		"Project": record.Project, "Services": services, "Clients": clients,
+		"State": string(record.State), "Uptime": shortDuration(time.Since(record.StartedAt)),
+		"Directory": record.Directory, "Mode": record.Mode, "Version": record.KranzVersion,
+		"StartedAt": record.StartedAt.Format(time.RFC3339),
+	}
 }
 
 // shortDuration renders an age the way a person reads one: the largest unit

--- a/cmd/kranz/main.go
+++ b/cmd/kranz/main.go
@@ -292,44 +292,54 @@ func containsMCPCommand(args []string) bool {
 }
 
 func runPS(options kranzcli.GlobalOptions, args []string, stdout, stderr io.Writer) int {
-	formatter, err := parseRowFormat("ps", options.Output, args)
+	query, err := parseWatchQuery("ps", options.Output, args, "name", "project", "state", "client")
 	if err != nil {
 		return kranzcli.WriteError(stdout, stderr, options.Output, err)
+	}
+	if len(query.args) > 0 {
+		return kranzcli.WriteError(stdout, stderr, options.Output, watchUsageError("ps", fmt.Sprintf("unexpected argument %q", query.args[0])))
 	}
 	registry, err := kranzruntime.DefaultRegistry()
 	if err != nil {
 		return kranzcli.WriteError(stdout, stderr, options.Output, err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	records, err := registry.List(ctx, version)
+	err = runWatch(query, stdout, func() error {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		records, listErr := registry.List(ctx, version)
+		if listErr != nil {
+			return listErr
+		}
+		filtered := records[:0]
+		for _, record := range records {
+			if options.Project != "" && !matchesRuntimeReference(record, options.Project) {
+				continue
+			}
+			if !matchesWatchFilters(query.filters, map[string][]string{
+				"name": {record.Name}, "project": {record.Project}, "state": {string(record.State)}, "client": record.ClientSurfaces,
+			}) {
+				continue
+			}
+			filtered = append(filtered, record)
+		}
+		return writePS(options.Output, query.formatter, filtered, stdout)
+	})
 	if err != nil {
 		return kranzcli.WriteError(stdout, stderr, options.Output, err)
 	}
-	if options.Project != "" {
-		filtered := records[:0]
-		for _, record := range records {
-			if record.Name == options.Project || record.ID == options.Project || strings.HasPrefix(record.ID, options.Project) {
-				filtered = append(filtered, record)
-			}
-		}
-		records = filtered
-	}
-	if options.Output == kranzcli.OutputJSON {
-		if err := kranzcli.WriteJSON(stdout, records); err != nil {
-			return kranzcli.WriteError(stdout, stderr, options.Output, err)
-		}
-		return 0
+	return 0
+}
+
+func writePS(output kranzcli.OutputFormat, formatter *rowTemplate, records []kranzruntime.SessionRecord, stdout io.Writer) error {
+	if output == kranzcli.OutputJSON {
+		return kranzcli.WriteJSON(stdout, records)
 	}
 	if formatter != nil {
 		rows := make([]map[string]any, 0, len(records))
 		for _, record := range records {
 			rows = append(rows, psFormatRow(record))
 		}
-		if err := formatter.write(stdout, psFormatHeaders(), rows); err != nil {
-			return kranzcli.WriteError(stdout, stderr, options.Output, err)
-		}
-		return 0
+		return formatter.write(stdout, psFormatHeaders(), rows)
 	}
 	w := tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
 	// MODE is gone: with the MCP adapter no longer a registry entry, the only
@@ -354,9 +364,9 @@ func runPS(options kranzcli.GlobalOptions, args []string, stdout, stderr io.Writ
 		_, _ = fmt.Fprintf(w, "%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\n", id, record.PID, record.Name, record.Project, services, clients, record.State, shortDuration(time.Since(record.StartedAt)))
 	}
 	if err := w.Flush(); err != nil {
-		return kranzcli.WriteError(stdout, stderr, options.Output, err)
+		return err
 	}
-	return 0
+	return nil
 }
 
 func psFormatHeaders() map[string]any {

--- a/cmd/kranz/main.go
+++ b/cmd/kranz/main.go
@@ -37,6 +37,9 @@ func execute(args []string, stdout, stderr io.Writer) int {
 	}
 
 	if invocation.Help {
+		if invocation.Globals.Output == kranzcli.OutputJSON {
+			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, textOnlyOutputError("help"))
+		}
 		output, helpErr := kranzcli.Help(tree, invocation.CommandPath)
 		if helpErr != nil {
 			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, helpErr)
@@ -164,6 +167,9 @@ func execute(args []string, stdout, stderr io.Writer) int {
 		}
 		return 0
 	case "completion":
+		if invocation.Globals.Output == kranzcli.OutputJSON {
+			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, textOnlyOutputError("completion"))
+		}
 		if len(invocation.Args) != 1 {
 			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, &kranzcli.Error{
 				Code:     "invalid_arguments",
@@ -280,6 +286,15 @@ func execute(args []string, stdout, stderr io.Writer) int {
 		return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
 	}
 	return 0
+}
+
+func textOnlyOutputError(command string) error {
+	return &kranzcli.Error{
+		Code:     "unsupported_output",
+		Message:  fmt.Sprintf("%s produces text and does not support --output=json", command),
+		Hint:     fmt.Sprintf("Run `kranz %s` without --output=json.", command),
+		ExitCode: kranzcli.ExitUsage,
+	}
 }
 
 func containsMCPCommand(args []string) bool {

--- a/cmd/kranz/main.go
+++ b/cmd/kranz/main.go
@@ -63,21 +63,15 @@ func execute(args []string, stdout, stderr io.Writer) int {
 			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
 		}
 	}
-
 	if invocation.Command() == "version" {
 		return writeVersion(stdout, stderr, invocation.Globals.Output)
 	}
 	if invocation.Command() == "mcp" {
-		attachOnly := false
 		for _, arg := range invocation.Args {
-			if arg == "--attach-only" {
-				attachOnly = true
-				continue
-			}
 			_, _ = fmt.Fprintf(stderr, "Kranz MCP: unknown mcp option or argument %q\n", arg)
 			return kranzcli.ExitUsage
 		}
-		if err := runMCP(invocation.Globals, attachOnly, stdout, stderr); err != nil {
+		if err := runMCP(invocation.Globals, stdout, stderr); err != nil {
 			_, _ = fmt.Fprintf(stderr, "Kranz MCP: %v\n", err)
 			return 1
 		}
@@ -116,13 +110,23 @@ func execute(args []string, stdout, stderr io.Writer) int {
 			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
 		}
 		return 0
-	case "list":
-		if err := runList(invocation.Globals, invocation.Args, stdout); err != nil {
+	case "services list":
+		if err := runServices(invocation.Globals, invocation.Args, stdout); err != nil {
 			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
 		}
 		return 0
-	case "info":
-		if err := runInfo(invocation.Globals, invocation.Args, stdout); err != nil {
+	case "tags":
+		if err := runTags(invocation.Globals, invocation.Args, stdout); err != nil {
+			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
+		}
+		return 0
+	case "services info":
+		if err := runServiceInfo(invocation.Globals, invocation.Args, stdout); err != nil {
+			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
+		}
+		return 0
+	case "project":
+		if err := runProject(invocation.Globals, invocation.Args, stdout); err != nil {
 			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
 		}
 		return 0
@@ -151,7 +155,7 @@ func execute(args []string, stdout, stderr io.Writer) int {
 			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
 		}
 		return 0
-	case "ports":
+	case "ports list":
 		if err := runPorts(invocation.Globals, invocation.Args, stdout); err != nil {
 			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
 		}
@@ -186,17 +190,17 @@ func execute(args []string, stdout, stderr io.Writer) int {
 			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
 		}
 		return 0
-	case "action list":
+	case "actions list":
 		if err := runActionList(invocation.Globals, invocation.Args, stdout); err != nil {
 			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
 		}
 		return 0
-	case "action info":
+	case "actions info":
 		if err := runActionInfo(invocation.Globals, invocation.Args, stdout); err != nil {
 			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
 		}
 		return 0
-	case "action run":
+	case "actions run":
 		if err := runActionRun(invocation.Globals, invocation.Args, stdout); err != nil {
 			var requested requestedExitError
 			if errors.As(err, &requested) {
@@ -205,7 +209,7 @@ func execute(args []string, stdout, stderr io.Writer) int {
 			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
 		}
 		return 0
-	case "port inspect":
+	case "ports inspect":
 		if err := runPortInspect(invocation.Globals, invocation.Args, stdout); err != nil {
 			return kranzcli.WriteError(stdout, stderr, invocation.Globals.Output, err)
 		}
@@ -515,7 +519,7 @@ func makeRestartRuntime(base kranzcli.GlobalOptions) func(directory string, conf
 		options.ConfigPaths = configPaths
 		options.Project = ""
 		options.Output = kranzcli.OutputText
-		return spawnBackground(options, nil, true, io.Discard)
+		return spawnBackground(options, nil, false, io.Discard)
 	}
 }
 
@@ -542,7 +546,7 @@ func resolveOrStartDashboardRuntime(options kranzcli.GlobalOptions, cfgPaths []s
 	backgroundOptions.Directory = directory
 	backgroundOptions.ConfigPaths = cfgPaths
 	backgroundOptions.Output = kranzcli.OutputText
-	if err := spawnBackground(backgroundOptions, nil, true, io.Discard); err != nil {
+	if err := spawnBackground(backgroundOptions, nil, false, io.Discard); err != nil {
 		return kranzruntime.SessionRecord{}, classifyRuntimeError(err)
 	}
 	record, err = resolve()

--- a/cmd/kranz/main_test.go
+++ b/cmd/kranz/main_test.go
@@ -81,7 +81,7 @@ func TestEnvironmentCoordinatesReachInspectionCommands(t *testing.T) {
 	t.Setenv("KRANZ_CONFIG", configPath)
 
 	var stdout, stderr bytes.Buffer
-	if code := execute([]string{"list", "services", "--output=json"}, &stdout, &stderr); code != 0 {
+	if code := execute([]string{"services", "--output=json"}, &stdout, &stderr); code != 0 {
 		t.Fatalf("exit=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
 	services := decodeJSONData[[]struct {
@@ -103,7 +103,11 @@ func TestForegroundHelperProcess(t *testing.T) {
 		command.Env = append(os.Environ(), "KRANZ_TEST_BACKGROUND_HELPER=1", "KRANZ_TEST_BACKGROUND_ARGS="+base64.StdEncoding.EncodeToString(data))
 		return command
 	}
-	os.Exit(execute([]string{"-C", directory, "up", "--no-start"}, os.Stdout, os.Stderr))
+	args := []string{"-C", directory, "up"}
+	if os.Getenv("KRANZ_TEST_FOREGROUND_START_ALL") == "1" {
+		args = append(args, "--start")
+	}
+	os.Exit(execute(args, os.Stdout, os.Stderr))
 }
 
 func TestBackgroundHelperProcess(t *testing.T) {
@@ -119,6 +123,69 @@ func TestBackgroundHelperProcess(t *testing.T) {
 		t.Fatal(err)
 	}
 	os.Exit(execute(args, os.Stdout, os.Stderr))
+}
+
+func TestUpRejectsConflictingStartModes(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	args := []string{"up", "--start", "web"}
+	if code := execute(args, &stdout, &stderr); code != kranzcli.ExitUsage {
+		t.Fatalf("execute(%q) exit = %d, stdout = %q, stderr = %q", args, code, stdout.String(), stderr.String())
+	}
+	if stdout.Len() != 0 || !strings.Contains(stderr.String(), "cannot be combined") {
+		t.Fatalf("execute(%q) stdout/stderr = %q/%q", args, stdout.String(), stderr.String())
+	}
+}
+
+func TestUpRejectsRemovedNoStartAsUnknownOption(t *testing.T) {
+	err := runUp(kranzcli.GlobalOptions{}, []string{"--no-start"}, io.Discard)
+	var commandErr *kranzcli.Error
+	if !errors.As(err, &commandErr) || commandErr.Code != "unknown_option" {
+		t.Fatalf("runUp error = %#v", err)
+	}
+}
+
+func TestUpStartAllStartsOnlyEnabledServices(t *testing.T) {
+	directory := t.TempDir()
+	name := fmt.Sprintf("test-up-start-%d", os.Getpid())
+	configText := fmt.Sprintf("project: Test Up Start\nruntime:\n  name: %s\nservices:\n  worker:\n    command: sleep 60\n  disabled:\n    command: sleep 60\n    disabled: true\n", name)
+	if err := os.WriteFile(filepath.Join(directory, "kranz.yaml"), []byte(configText), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	useHelperBackgroundRuntimes(t)
+	var stdout, stderr bytes.Buffer
+	if code := execute([]string{"-C", directory, "up", "-d", "--start"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("up exit=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	t.Cleanup(func() { _ = execute([]string{"-p", name, "down"}, io.Discard, io.Discard) })
+	stdout.Reset()
+	stderr.Reset()
+	if code := execute([]string{"-p", name, "status", "--format", "{{.Name}}:{{.PID}}"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("status exit=%d stderr=%q", code, stderr.String())
+	}
+	lines := stdout.String()
+	if strings.Contains(lines, "worker:-") {
+		t.Fatalf("enabled service did not start: %q", lines)
+	}
+	if !strings.Contains(lines, "disabled:-") {
+		t.Fatalf("disabled service started: %q", lines)
+	}
+}
+
+func TestRemovedCLIGrammarIsRejected(t *testing.T) {
+	for _, args := range [][]string{
+		{"list"}, {"list", "actions"}, {"list", "tags"},
+		{"action"}, {"action", "list"}, {"action", "info", "api/check"},
+		{"info"}, {"info", "api"}, {"port"}, {"port", "inspect", "8080"},
+		{"up", "--no-start"}, {"mcp", "--attach-only"},
+	} {
+		var stdout, stderr bytes.Buffer
+		if code := execute(args, &stdout, &stderr); code != kranzcli.ExitUsage {
+			t.Errorf("execute(%q) exit = %d, stdout = %q, stderr = %q", args, code, stdout.String(), stderr.String())
+		}
+		if stdout.Len() != 0 || !strings.Contains(stderr.String(), "unknown") {
+			t.Errorf("execute(%q) stdout/stderr = %q/%q", args, stdout.String(), stderr.String())
+		}
+	}
 }
 
 func TestBackgroundRuntimeReadinessConflictAndDown(t *testing.T) {
@@ -137,7 +204,7 @@ func TestBackgroundRuntimeReadinessConflictAndDown(t *testing.T) {
 	}
 	defer func() { newBackgroundCommand = previousFactory }()
 	var stdout, stderr bytes.Buffer
-	if code := execute([]string{"-C", directory, "--output=json", "up", "-d", "--no-start"}, &stdout, &stderr); code != 0 {
+	if code := execute([]string{"-C", directory, "--output=json", "up", "-d"}, &stdout, &stderr); code != 0 {
 		t.Fatalf("up -d exit=%d stderr=%s", code, stderr.String())
 	}
 	started := decodeJSONData[backgroundStartResult](t, stdout.Bytes())
@@ -146,7 +213,7 @@ func TestBackgroundRuntimeReadinessConflictAndDown(t *testing.T) {
 	}
 	stdout.Reset()
 	stderr.Reset()
-	if code := execute([]string{"-C", directory, "up", "-d", "--no-start"}, &stdout, &stderr); code != kranzcli.ExitConflict {
+	if code := execute([]string{"-C", directory, "up", "-d"}, &stdout, &stderr); code != kranzcli.ExitConflict {
 		t.Fatalf("duplicate exit=%d stderr=%s", code, stderr.String())
 	}
 	stdout.Reset()
@@ -184,7 +251,7 @@ func TestBackgroundRuntimeReadinessConflictAndDown(t *testing.T) {
 	}
 	stdout.Reset()
 	stderr.Reset()
-	if code := execute([]string{"-p", name, "--output=json", "action", "run", "sleeper/ping"}, &stdout, &stderr); code != 0 {
+	if code := execute([]string{"-p", name, "--output=json", "actions", "run", "sleeper/ping"}, &stdout, &stderr); code != 0 {
 		t.Fatalf("action run exit=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
 	action := decodeJSONData[struct {
@@ -380,7 +447,7 @@ func TestLogsSnapshotFollowAndClientInterrupt(t *testing.T) {
 	}
 	defer func() { newBackgroundCommand = previousFactory }()
 	var stdout, stderr bytes.Buffer
-	if code := execute([]string{"-C", directory, "up", "-d", "--no-start"}, &stdout, &stderr); code != 0 {
+	if code := execute([]string{"-C", directory, "up", "-d"}, &stdout, &stderr); code != 0 {
 		t.Fatalf("up -d exit=%d stderr=%s", code, stderr.String())
 	}
 	t.Cleanup(func() { _ = execute([]string{"-p", name, "down"}, io.Discard, io.Discard) })
@@ -618,12 +685,30 @@ func TestForegroundSignalsPreserveSignalDeath(t *testing.T) {
 	}
 }
 
+func TestForegroundStartAllPreservesProjectExitCode(t *testing.T) {
+	directory := t.TempDir()
+	name := fmt.Sprintf("test-exit-code-%d", os.Getpid())
+	configText := fmt.Sprintf("project: Test Exit Code\nruntime:\n  name: %s\nservices:\n  job:\n    command: exit 7\n    availability:\n      exit_on_end: true\n", name)
+	if err := os.WriteFile(filepath.Join(directory, "kranz.yaml"), []byte(configText), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	command := exec.Command(os.Args[0], "-test.run=^TestForegroundHelperProcess$")
+	command.Env = append(os.Environ(), "KRANZ_TEST_FOREGROUND_HELPER=1", "KRANZ_TEST_FOREGROUND_START_ALL=1", "KRANZ_TEST_PROJECT_DIR="+directory)
+	var stderr bytes.Buffer
+	command.Stdout, command.Stderr = io.Discard, &stderr
+	if err := command.Run(); err == nil {
+		t.Fatal("foreground up --start exited successfully, want project exit code 7")
+	} else if exitErr, ok := err.(*exec.ExitError); !ok || exitErr.ExitCode() != 7 {
+		t.Fatalf("foreground exit = %v, stderr = %q", err, stderr.String())
+	}
+}
+
 func TestHelpUsesCommandTree(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	if code := execute([]string{"help", "action"}, &stdout, &stderr); code != 0 {
+	if code := execute([]string{"help", "actions"}, &stdout, &stderr); code != 0 {
 		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
 	}
-	for _, expected := range []string{"action", "list", "info", "run", "--project VALUE"} {
+	for _, expected := range []string{"actions", "list", "info", "run", "--project VALUE"} {
 		if !strings.Contains(stdout.String(), expected) {
 			t.Errorf("help missing %q:\n%s", expected, stdout.String())
 		}
@@ -725,7 +810,7 @@ func TestLifecycleResolvesRuntimeFromDirectory(t *testing.T) {
 	defer func() { newBackgroundCommand = previousFactory }()
 
 	var stdout, stderr bytes.Buffer
-	if code := execute([]string{"-C", directory, "up", "-d", "--no-start"}, &stdout, &stderr); code != 0 {
+	if code := execute([]string{"-C", directory, "up", "-d"}, &stdout, &stderr); code != 0 {
 		t.Fatalf("up -d exit=%d stderr=%s", code, stderr.String())
 	}
 	defer func() {

--- a/cmd/kranz/main_test.go
+++ b/cmd/kranz/main_test.go
@@ -630,6 +630,26 @@ func TestHelpUsesCommandTree(t *testing.T) {
 	}
 }
 
+func TestTextArtifactsRejectJSONOutputCleanly(t *testing.T) {
+	for _, args := range [][]string{{"--output=json", "--help"}, {"completion", "bash", "--output=json"}} {
+		var stdout, stderr bytes.Buffer
+		if code := execute(args, &stdout, &stderr); code != kranzcli.ExitUsage {
+			t.Fatalf("execute(%q) exit = %d", args, code)
+		}
+		if stderr.Len() != 0 || !json.Valid(stdout.Bytes()) {
+			t.Fatalf("execute(%q) stdout/stderr = %q/%q", args, stdout.String(), stderr.String())
+		}
+		var envelope struct {
+			Error struct {
+				Code string `json:"code"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil || envelope.Error.Code != "unsupported_output" {
+			t.Fatalf("execute(%q) envelope = %#v, err=%v", args, envelope, err)
+		}
+	}
+}
+
 func TestMCPHelpAcceptsGlobalOptionsBeforeAndAfterCommand(t *testing.T) {
 	for _, args := range [][]string{
 		{"-C", "/tmp/project", "mcp", "--help"},

--- a/cmd/kranz/main_test.go
+++ b/cmd/kranz/main_test.go
@@ -167,6 +167,14 @@ func TestBackgroundRuntimeReadinessConflictAndDown(t *testing.T) {
 	}
 	stdout.Reset()
 	stderr.Reset()
+	if code := execute([]string{"-p", name, "status", "--format", "{{.Name}}:{{.PID}}"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("formatted status exit=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "sleeper:-") {
+		t.Fatalf("formatted status = %q", stdout.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
 	if code := execute([]string{"-p", name, "--output=json", "start", "workers"}, &stdout, &stderr); code != 0 {
 		t.Fatalf("start tag exit=%d stderr=%s", code, stderr.String())
 	}

--- a/cmd/kranz/mcp.go
+++ b/cmd/kranz/mcp.go
@@ -24,9 +24,16 @@ func runMCP(options kranzcli.GlobalOptions, attachOnly bool, stdout, stderr io.W
 	if options.Output != kranzcli.OutputText {
 		return errors.New("--output is not valid for MCP stdio; stdout is reserved for JSON-RPC framing")
 	}
+	warnDeprecatedMCPOptions(attachOnly, stderr)
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 	return runMCPContextOptions(ctx, options, attachOnly, mcpStdin, stdout, stderr)
+}
+
+func warnDeprecatedMCPOptions(attachOnly bool, stderr io.Writer) {
+	if attachOnly {
+		_, _ = io.WriteString(stderr, "Kranz MCP: warning: --attach-only is deprecated, has no effect, and will be removed in a future major release\n")
+	}
 }
 
 func runMCPContext(ctx context.Context, options kranzcli.GlobalOptions, stdin io.Reader, stdout, stderr io.Writer) error {
@@ -38,7 +45,8 @@ func runMCPContext(ctx context.Context, options kranzcli.GlobalOptions, stdin io
 // of runtimes, and which runtime answers is decided per call.
 func runMCPContextOptions(ctx context.Context, options kranzcli.GlobalOptions, attachOnly bool, stdin io.Reader, stdout, stderr io.Writer) error {
 	// --attach-only described the old owner fallback, which no longer exists.
-	// Accepting it silently keeps existing registrations working.
+	// runMCP warns interactive callers while this lower testable seam preserves
+	// old registrations until the next major release.
 	_ = attachOnly
 	resolver, err := newMCPResolver(options)
 	if err != nil {

--- a/cmd/kranz/mcp.go
+++ b/cmd/kranz/mcp.go
@@ -20,34 +20,19 @@ var mcpStdin io.Reader = os.Stdin
 // runMCP starts the stdio adapter. It needs no project: a Kranz configuration
 // in the working directory becomes the default address for calls that name no
 // runtime, and its absence is not an error.
-func runMCP(options kranzcli.GlobalOptions, attachOnly bool, stdout, stderr io.Writer) error {
+func runMCP(options kranzcli.GlobalOptions, stdout, stderr io.Writer) error {
 	if options.Output != kranzcli.OutputText {
 		return errors.New("--output is not valid for MCP stdio; stdout is reserved for JSON-RPC framing")
 	}
-	warnDeprecatedMCPOptions(attachOnly, stderr)
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
-	return runMCPContextOptions(ctx, options, attachOnly, mcpStdin, stdout, stderr)
-}
-
-func warnDeprecatedMCPOptions(attachOnly bool, stderr io.Writer) {
-	if attachOnly {
-		_, _ = io.WriteString(stderr, "Kranz MCP: warning: --attach-only is deprecated, has no effect, and will be removed in a future major release\n")
-	}
+	return runMCPContext(ctx, options, mcpStdin, stdout, stderr)
 }
 
 func runMCPContext(ctx context.Context, options kranzcli.GlobalOptions, stdin io.Reader, stdout, stderr io.Writer) error {
-	return runMCPContextOptions(ctx, options, false, stdin, stdout, stderr)
-}
-
-// runMCPContextOptions serves MCP over stdio without owning anything. The
-// process writes no registry entry and supervises no project: it is a client
-// of runtimes, and which runtime answers is decided per call.
-func runMCPContextOptions(ctx context.Context, options kranzcli.GlobalOptions, attachOnly bool, stdin io.Reader, stdout, stderr io.Writer) error {
-	// --attach-only described the old owner fallback, which no longer exists.
-	// runMCP warns interactive callers while this lower testable seam preserves
-	// old registrations until the next major release.
-	_ = attachOnly
+	// runMCPContext serves MCP over stdio without owning anything. The
+	// process writes no registry entry and supervises no project: it is a client
+	// of runtimes, and which runtime answers is decided per call.
 	resolver, err := newMCPResolver(options)
 	if err != nil {
 		return err
@@ -122,7 +107,7 @@ func mcpClientLabel() string {
 	return "Kranz MCP"
 }
 
-// launchDetachedRuntime starts a runtime the same way `kranz up -d --no-start`
+// launchDetachedRuntime starts a runtime the same way `kranz up -d`
 // does, in its own process. The MCP process must not host a supervisor: it
 // serves many projects, a hosted runtime would tie it to one directory, and an
 // agent disconnecting would take the project down with it. The bool distinguishes
@@ -143,7 +128,7 @@ func launchDetachedRuntime(ctx context.Context, options kranzcli.GlobalOptions, 
 	if record, resolveErr := registry.Resolve(ctx, name, version); resolveErr == nil && record.State == kranzruntime.SessionRunning {
 		return record, false, nil
 	}
-	if err := spawnBackground(target, nil, true, io.Discard); err != nil {
+	if err := spawnBackground(target, nil, false, io.Discard); err != nil {
 		return kranzruntime.SessionRecord{}, false, err
 	}
 	record, err := registry.Resolve(ctx, name, version)

--- a/cmd/kranz/mcp_test.go
+++ b/cmd/kranz/mcp_test.go
@@ -24,16 +24,13 @@ import (
 
 var mcpProjectCounter atomic.Int64
 
-func TestMCPAttachOnlyWarnsWithoutWritingProtocolOutput(t *testing.T) {
-	var stderr bytes.Buffer
-	warnDeprecatedMCPOptions(true, &stderr)
-	if !strings.Contains(stderr.String(), "--attach-only is deprecated") {
-		t.Fatalf("warning = %q", stderr.String())
+func TestMCPRejectsRemovedAttachOnlyOption(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if code := execute([]string{"mcp", "--attach-only"}, &stdout, &stderr); code != kranzcli.ExitUsage {
+		t.Fatalf("exit = %d, stdout/stderr = %q/%q", code, stdout.String(), stderr.String())
 	}
-	stderr.Reset()
-	warnDeprecatedMCPOptions(false, &stderr)
-	if stderr.Len() != 0 {
-		t.Fatalf("unexpected warning = %q", stderr.String())
+	if stdout.Len() != 0 || !strings.Contains(stderr.String(), "unknown") {
+		t.Fatalf("stdout/stderr = %q/%q", stdout.String(), stderr.String())
 	}
 }
 
@@ -87,7 +84,7 @@ func useHelperBackgroundRuntimes(t *testing.T) {
 func startTestRuntime(t *testing.T, options kranzcli.GlobalOptions, name string) kranzruntime.SessionRecord {
 	t.Helper()
 	useHelperBackgroundRuntimes(t)
-	if err := runUp(options, []string{"-d", "--no-start"}, io.Discard); err != nil {
+	if err := runUp(options, []string{"-d"}, io.Discard); err != nil {
 		t.Fatalf("start runtime: %v", err)
 	}
 	t.Cleanup(func() {

--- a/cmd/kranz/mcp_test.go
+++ b/cmd/kranz/mcp_test.go
@@ -24,6 +24,19 @@ import (
 
 var mcpProjectCounter atomic.Int64
 
+func TestMCPAttachOnlyWarnsWithoutWritingProtocolOutput(t *testing.T) {
+	var stderr bytes.Buffer
+	warnDeprecatedMCPOptions(true, &stderr)
+	if !strings.Contains(stderr.String(), "--attach-only is deprecated") {
+		t.Fatalf("warning = %q", stderr.String())
+	}
+	stderr.Reset()
+	warnDeprecatedMCPOptions(false, &stderr)
+	if stderr.Len() != 0 {
+		t.Fatalf("unexpected warning = %q", stderr.String())
+	}
+}
+
 func TestMCPHelperProcess(t *testing.T) {
 	if os.Getenv("KRANZ_TEST_MCP_HELPER") != "1" {
 		return

--- a/cmd/kranz/row_format.go
+++ b/cmd/kranz/row_format.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+	"text/template"
+
+	kranzcli "github.com/kranz-org/kranz/internal/cli"
+)
+
+// rowTemplate is the Docker-style formatter shared by commands whose natural
+// output is one record per line. Its data is always an explicit map assembled
+// by the command, so templates are insulated from internal Go type changes.
+type rowTemplate struct {
+	table    bool
+	template *template.Template
+}
+
+func parseRowFormat(command string, output kranzcli.OutputFormat, args []string) (*rowTemplate, error) {
+	format := ""
+	formatSet := false
+	for index := 0; index < len(args); index++ {
+		switch {
+		case args[index] == "--format":
+			if formatSet {
+				return nil, rowFormatUsageError(command, "--format may be specified only once")
+			}
+			if index+1 >= len(args) {
+				return nil, rowFormatUsageError(command, "--format requires a template")
+			}
+			index++
+			format = args[index]
+			formatSet = true
+		case strings.HasPrefix(args[index], "--format="):
+			if formatSet {
+				return nil, rowFormatUsageError(command, "--format may be specified only once")
+			}
+			format = strings.TrimPrefix(args[index], "--format=")
+			formatSet = true
+			if format == "" {
+				return nil, rowFormatUsageError(command, "--format requires a template")
+			}
+		default:
+			return nil, rowFormatUsageError(command, fmt.Sprintf("unknown %s argument %q", command, args[index]))
+		}
+	}
+	if !formatSet {
+		return nil, nil
+	}
+	if output == kranzcli.OutputJSON {
+		return nil, rowFormatUsageError(command, "--format cannot be combined with --output=json")
+	}
+
+	formatter := &rowTemplate{}
+	if strings.HasPrefix(format, "table ") {
+		formatter.table = true
+		format = strings.TrimPrefix(format, "table ")
+	}
+	if format == "" {
+		return nil, rowFormatUsageError(command, "--format requires a template after table")
+	}
+	// Docker accepts visible escape spellings in a quoted shell argument.
+	format = strings.NewReplacer(`\t`, "\t", `\n`, "\n").Replace(format)
+	parsed, err := template.New(command).Option("missingkey=error").Funcs(template.FuncMap{
+		"json": func(value any) (string, error) {
+			encoded, err := json.Marshal(value)
+			return string(encoded), err
+		},
+		"lower": strings.ToLower,
+		"upper": strings.ToUpper,
+		"split": strings.Split,
+		"join":  strings.Join,
+	}).Parse(format)
+	if err != nil {
+		return nil, rowFormatUsageError(command, "invalid format template: "+err.Error())
+	}
+	formatter.template = parsed
+	return formatter, nil
+}
+
+func rowFormatUsageError(command, message string) error {
+	return &kranzcli.Error{
+		Code:     "invalid_format",
+		Message:  message,
+		Hint:     fmt.Sprintf("Use `kranz %s --format '{{.Field}}'` or prefix the template with `table `.", command),
+		ExitCode: kranzcli.ExitUsage,
+	}
+}
+
+func (formatter *rowTemplate) write(output io.Writer, headers map[string]any, rows []map[string]any) error {
+	if formatter == nil {
+		return nil
+	}
+	// Execute once against the header map even without `table`: this catches an
+	// unknown field consistently when the command happens to return zero rows.
+	if _, err := formatter.execute(headers); err != nil {
+		return rowFormatUsageError(formatter.template.Name(), "invalid format template: "+err.Error())
+	}
+	w := output
+	var aligned *tabwriter.Writer
+	if formatter.table {
+		aligned = tabwriter.NewWriter(output, 0, 4, 2, ' ', 0)
+		w = aligned
+		if err := formatter.writeRow(w, headers); err != nil {
+			return err
+		}
+	}
+	for _, row := range rows {
+		if err := formatter.writeRow(w, row); err != nil {
+			return err
+		}
+	}
+	if aligned != nil {
+		return aligned.Flush()
+	}
+	return nil
+}
+
+func (formatter *rowTemplate) writeRow(output io.Writer, row map[string]any) error {
+	rendered, err := formatter.execute(row)
+	if err != nil {
+		return rowFormatUsageError(formatter.template.Name(), "invalid format template: "+err.Error())
+	}
+	if _, err := io.WriteString(output, rendered); err != nil {
+		return err
+	}
+	if !strings.HasSuffix(rendered, "\n") {
+		_, err = io.WriteString(output, "\n")
+	}
+	return err
+}
+
+func (formatter *rowTemplate) execute(row map[string]any) (string, error) {
+	var output bytes.Buffer
+	err := formatter.template.Execute(&output, row)
+	return output.String(), err
+}

--- a/cmd/kranz/row_format.go
+++ b/cmd/kranz/row_format.go
@@ -21,38 +21,52 @@ type rowTemplate struct {
 }
 
 func parseRowFormat(command string, output kranzcli.OutputFormat, args []string) (*rowTemplate, error) {
+	formatter, remaining, err := extractRowFormat(command, output, args)
+	if err != nil {
+		return nil, err
+	}
+	if len(remaining) > 0 {
+		return nil, rowFormatUsageError(command, fmt.Sprintf("unknown %s argument %q", command, remaining[0]))
+	}
+	return formatter, nil
+}
+
+// extractRowFormat removes one --format option and leaves positional arguments
+// for commands such as status and ports that also accept selectors.
+func extractRowFormat(command string, output kranzcli.OutputFormat, args []string) (*rowTemplate, []string, error) {
 	format := ""
 	formatSet := false
+	remaining := make([]string, 0, len(args))
 	for index := 0; index < len(args); index++ {
 		switch {
 		case args[index] == "--format":
 			if formatSet {
-				return nil, rowFormatUsageError(command, "--format may be specified only once")
+				return nil, nil, rowFormatUsageError(command, "--format may be specified only once")
 			}
 			if index+1 >= len(args) {
-				return nil, rowFormatUsageError(command, "--format requires a template")
+				return nil, nil, rowFormatUsageError(command, "--format requires a template")
 			}
 			index++
 			format = args[index]
 			formatSet = true
 		case strings.HasPrefix(args[index], "--format="):
 			if formatSet {
-				return nil, rowFormatUsageError(command, "--format may be specified only once")
+				return nil, nil, rowFormatUsageError(command, "--format may be specified only once")
 			}
 			format = strings.TrimPrefix(args[index], "--format=")
 			formatSet = true
 			if format == "" {
-				return nil, rowFormatUsageError(command, "--format requires a template")
+				return nil, nil, rowFormatUsageError(command, "--format requires a template")
 			}
 		default:
-			return nil, rowFormatUsageError(command, fmt.Sprintf("unknown %s argument %q", command, args[index]))
+			remaining = append(remaining, args[index])
 		}
 	}
 	if !formatSet {
-		return nil, nil
+		return nil, remaining, nil
 	}
 	if output == kranzcli.OutputJSON {
-		return nil, rowFormatUsageError(command, "--format cannot be combined with --output=json")
+		return nil, nil, rowFormatUsageError(command, "--format cannot be combined with --output=json")
 	}
 
 	formatter := &rowTemplate{}
@@ -61,7 +75,7 @@ func parseRowFormat(command string, output kranzcli.OutputFormat, args []string)
 		format = strings.TrimPrefix(format, "table ")
 	}
 	if format == "" {
-		return nil, rowFormatUsageError(command, "--format requires a template after table")
+		return nil, nil, rowFormatUsageError(command, "--format requires a template after table")
 	}
 	// Docker accepts visible escape spellings in a quoted shell argument.
 	format = strings.NewReplacer(`\t`, "\t", `\n`, "\n").Replace(format)
@@ -76,10 +90,10 @@ func parseRowFormat(command string, output kranzcli.OutputFormat, args []string)
 		"join":  strings.Join,
 	}).Parse(format)
 	if err != nil {
-		return nil, rowFormatUsageError(command, "invalid format template: "+err.Error())
+		return nil, nil, rowFormatUsageError(command, "invalid format template: "+err.Error())
 	}
 	formatter.template = parsed
-	return formatter, nil
+	return formatter, remaining, nil
 }
 
 func rowFormatUsageError(command, message string) error {

--- a/cmd/kranz/row_format_test.go
+++ b/cmd/kranz/row_format_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	kranzcli "github.com/kranz-org/kranz/internal/cli"
+)
+
+func TestRowFormatRendersDockerStyleEscapes(t *testing.T) {
+	formatter, err := parseRowFormat("ps", kranzcli.OutputText, []string{"--format", `{{.PID}}\t{{upper .Name}}`})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	if err := formatter.write(&output,
+		map[string]any{"PID": "PID", "Name": "NAME"},
+		[]map[string]any{{"PID": 42, "Name": "worker"}},
+	); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := output.String(), "42\tWORKER\n"; got != want {
+		t.Fatalf("formatted output = %q, want %q", got, want)
+	}
+}
+
+func TestRowFormatTableWritesHeadersAndAlignsColumns(t *testing.T) {
+	formatter, err := parseRowFormat("clients", kranzcli.OutputText, []string{"--format=table {{.PID}}\t{{.Client}}"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	if err := formatter.write(&output,
+		map[string]any{"PID": "PID", "Client": "CLIENT"},
+		[]map[string]any{{"PID": 7, "Client": "MCP: codex"}},
+	); err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(output.String()), "\n")
+	if len(lines) != 2 || !strings.HasPrefix(lines[0], "PID") || !strings.HasSuffix(lines[0], "CLIENT") ||
+		!strings.HasPrefix(lines[1], "7") || !strings.HasSuffix(lines[1], "MCP: codex") {
+		t.Fatalf("table output = %q", output.String())
+	}
+}
+
+func TestRowFormatRejectsInvalidUses(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		output kranzcli.OutputFormat
+		args   []string
+	}{
+		{name: "missing value", output: kranzcli.OutputText, args: []string{"--format"}},
+		{name: "empty value", output: kranzcli.OutputText, args: []string{"--format="}},
+		{name: "duplicate", output: kranzcli.OutputText, args: []string{"--format", "{{.PID}}", "--format", "{{.Name}}"}},
+		{name: "JSON conflict", output: kranzcli.OutputJSON, args: []string{"--format", "{{.PID}}"}},
+		{name: "invalid template", output: kranzcli.OutputText, args: []string{"--format", "{{"}},
+		{name: "unknown argument", output: kranzcli.OutputText, args: []string{"extra"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := parseRowFormat("ps", test.output, test.args); err == nil {
+				t.Fatal("expected an error")
+			}
+		})
+	}
+}
+
+func TestRowFormatRejectsUnknownFieldEvenWithoutRows(t *testing.T) {
+	formatter, err := parseRowFormat("ps", kranzcli.OutputText, []string{"--format", "{{.Missing}}"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	if err := formatter.write(&output, map[string]any{"PID": "PID"}, nil); err == nil {
+		t.Fatal("expected an unknown-field error")
+	}
+}

--- a/cmd/kranz/runs.go
+++ b/cmd/kranz/runs.go
@@ -86,39 +86,34 @@ func parseRunIdentity(value string) (string, uint32, error) {
 }
 
 func runRuns(options kranzcli.GlobalOptions, targets []string, stdout io.Writer) error {
+	query, err := parseRunsListArgs(options.Output, targets)
+	if err != nil {
+		return err
+	}
 	client, closeClient, err := dialProjectRuntime(options)
 	if err != nil {
 		return err
 	}
 	defer closeClient()
-	runs := filterRuns(client.Runs(), targets)
-	retention := filterRunRetention(client.RunRetention(), targets)
+	runs := filterRuns(client.Runs(), query.targets, query.statuses, query.since, time.Now())
+	if query.limit > 0 && len(runs) > query.limit {
+		runs = runs[len(runs)-query.limit:]
+	}
 	if options.Output == kranzcli.OutputJSON {
+		// Preserve the established machine-readable envelope. Text output has
+		// one record type per command; JSON consumers can migrate retention at
+		// their own pace to `runs retention --output=json`.
 		return kranzcli.WriteJSON(stdout, struct {
 			Runs      []app.RunSummary           `json:"runs"`
 			Retention []app.RunRetentionBoundary `json:"retention"`
-		}{Runs: runs, Retention: retention})
+		}{Runs: runs, Retention: filterRunRetention(client.RunRetention(), query.targets)})
 	}
-	// The two tables describe different things and share no columns. One
-	// tabwriter aligned them against each other, so a long budget string
-	// stretched the run table's DURATION column across half the terminal.
-	if len(retention) > 0 {
-		rw := tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
-		_, _ = fmt.Fprintln(rw, "TARGET\tOLDEST\tBUDGETS\tEVICTED")
-		for _, boundary := range retention {
-			oldest := "-"
-			if boundary.OldestRetainedRun > 0 {
-				oldest = fmt.Sprintf("#%d", boundary.OldestRetainedRun)
-			}
-			_, _ = fmt.Fprintf(rw, "%s\t%s\t%d runs / %d entries / %s\t%d runs\n",
-				runTargetName(boundary.Target), oldest, boundary.MaxRuns, boundary.MaxEntries, formatRunBytes(boundary.MaxBytes), boundary.EvictedRuns)
+	if query.formatter != nil {
+		rows := make([]map[string]any, 0, len(runs))
+		for _, run := range runs {
+			rows = append(rows, runFormatRow(run))
 		}
-		if err := rw.Flush(); err != nil {
-			return err
-		}
-		if _, err := fmt.Fprintln(stdout); err != nil {
-			return err
-		}
+		return query.formatter.write(stdout, runFormatHeaders(), rows)
 	}
 	w := tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
 	_, _ = fmt.Fprintln(w, "RUN\tSTATUS\tSTARTED\tDURATION\tEXIT\tREASON\tINITIATOR\tOUTPUT")
@@ -136,6 +131,136 @@ func runRuns(options kranzcli.GlobalOptions, targets []string, stdout io.Writer)
 			run.StartReason, runInitiator(run), run.Output.State)
 	}
 	return w.Flush()
+}
+
+type runsListQuery struct {
+	targets   []string
+	statuses  map[string]bool
+	limit     int
+	since     time.Duration
+	formatter *rowTemplate
+}
+
+func parseRunsListArgs(output kranzcli.OutputFormat, args []string) (runsListQuery, error) {
+	formatter, args, err := extractRowFormat("runs", output, args)
+	if err != nil {
+		return runsListQuery{}, err
+	}
+	query := runsListQuery{formatter: formatter, statuses: make(map[string]bool)}
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		value := ""
+		switch {
+		case arg == "--limit" || arg == "--since" || arg == "--status":
+			if index+1 >= len(args) {
+				return runsListQuery{}, runsUsageError(arg + " requires a value")
+			}
+			index++
+			value = args[index]
+		case strings.HasPrefix(arg, "--limit="):
+			arg, value = "--limit", strings.TrimPrefix(arg, "--limit=")
+		case strings.HasPrefix(arg, "--since="):
+			arg, value = "--since", strings.TrimPrefix(arg, "--since=")
+		case strings.HasPrefix(arg, "--status="):
+			arg, value = "--status", strings.TrimPrefix(arg, "--status=")
+		case strings.HasPrefix(arg, "-"):
+			return runsListQuery{}, runsUsageError(fmt.Sprintf("unknown runs option %q", arg))
+		default:
+			query.targets = append(query.targets, arg)
+			continue
+		}
+		switch arg {
+		case "--limit":
+			limit, parseErr := strconv.Atoi(value)
+			if parseErr != nil || limit <= 0 {
+				return runsListQuery{}, runsUsageError("--limit must be a positive integer")
+			}
+			query.limit = limit
+		case "--since":
+			since, parseErr := time.ParseDuration(value)
+			if parseErr != nil || since <= 0 {
+				return runsListQuery{}, runsUsageError("--since must be a positive duration such as 30m or 2h")
+			}
+			query.since = since
+		case "--status":
+			for _, status := range strings.Split(value, ",") {
+				status = strings.ToLower(strings.TrimSpace(status))
+				if status == "" {
+					return runsListQuery{}, runsUsageError("--status requires one or more statuses")
+				}
+				query.statuses[status] = true
+			}
+		}
+	}
+	return query, nil
+}
+
+func runsUsageError(message string) error {
+	return &kranzcli.Error{Code: "invalid_runs_query", Message: message, Hint: "Use `kranz runs --help` to inspect filters.", ExitCode: kranzcli.ExitUsage}
+}
+
+func runRunsRetention(options kranzcli.GlobalOptions, args []string, stdout io.Writer) error {
+	formatter, targets, err := extractRowFormat("runs retention", options.Output, args)
+	if err != nil {
+		return err
+	}
+	for _, target := range targets {
+		if strings.HasPrefix(target, "-") {
+			return runsUsageError(fmt.Sprintf("unknown runs retention option %q", target))
+		}
+	}
+	client, closeClient, err := dialProjectRuntime(options)
+	if err != nil {
+		return err
+	}
+	defer closeClient()
+	boundaries := filterRunRetention(client.RunRetention(), targets)
+	if options.Output == kranzcli.OutputJSON {
+		return kranzcli.WriteJSON(stdout, boundaries)
+	}
+	if formatter != nil {
+		rows := make([]map[string]any, 0, len(boundaries))
+		for _, boundary := range boundaries {
+			rows = append(rows, retentionFormatRow(boundary))
+		}
+		return formatter.write(stdout, retentionFormatHeaders(), rows)
+	}
+	w := tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "TARGET\tOLDEST\tBUDGETS\tEVICTED")
+	for _, boundary := range boundaries {
+		row := retentionFormatRow(boundary)
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%d runs / %d entries / %s\t%d runs\n",
+			row["Target"], row["Oldest"], boundary.MaxRuns, boundary.MaxEntries, row["MaxBytes"], boundary.EvictedRuns)
+	}
+	return w.Flush()
+}
+
+func runFormatHeaders() map[string]any {
+	return map[string]any{"Run": "RUN", "Target": "TARGET", "Number": "NUMBER", "Kind": "KIND", "Status": "STATUS", "Started": "STARTED", "StartedAt": "STARTED AT", "FinishedAt": "FINISHED AT", "Duration": "DURATION", "PID": "PID", "Exit": "EXIT", "Reason": "REASON", "Initiator": "INITIATOR", "Surface": "SURFACE", "Client": "CLIENT", "Live": "LIVE", "Output": "OUTPUT"}
+}
+
+func runFormatRow(run app.RunSummary) map[string]any {
+	exit, finished := "-", "-"
+	if run.ExitCode != nil {
+		exit = fmt.Sprint(*run.ExitCode)
+	}
+	duration := time.Since(run.StartedAt)
+	if !run.FinishedAt.IsZero() {
+		duration, finished = run.FinishedAt.Sub(run.StartedAt), run.FinishedAt.Format(time.RFC3339)
+	}
+	return map[string]any{"Run": fmt.Sprintf("%s#%d", runTargetName(run.Target), run.Run), "Target": runTargetName(run.Target), "Number": run.Run, "Kind": string(run.Target.Kind), "Status": run.Status, "Started": shortDuration(time.Since(run.StartedAt)), "StartedAt": run.StartedAt.Format(time.RFC3339), "FinishedAt": finished, "Duration": duration.Round(time.Millisecond), "PID": run.PID, "Exit": exit, "Reason": run.StartReason, "Initiator": runInitiator(run), "Surface": run.Surface, "Client": run.ClientLabel, "Live": run.Live, "Output": run.Output.State}
+}
+
+func retentionFormatHeaders() map[string]any {
+	return map[string]any{"Target": "TARGET", "Oldest": "OLDEST", "MaxRuns": "MAX RUNS", "MaxEntries": "MAX ENTRIES", "MaxBytes": "MAX BYTES", "MaxBytesRaw": "MAX BYTES RAW", "Evicted": "EVICTED"}
+}
+
+func retentionFormatRow(boundary app.RunRetentionBoundary) map[string]any {
+	oldest := "-"
+	if boundary.OldestRetainedRun > 0 {
+		oldest = fmt.Sprintf("#%d", boundary.OldestRetainedRun)
+	}
+	return map[string]any{"Target": runTargetName(boundary.Target), "Oldest": oldest, "MaxRuns": boundary.MaxRuns, "MaxEntries": boundary.MaxEntries, "MaxBytes": formatRunBytes(boundary.MaxBytes), "MaxBytesRaw": boundary.MaxBytes, "Evicted": boundary.EvictedRuns}
 }
 
 func filterRunRetention(boundaries []app.RunRetentionBoundary, targets []string) []app.RunRetentionBoundary {
@@ -183,19 +308,23 @@ func runInitiator(run app.RunSummary) string {
 	return run.Surface + ":" + run.ClientLabel
 }
 
-func filterRuns(runs []app.RunSummary, targets []string) []app.RunSummary {
-	if len(targets) == 0 {
-		return runs
-	}
+func filterRuns(runs []app.RunSummary, targets []string, statuses map[string]bool, since time.Duration, now time.Time) []app.RunSummary {
 	selected := make(map[string]bool, len(targets))
 	for _, target := range targets {
 		selected[strings.ToLower(target)] = true
 	}
 	result := make([]app.RunSummary, 0, len(runs))
 	for _, run := range runs {
-		if selected[strings.ToLower(runTargetName(run.Target))] {
-			result = append(result, run)
+		if len(selected) > 0 && !selected[strings.ToLower(runTargetName(run.Target))] {
+			continue
 		}
+		if len(statuses) > 0 && !statuses[strings.ToLower(run.Status)] {
+			continue
+		}
+		if since > 0 && run.StartedAt.Before(now.Add(-since)) {
+			continue
+		}
+		result = append(result, run)
 	}
 	return result
 }

--- a/cmd/kranz/runs_test.go
+++ b/cmd/kranz/runs_test.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"errors"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/kranz-org/kranz/internal/app"
 	kranzcli "github.com/kranz-org/kranz/internal/cli"
 )
 
@@ -24,5 +28,56 @@ func TestRunsDeleteRequiresExplicitConfirmationBeforeRuntimeAccess(t *testing.T)
 	var commandErr *kranzcli.Error
 	if !errors.As(err, &commandErr) || commandErr.Code != "confirmation_required" {
 		t.Fatalf("runRunsDelete error = %#v", err)
+	}
+}
+
+func TestParseRunsListArgsCombinesFiltersAndFormat(t *testing.T) {
+	query, err := parseRunsListArgs(kranzcli.OutputText, []string{"api", "--status", "running, stopped", "--status=failed", "--since=90m", "--limit", "2", "--format", "{{.Run}}"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(query.targets) != 1 || query.targets[0] != "api" || query.limit != 2 || query.since != 90*time.Minute || query.formatter == nil {
+		t.Fatalf("unexpected query: %#v", query)
+	}
+	for _, status := range []string{"running", "stopped", "failed"} {
+		if !query.statuses[status] {
+			t.Errorf("status %q was not selected", status)
+		}
+	}
+}
+
+func TestParseRunsListArgsRejectsInvalidBounds(t *testing.T) {
+	for _, args := range [][]string{{"--limit", "0"}, {"--since", "later"}, {"--status="}} {
+		if _, err := parseRunsListArgs(kranzcli.OutputText, args); err == nil {
+			t.Errorf("parseRunsListArgs(%q) unexpectedly succeeded", args)
+		}
+	}
+}
+
+func TestFilterRunsAppliesTargetStatusAndTime(t *testing.T) {
+	now := time.Date(2026, time.January, 2, 15, 0, 0, 0, time.UTC)
+	runs := []app.RunSummary{
+		{Target: app.ServiceRunTarget("api"), Run: 1, Status: "stopped", StartedAt: now.Add(-2 * time.Hour)},
+		{Target: app.ServiceRunTarget("api"), Run: 2, Status: "Running", StartedAt: now.Add(-10 * time.Minute)},
+		{Target: app.ServiceRunTarget("worker"), Run: 3, Status: "running", StartedAt: now.Add(-5 * time.Minute)},
+	}
+	filtered := filterRuns(runs, []string{"API"}, map[string]bool{"running": true}, time.Hour, now)
+	if len(filtered) != 1 || filtered[0].Run != 2 {
+		t.Fatalf("filterRuns = %#v", filtered)
+	}
+}
+
+func TestRunFormatterExposesStableRunFields(t *testing.T) {
+	formatter, err := parseRowFormat("runs", kranzcli.OutputText, []string{"--format", "table {{.Run}}\\t{{.PID}}\\t{{.Status}}"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run := app.RunSummary{Target: app.ServiceRunTarget("api"), Run: 7, PID: 321, Status: "running", StartedAt: time.Now()}
+	var output bytes.Buffer
+	if err := formatter.write(&output, runFormatHeaders(), []map[string]any{runFormatRow(run)}); err != nil {
+		t.Fatal(err)
+	}
+	if rendered := output.String(); !strings.Contains(rendered, "RUN") || !strings.Contains(rendered, "api#7") || !strings.Contains(rendered, "321") {
+		t.Fatalf("unexpected formatted output: %q", rendered)
 	}
 }

--- a/cmd/kranz/runtime_commands.go
+++ b/cmd/kranz/runtime_commands.go
@@ -158,13 +158,13 @@ func (h *runtimeHost) Close() error {
 }
 
 func runUp(options kranzcli.GlobalOptions, args []string, stdout io.Writer) error {
-	noStart := false
+	startAll := false
 	detached := false
 	selectors := make([]string, 0, len(args))
 	for _, arg := range args {
 		switch arg {
-		case "--no-start":
-			noStart = true
+		case "--start":
+			startAll = true
 		case "-d", "--detach":
 			detached = true
 		default:
@@ -177,20 +177,20 @@ func runUp(options kranzcli.GlobalOptions, args []string, stdout io.Writer) erro
 	if !detached && options.Output != kranzcli.OutputText {
 		return &kranzcli.Error{Code: "invalid_output", Message: "foreground up requires text output", Hint: "Use `kranz up -d --output json` for a machine-readable background start.", ExitCode: kranzcli.ExitUsage}
 	}
-	if noStart && len(selectors) > 0 {
-		return &kranzcli.Error{Code: "invalid_arguments", Message: "--no-start cannot be combined with selectors", ExitCode: kranzcli.ExitUsage}
+	if startAll && len(selectors) > 0 {
+		return &kranzcli.Error{Code: "invalid_arguments", Message: "--start cannot be combined with selectors", ExitCode: kranzcli.ExitUsage}
 	}
 	if detached {
 		if os.Getenv("KRANZ_INTERNAL_BACKGROUND") == "1" {
 			_ = os.Unsetenv("KRANZ_INTERNAL_BACKGROUND")
-			return runBackgroundChild(options, selectors, noStart)
+			return runBackgroundChild(options, selectors, startAll)
 		}
-		return spawnBackground(options, selectors, noStart, stdout)
+		return spawnBackground(options, selectors, startAll, stdout)
 	}
 	signals := make(chan os.Signal, 2)
 	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
 	defer signal.Stop(signals)
-	if err := spawnBackground(options, selectors, noStart, io.Discard); err != nil {
+	if err := spawnBackground(options, selectors, startAll, io.Discard); err != nil {
 		return classifyRuntimeError(err)
 	}
 	record, err := resolveSession(options)
@@ -273,7 +273,7 @@ type backgroundStartResult struct {
 
 var newBackgroundCommand = func(executable string, args ...string) *exec.Cmd { return exec.Command(executable, args...) }
 
-func spawnBackground(options kranzcli.GlobalOptions, selectors []string, noStart bool, stdout io.Writer) error {
+func spawnBackground(options kranzcli.GlobalOptions, selectors []string, startAll bool, stdout io.Writer) error {
 	executable, err := os.Executable()
 	if err != nil {
 		return err
@@ -291,11 +291,10 @@ func spawnBackground(options kranzcli.GlobalOptions, selectors []string, noStart
 		args = append(args, "-p", options.Project)
 	}
 	args = append(args, "up", "-d")
-	if noStart {
-		args = append(args, "--no-start")
-	} else {
-		args = append(args, selectors...)
+	if startAll {
+		args = append(args, "--start")
 	}
+	args = append(args, selectors...)
 	command := newBackgroundCommand(executable, args...)
 	if command.Env == nil {
 		command.Env = os.Environ()
@@ -370,7 +369,7 @@ func spawnBackground(options kranzcli.GlobalOptions, selectors []string, noStart
 	}
 }
 
-func runBackgroundChild(options kranzcli.GlobalOptions, selectors []string, noStart bool) error {
+func runBackgroundChild(options kranzcli.GlobalOptions, selectors []string, startAll bool) error {
 	readyFile := os.NewFile(3, "kranz-readiness")
 	if readyFile == nil {
 		return errors.New("background readiness descriptor is missing")
@@ -396,8 +395,8 @@ func runBackgroundChild(options kranzcli.GlobalOptions, selectors []string, noSt
 		return host.Close()
 	}
 	defer func() { _ = closeHost() }()
-	if !noStart {
-		if len(selectors) == 0 {
+	if startAll || len(selectors) > 0 {
+		if startAll {
 			for _, name := range cfg.ServiceOrder {
 				if !cfg.Services[name].Disabled {
 					selectors = append(selectors, name)

--- a/cmd/kranz/runtime_commands.go
+++ b/cmd/kranz/runtime_commands.go
@@ -591,6 +591,10 @@ func runtimeNameFromDirectory(options kranzcli.GlobalOptions) (string, error) {
 }
 
 func runStatus(options kranzcli.GlobalOptions, args []string, stdout io.Writer) error {
+	formatter, args, err := extractRowFormat("status", options.Output, args)
+	if err != nil {
+		return err
+	}
 	record, err := resolveSession(options)
 	if err != nil {
 		return err
@@ -645,6 +649,20 @@ func runStatus(options kranzcli.GlobalOptions, args []string, stdout io.Writer) 
 			Session  kranzruntime.SessionMetadata `json:"session"`
 			Services []statusService              `json:"services"`
 		}{record.SessionMetadata, safe})
+	}
+	if formatter != nil {
+		rows := make([]map[string]any, 0, len(services))
+		for _, service := range services {
+			rows = append(rows, map[string]any{
+				"Name": service.Name, "State": service.State.Status.String(), "Health": healthLabel(service),
+				"Uptime": serviceUptime(service), "PID": pidLabel(service.State.PID),
+				"Ports": joinPortsOrDash(service.DetectedPorts), "Error": service.State.ExitError,
+			})
+		}
+		return formatter.write(stdout, map[string]any{
+			"Name": "NAME", "State": "STATE", "Health": "HEALTH", "Uptime": "UPTIME",
+			"PID": "PID", "Ports": "PORTS", "Error": "ERROR",
+		}, rows)
 	}
 	w := tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
 	_, _ = fmt.Fprintln(w, "NAME\tSTATE\tHEALTH\tUPTIME\tPID\tPORTS")

--- a/cmd/kranz/runtime_commands.go
+++ b/cmd/kranz/runtime_commands.go
@@ -591,25 +591,33 @@ func runtimeNameFromDirectory(options kranzcli.GlobalOptions) (string, error) {
 }
 
 func runStatus(options kranzcli.GlobalOptions, args []string, stdout io.Writer) error {
-	formatter, args, err := extractRowFormat("status", options.Output, args)
+	query, err := parseWatchQuery("status", options.Output, args, "name", "state", "health")
 	if err != nil {
 		return err
 	}
+	return runWatch(query, stdout, func() error {
+		return refreshStatus(options, query, stdout)
+	})
+}
+
+func refreshStatus(options kranzcli.GlobalOptions, query watchQuery, stdout io.Writer) error {
 	record, err := resolveSession(options)
 	if err != nil {
 		return err
 	}
-	client, err := kranzruntime.DialContext(context.Background(), record.Socket, version)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	client, err := kranzruntime.DialContext(ctx, record.Socket, version)
 	if err != nil {
 		return classifyRuntimeError(err)
 	}
 	defer func() { _ = client.Close() }()
 	services := client.Services()
-	if len(args) > 0 {
+	if len(query.args) > 0 {
 		// status answers questions about the same words the lifecycle commands
 		// act on. Resolving them differently would make `kranz status web` and
 		// `kranz restart web` disagree about what "web" means.
-		names, err := resolveServiceSelectors(client.Config(), args)
+		names, err := resolveServiceSelectors(client.Config(), query.args)
 		if err != nil {
 			return err
 		}
@@ -623,15 +631,28 @@ func runStatus(options kranzcli.GlobalOptions, args []string, stdout io.Writer) 
 		}
 		services = selected
 	}
-	if options.Output == kranzcli.OutputJSON {
-		type statusService struct {
-			Name          string `json:"name"`
-			State         string `json:"state"`
-			PID           int    `json:"pid"`
-			Ready         *bool  `json:"ready"`
-			Alive         *bool  `json:"alive"`
-			DetectedPorts []int  `json:"detected_ports"`
+	filtered := services[:0]
+	for _, service := range services {
+		if matchesWatchFilters(query.filters, map[string][]string{
+			"name": {service.Name}, "state": {service.State.Status.String()}, "health": {healthLabel(service)},
+		}) {
+			filtered = append(filtered, service)
 		}
+	}
+	return writeStatus(options.Output, query.formatter, record, filtered, stdout)
+}
+
+type statusService struct {
+	Name          string `json:"name"`
+	State         string `json:"state"`
+	PID           int    `json:"pid"`
+	Ready         *bool  `json:"ready"`
+	Alive         *bool  `json:"alive"`
+	DetectedPorts []int  `json:"detected_ports"`
+}
+
+func writeStatus(output kranzcli.OutputFormat, formatter *rowTemplate, record kranzruntime.SessionRecord, services []*app.ServiceSnapshot, stdout io.Writer) error {
+	if output == kranzcli.OutputJSON {
 		safe := make([]statusService, 0, len(services))
 		for _, service := range services {
 			var ready, alive *bool

--- a/cmd/kranz/watch.go
+++ b/cmd/kranz/watch.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	kranzcli "github.com/kranz-org/kranz/internal/cli"
+)
+
+type watchQuery struct {
+	formatter *rowTemplate
+	args      []string
+	filters   map[string]map[string]bool
+	watch     bool
+	interval  time.Duration
+	count     int
+}
+
+func parseWatchQuery(command string, output kranzcli.OutputFormat, args []string, allowedFilters ...string) (watchQuery, error) {
+	formatter, args, err := extractRowFormat(command, output, args)
+	if err != nil {
+		return watchQuery{}, err
+	}
+	allowed := make(map[string]bool, len(allowedFilters))
+	for _, key := range allowedFilters {
+		allowed[key] = true
+	}
+	query := watchQuery{formatter: formatter, filters: make(map[string]map[string]bool), interval: time.Second}
+	intervalSet := false
+	for index := 0; index < len(args); index++ {
+		arg, value := args[index], ""
+		switch {
+		case arg == "--watch":
+			query.watch = true
+			continue
+		case arg == "--filter" || arg == "--interval" || arg == "--count":
+			if index+1 >= len(args) {
+				return watchQuery{}, watchUsageError(command, arg+" requires a value")
+			}
+			index++
+			value = args[index]
+		case strings.HasPrefix(arg, "--filter="):
+			arg, value = "--filter", strings.TrimPrefix(arg, "--filter=")
+		case strings.HasPrefix(arg, "--interval="):
+			arg, value = "--interval", strings.TrimPrefix(arg, "--interval=")
+		case strings.HasPrefix(arg, "--count="):
+			arg, value = "--count", strings.TrimPrefix(arg, "--count=")
+		case strings.HasPrefix(arg, "-"):
+			return watchQuery{}, watchUsageError(command, fmt.Sprintf("unknown %s option %q", command, arg))
+		default:
+			query.args = append(query.args, arg)
+			continue
+		}
+		switch arg {
+		case "--filter":
+			key, filterValue, ok := strings.Cut(value, "=")
+			key = strings.ToLower(strings.TrimSpace(key))
+			if !ok || !allowed[key] {
+				return watchQuery{}, watchUsageError(command, fmt.Sprintf("unsupported filter %q; use one of: %s", key, strings.Join(allowedFilters, ", ")))
+			}
+			for _, candidate := range strings.Split(filterValue, ",") {
+				candidate = strings.ToLower(strings.TrimSpace(candidate))
+				if candidate == "" {
+					return watchQuery{}, watchUsageError(command, "--filter values cannot be empty")
+				}
+				if query.filters[key] == nil {
+					query.filters[key] = make(map[string]bool)
+				}
+				query.filters[key][candidate] = true
+			}
+		case "--interval":
+			interval, parseErr := time.ParseDuration(value)
+			if parseErr != nil || interval <= 0 {
+				return watchQuery{}, watchUsageError(command, "--interval must be a positive duration")
+			}
+			query.interval = interval
+			intervalSet = true
+		case "--count":
+			count, parseErr := strconv.Atoi(value)
+			if parseErr != nil || count <= 0 {
+				return watchQuery{}, watchUsageError(command, "--count must be a positive integer")
+			}
+			query.count = count
+		}
+	}
+	if !query.watch && (query.count > 0 || intervalSet) {
+		return watchQuery{}, watchUsageError(command, "--count and --interval require --watch")
+	}
+	if query.watch && output == kranzcli.OutputJSON {
+		return watchQuery{}, watchUsageError(command, "--watch cannot be combined with --output=json; use --format for streaming rows")
+	}
+	return query, nil
+}
+
+func watchUsageError(command, message string) error {
+	return &kranzcli.Error{Code: "invalid_watch_query", Message: message, Hint: fmt.Sprintf("Use `kranz %s --help` to inspect filters and watch options.", command), ExitCode: kranzcli.ExitUsage}
+}
+
+func matchesWatchFilters(filters map[string]map[string]bool, values map[string][]string) bool {
+	for key, accepted := range filters {
+		matched := false
+		for _, candidate := range values[key] {
+			if accepted[strings.ToLower(candidate)] {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	return true
+}
+
+// runWatch executes immediately, then waits between bounded refreshes. Signals
+// interrupt the wait and return success; each refresh function owns its own
+// I/O timeout so an unavailable runtime cannot trap a watch indefinitely.
+func runWatch(query watchQuery, output io.Writer, refresh func() error) error {
+	if !query.watch {
+		return refresh()
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	for iteration := 1; ; iteration++ {
+		if iteration > 1 && query.formatter == nil {
+			if _, err := fmt.Fprintln(output); err != nil {
+				return err
+			}
+		}
+		if err := refresh(); err != nil {
+			return err
+		}
+		if query.count > 0 && iteration >= query.count {
+			return nil
+		}
+		timer := time.NewTimer(query.interval)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return nil
+		case <-timer.C:
+		}
+	}
+}

--- a/cmd/kranz/watch_test.go
+++ b/cmd/kranz/watch_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+
+	kranzcli "github.com/kranz-org/kranz/internal/cli"
+)
+
+func TestParseWatchQuerySeparatesSelectorsAndFilters(t *testing.T) {
+	query, err := parseWatchQuery("status", kranzcli.OutputText, []string{
+		"web", "--filter", "state=running,unhealthy", "--filter=health=ready", "--watch", "--interval=2s", "--count", "3", "--format", "{{.Name}}",
+	}, "name", "state", "health")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(query.args) != 1 || query.args[0] != "web" || !query.watch || query.interval != 2*time.Second || query.count != 3 || query.formatter == nil {
+		t.Fatalf("unexpected query: %#v", query)
+	}
+	if !query.filters["state"]["running"] || !query.filters["state"]["unhealthy"] || !query.filters["health"]["ready"] {
+		t.Fatalf("unexpected filters: %#v", query.filters)
+	}
+}
+
+func TestParseWatchQueryRejectsAmbiguousModes(t *testing.T) {
+	tests := []struct {
+		output kranzcli.OutputFormat
+		args   []string
+	}{
+		{kranzcli.OutputText, []string{"--filter", "unknown=value"}},
+		{kranzcli.OutputText, []string{"--interval", "2s"}},
+		{kranzcli.OutputJSON, []string{"--watch"}},
+	}
+	for _, test := range tests {
+		if _, err := parseWatchQuery("ps", test.output, test.args, "state"); err == nil {
+			t.Errorf("parseWatchQuery(%q) unexpectedly succeeded", test.args)
+		}
+	}
+}
+
+func TestMatchesWatchFiltersUsesOrWithinKeyAndAcrossKeys(t *testing.T) {
+	filters := map[string]map[string]bool{
+		"state":  {"running": true, "unhealthy": true},
+		"client": {"mcp": true},
+	}
+	if !matchesWatchFilters(filters, map[string][]string{"state": {"Running"}, "client": {"tui", "MCP"}}) {
+		t.Fatal("expected row to match")
+	}
+	if matchesWatchFilters(filters, map[string][]string{"state": {"stopped"}, "client": {"mcp"}}) {
+		t.Fatal("unexpected state match")
+	}
+}
+
+func TestRunWatchHonorsSnapshotCount(t *testing.T) {
+	query := watchQuery{watch: true, interval: time.Millisecond, count: 2}
+	var output bytes.Buffer
+	refreshes := 0
+	err := runWatch(query, &output, func() error {
+		refreshes++
+		return nil
+	})
+	if err != nil || refreshes != 2 {
+		t.Fatalf("runWatch refreshes=%d err=%v", refreshes, err)
+	}
+}
+
+func TestRunWatchStopsOnRefreshError(t *testing.T) {
+	want := errors.New("refresh failed")
+	err := runWatch(watchQuery{}, &bytes.Buffer{}, func() error { return want })
+	if !errors.Is(err, want) {
+		t.Fatalf("runWatch error = %v", err)
+	}
+}

--- a/docs/examples/mcp-shared-runtime.md
+++ b/docs/examples/mcp-shared-runtime.md
@@ -52,8 +52,8 @@ reports a port conflict, inspect the owner instead of changing the example's
 ports silently:
 
 ```bash
-kranz port inspect 18931
-kranz port inspect 18932
+kranz ports inspect 18931
+kranz ports inspect 18932
 ```
 
 ## Regenerate the recording

--- a/docs/guide/cli-workflow.md
+++ b/docs/guide/cli-workflow.md
@@ -46,9 +46,9 @@ supervisor.
 
 ```console
 $ kranz ps
-ID        NAME      PROJECT  SERVICES  CLIENTS  STATE    UPTIME
-7fa21c8d  shop-dev  Shop     4/4       1        running  18m
-91bc430a  billing   Billing  3/3       2        running  6m
+ID        PID    NAME      PROJECT  SERVICES  CLIENTS  STATE    UPTIME
+7fa21c8d  18400  shop-dev  Shop     4/4       1        running  18m
+91bc430a  18022  billing   Billing  3/3       2        running  6m
 ```
 
 `clients` answers the other half: who is attached to those runtimes, whether

--- a/docs/guide/cli-workflow.md
+++ b/docs/guide/cli-workflow.md
@@ -68,6 +68,15 @@ worker   running  -       18m     26085  -
 not turn the internal assumption that a missing probe permits startup into a
 false claim that a probe passed.
 
+Use exact filters to narrow live tables, and `--watch` to follow changes. A
+bounded watch is convenient in automation:
+
+```bash
+kranz ps --filter client=mcp
+kranz clients --filter client=tui,mcp --watch --count 3
+kranz status api --filter state=running,unhealthy --watch --interval 2s
+```
+
 ## Act on services
 
 ```bash

--- a/docs/guide/cli-workflow.md
+++ b/docs/guide/cli-workflow.md
@@ -17,7 +17,7 @@ one-shot coordinate instead of repeating a flag:
 
 ```bash
 KRANZ_PROJECT=shop-dev kranz status
-KRANZ_DIRECTORY=/work/shop kranz list services
+KRANZ_DIRECTORY=/work/shop kranz services
 ```
 
 The equivalent `-p` and `-C` flags remain available and take precedence over
@@ -26,19 +26,21 @@ the environment.
 ## Start a project and leave it running
 
 ```console
-$ kranz up -d
+$ kranz up --start -d
 Started shop-dev (7fa21c8d), PID 18421.
 ```
 
-`up -d` creates a background runtime for this project and gives you the prompt
-back. The processes belong to that runtime, not to your shell, so closing the
-terminal leaves them alone.
+`up --start -d` creates a background runtime, starts every enabled service, and
+gives you the prompt back. The processes belong to that runtime, not to your
+shell, so closing the terminal leaves them alone. Use `up -d` without
+`--start` when you want an empty runtime and will start services explicitly.
 
-Without `-d`, `up` keeps a foreground client attached and streams every
-service's output with a prefix. The runtime supervisor is still a separate
-process; `Ctrl+C` explicitly asks it to shut down before the foreground client
-terminates. This is the shape you want inside a container or under another
-supervisor.
+Without `-d`, `up` keeps a foreground client attached. Selectors start and
+stream only the named services; `--start` starts and streams every enabled
+service; bare `up` starts none. The runtime supervisor is still a separate
+process, and `Ctrl+C` explicitly asks it to shut down before the foreground
+client terminates. This is the shape you want inside a container or under
+another supervisor.
 
 ## See what is running
 
@@ -115,7 +117,7 @@ kranz logs --since 5m
 Logs survive the service. A worker that crashed two minutes ago still answers
 `kranz logs worker`, which is when you actually need it.
 
-Actions keep their own history under the same name `kranz action run` uses, so
+Actions keep their own history under the same name `kranz actions run` uses, so
 an action that has already finished can be read again without running it twice:
 
 ```bash
@@ -161,7 +163,7 @@ service answers to is tried as a tag. `kranz plan api`, `kranz status api` and
 `kranz stop api` therefore always cover the same services.
 
 Actions extend the rule rather than change it: `OWNER/ACTION` addresses one
-action, using the same name `kranz action run` uses. Because of that, a service
+action, using the same name `kranz actions run` uses. Because of that, a service
 and an action group may not share a name — the actions under the second one
 would be unreachable — and `kranz config check` rejects a project that tries.
 
@@ -217,7 +219,7 @@ started:
 kranz config check
 kranz doctor
 kranz plan
-kranz list services
+kranz services
 kranz ports
 ```
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -70,8 +70,8 @@ Return to panel `1`, keep both services selected, and press `s`. Kranz asks for
 confirmation before every stop. Confirm it and watch both process groups exit.
 
 Press `q` to leave. If services are still running, choose `Enter` or `y` to
-stop the runtime, `d` to detach while keeping it running, or `Esc` or `n` to
-stay in the TUI.
+stop the runtime, `d` to detach while keeping it running, `c` to stop it and
+choose another runtime without leaving the TUI, or `Esc` or `n` to stay.
 
 ## 5. What to try next
 

--- a/docs/guide/logs-and-ports.md
+++ b/docs/guide/logs-and-ports.md
@@ -52,8 +52,10 @@ target's. Think of the catalog as the index of executions and the log buffer as
 the retained evidence for what those executions printed.
 
 ```bash
-kranz runs                          # every retained run, with retention budgets
+kranz runs                          # every retained run
 kranz runs api analytics/stats      # narrow to one or more targets
+kranz runs --status failed --since 2h --limit 10
+kranz runs retention                # per-target catalog and output budgets
 kranz logs api --run 4              # only run #4
 kranz logs api --run -1             # the newest run
 kranz logs api --runs 3             # the last three runs

--- a/docs/guide/mcp.md
+++ b/docs/guide/mcp.md
@@ -208,8 +208,9 @@ with `runtime_pinned` — useful when a client should be unable to reach beyond
 one checkout. Existing registrations that pass these flags keep working
 unchanged; they are now a choice rather than a requirement.
 
-`--attach-only` is accepted and ignored. It disabled an owner fallback that no
-longer exists.
+`--attach-only` is deprecated and ignored. It disabled an owner fallback that
+no longer exists, now emits a warning, and will be removed in the next major
+release.
 
 ## Starting a project the agent was asked to start
 

--- a/docs/guide/mcp.md
+++ b/docs/guide/mcp.md
@@ -205,12 +205,7 @@ display label only; runtime addressing still follows the rules above.
 `-C DIR`, `-f FILE`, and `-p NAME|ID` pin the server to one project. A pinned
 connection resolves everything to that runtime and refuses any other address
 with `runtime_pinned` — useful when a client should be unable to reach beyond
-one checkout. Existing registrations that pass these flags keep working
-unchanged; they are now a choice rather than a requirement.
-
-`--attach-only` is deprecated and ignored. It disabled an owner fallback that
-no longer exists, now emits a warning, and will be removed in the next major
-release.
+one checkout.
 
 ## Starting a project the agent was asked to start
 

--- a/docs/guide/tui.md
+++ b/docs/guide/tui.md
@@ -103,8 +103,9 @@ Every TUI is attached to an independently owned runtime, including the one
 opened by bare `kranz`. The quit confirmation always shows
 which managed processes and configured detached resources will stop and which
 external resources will remain active. Confirm shutdown with `Enter` or `y`,
-press `d` to detach the TUI and keep the complete runtime running, or use `Esc`
-or `n` to stay.
+press `d` to detach the TUI and keep the complete runtime running, or press `c`
+for **Close & choose**: stop this runtime and immediately choose another in the
+same TUI process. Use `Esc` or `n` to stay.
 
 The [CLI workflow](./cli-workflow) and [MCP guide](./mcp) operate the same live
 runtime. A restart from either is reflected immediately in this TUI.
@@ -139,6 +140,10 @@ instead of closing, offering `r` to restart that project or `c` to choose
 another running one. See the [switching runtimes
 reference](../reference/controls#switching-runtimes) for the complete key
 list, row states, and recovery behavior.
+
+**Close & choose** uses this same live list after intentionally stopping the
+current runtime. An empty list is a normal state; `q` exits and `Esc` returns to
+the recovery actions.
 
 ## Common keys
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -94,7 +94,8 @@ prefix.
 ### Creating a configuration
 
 ```bash
-kranz init                                   # wizard, or flags when there is no terminal
+kranz init                                   # interactive authoring wizard
+kranz init ./new-project                     # start in another directory
 kranz init --from Procfile                   # convert an existing source
 kranz init --from process-compose.yaml
 kranz init --name Shop --service api --command "npm run dev" --yes
@@ -102,16 +103,34 @@ kranz init --service api --command "npm run dev" --yes
 kranz init -o kranz.local.yaml
 ```
 
-`init` discovers a Kranz, Process Compose, or Procfile source and offers to
-convert it, reads `package.json` scripts and offers them as actions without
-running them, previews the file it is about to write, and refuses to replace an
-existing file without `--yes` or a confirmation. It reloads what it wrote before
-reporting success.
+Interactive `init` builds an in-memory draft. Start with the project name and
+directory, optionally configure the full project appearance with a live theme
+preview, then add any number of services and actions. Draft entries can be
+opened, edited, or deleted before the final YAML review. A service asks for its
+name, directory, command, and optional port. An action asks for its name,
+project-or-service owner, directory, and command.
+
+`init` does not inspect package registries or infer commands. Import is explicit
+through `--from`. An existing native configuration opens a replacement choice
+before the wizard and a line diff before the final save; cancelling at either
+point leaves it byte-for-byte unchanged. The file is written atomically and
+reloaded before success is reported.
+
+Appearance settings are independent. Choosing only a theme writes only
+`ui.theme`; accent, background source or custom colour, and `auto`/`dark`/`light`
+colour mode are emitted only when changed. Choosing inherited appearance omits
+the `ui` block entirely.
 
 `--name` sets the project written into the new file. Older scripts may keep
 using `-p/--project` with `init`, but new invocations should prefer `--name` so
 the value cannot be confused with the global runtime selector. Supplying both
 forms is an error.
+
+Without a terminal, the inputs must be explicit. `--yes` confirms that complete
+flag form; it does not discover commands, classify nearby files, or permit an
+overwrite. Existing automation can continue to use an explicit `--from PATH`
+conversion. Replacing a file without a terminal additionally requires
+`--force`.
 
 ### Inspecting a project
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -46,7 +46,7 @@ than being appended to a hidden inherited list.
 
 ```bash
 KRANZ_PROJECT=billing kranz status
-KRANZ_DIRECTORY=~/projects/shop kranz list services
+KRANZ_DIRECTORY=~/projects/shop kranz services
 KRANZ_CONFIG=kranz.yaml:kranz.local.yaml kranz config show
 ```
 
@@ -121,10 +121,8 @@ Appearance settings are independent. Choosing only a theme writes only
 colour mode are emitted only when changed. Choosing inherited appearance omits
 the `ui` block entirely.
 
-`--name` sets the project written into the new file. Older scripts may keep
-using `-p/--project` with `init`, but new invocations should prefer `--name` so
-the value cannot be confused with the global runtime selector. Supplying both
-forms is an error.
+`--name` sets the project written into the new file. Global `-p/--project`
+always selects a runtime and is therefore rejected by `init`.
 
 Without a terminal, the inputs must be explicit. `--yes` confirms that complete
 flag form; it does not discover commands, classify nearby files, or permit an
@@ -144,21 +142,25 @@ kranz config check                  # load, merge, and validate
 kranz config show [--provenance]    # effective configuration, secrets redacted
 kranz config explain [SERVICE] [--all]  # which layer set each field
 kranz doctor                        # preflight checks
-kranz list [services|actions|tags]
-kranz info [SERVICE]
+kranz project                       # project details
+kranz services                      # configured services
+kranz services info SERVICE         # one service's configuration and live state
+kranz actions [OWNER]               # configured actions; optionally by owner
+kranz tags                          # configured service tags
 kranz plan [SELECTOR ...]           # the waves a start would use
 kranz plan --operation stop api     # services a stop would affect
 kranz graph [--format text|json|dot]
 kranz ports [SELECTOR ...]
-kranz port inspect PORT
+kranz ports inspect PORT
 ```
 
 `ports` reports both the ports a service declares and the ports a running
 runtime saw it open, labelled by origin, because a service that picks its port
 at runtime is exactly the case where the configuration cannot answer.
 
-`info SERVICE` describes the configuration, and adds what the service is doing
-right now when a runtime is up.
+`services info SERVICE` describes the configuration, and adds what the service
+is doing right now when a runtime is up. `project` describes only the project,
+so the same command never changes entity based on whether an argument is present.
 
 `config show` redacts environment values whose name looks like a credential and
 keeps services, action groups, and actions in the order the configuration
@@ -166,8 +168,8 @@ declares them. `config explain` on a single-layer project says so instead of
 repeating the same filename on every field; `--all` lists them anyway.
 
 A group runs its obvious subcommand when invoked bare: `kranz config` is
-`config show`, `kranz action` is `action list`, and `kranz port 8080` is
-`port inspect 8080`.
+`config show`, `kranz services` is `services list`, `kranz actions` is
+`actions list`, and `kranz ports` is `ports list`.
 
 `plan` prints the dependency waves the supervisor itself gates readiness on, and
 pulls in the dependencies of whatever you selected:
@@ -197,9 +199,12 @@ when any check fails.
 ```bash
 kranz ps                            # every runtime this user has running
 kranz clients                       # who is attached to those runtimes
-kranz up [SELECTOR ...]             # start runtime and stream multiplexed logs
-kranz up -d [SELECTOR ...]          # background runtime, returns the prompt
-kranz up --no-start                 # empty runtime with foreground log client
+kranz up                            # empty runtime; Ctrl+C stops it
+kranz up -d                         # empty background runtime; prompt returns
+kranz up [SELECTOR ...]             # selected services; foreground log stream
+kranz up -d [SELECTOR ...]          # selected services in the background
+kranz up --start                    # every enabled service; foreground stream
+kranz up --start -d                 # every enabled service in the background
 kranz attach                        # open the TUI on a running runtime
 kranz status [SELECTOR ...]
 kranz start SELECTOR ...
@@ -245,6 +250,11 @@ does not show it and never shows its own discovery connection. A runtime with
 no clients remains visible in `kranz ps` and the TUI Runtimes window, where its
 `CLIENTS` value is `-`.
 
+`up` has two independent choices. With no selectors it starts no services;
+selectors start only what they name, and `--start` explicitly starts every
+enabled service. Without `-d`, the terminal owns the runtime lifetime, streams
+logs, and receives project exit codes; `-d` returns after readiness.
+
 Built-in clients are displayed compactly as `TUI`, `CLI`, and `MCP`.
 Meaningful variants retain their identity, such as `TUI: attach`,
 `CLI: foreground`, or `MCP: codex`. An MCP launcher can set
@@ -272,7 +282,7 @@ PID     RUNTIME    CLIENT
 `.ConnectedAt`. The `json`, `lower`, `upper`, `split`, and `join` template
 functions are available. `--format` and `--output=json` cannot be combined.
 The same formatter is available for `status`, `ports`, `doctor`,
-`config explain`, `action list`, and `list services/actions/tags`. Run a
+`config explain`, `services`, `actions`, and `tags`. Run a
 command with `--format '{{json .}}'` to discover its stable fields and current
 values; `table ` may be prefixed once the desired columns are selected.
 
@@ -315,8 +325,7 @@ entry, supervises nothing, and picks the runtime per call: the tool's `runtime`
 argument, then the `-C`/`-p` pin, then the directory it was started in, then an
 error carrying the runtimes that would have worked. `-C`, `-f`, and `-p` pin the
 connection to one project and make every other address an error.
-`--attach-only` is deprecated and ignored. It emits a warning and will be
-removed in the next major release. See the [MCP reference](./mcp.md).
+See the [MCP reference](./mcp.md).
 
 ### Logs
 
@@ -385,9 +394,9 @@ rather than an address and stays silent when it overlaps the start of history.
 ### Actions
 
 ```bash
-kranz action list [OWNER]
-kranz action info OWNER/ACTION
-kranz action run OWNER/ACTION
+kranz actions [OWNER]
+kranz actions info OWNER/ACTION
+kranz actions run OWNER/ACTION
 ```
 
 An action is identified by owner and name together, so a service action and an
@@ -457,7 +466,7 @@ Failures use the same envelope with an `error` object, and stdout stays valid
 JSON so a script never has to parse prose:
 
 ```console
-$ kranz list --output json
+$ kranz services --output json
 {"schema_version":1,"error":{"code":"no_project","message":"no Kranz configuration was found in this directory","hint":"Run from a project directory or pass -f PATH."}}
 ```
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -109,8 +109,9 @@ reporting success.
 
 ### Inspecting a project
 
-These read the configuration only. They work before the first `up` and never
-disturb a running runtime.
+These inspect configuration and, where useful, current runtime state. They
+never mutate a running runtime; configuration-only forms work before the first
+`up`.
 
 ```bash
 kranz config                        # same as config show
@@ -121,6 +122,7 @@ kranz doctor                        # preflight checks
 kranz list [services|actions|tags]
 kranz info [SERVICE]
 kranz plan [SELECTOR ...]           # the waves a start would use
+kranz plan --operation stop api     # services a stop would affect
 kranz graph [--format text|json|dot]
 kranz ports [SELECTOR ...]
 kranz port inspect PORT
@@ -157,6 +159,10 @@ Wave 3:
 Wave 4:
   gateway  (after billing-api, catalog-api)
 ```
+
+Bare `plan` and `--operation start` work from configuration alone. Stop and
+restart previews require a running runtime because they report only the
+currently running dependents that the real operation would affect.
 
 `doctor` reports every finding rather than stopping at the first, and exits `3`
 when any check fails.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -187,42 +187,59 @@ Every runtime has an independent background supervisor. Leaving a TUI through
 its detach action does not stop it; confirming shutdown or running an external
 `down` stops the runtime and closes attached clients cleanly.
 
-`ps` lists runtimes; `clients` lists each runtime's owner together with the CLI,
-TUI, and MCP connections working in it, including surface, label, PID, and
-connection age. They are two commands because they answer two questions: what
-is running, and who is using it. Narrow either one to a single runtime with
-`-p NAME|ID`.
+`ps` lists runtimes; `clients` lists the CLI, TUI, and MCP connections working
+in them, including client identity, PID, and connection age. They are two
+commands because they answer two questions: what is running, and who is using
+it. Narrow either one to a single runtime with `-p NAME|ID`.
 
 ```console
 $ kranz ps
-ID        NAME       PROJECT    SERVICES  CLIENTS  STATE    UPTIME
-7fa21c8d  shop-dev   Shop       4/4       3        running  18m
-91bc430a  billing    Billing    3/3       1        running  6m
-3de94a71  analytics  Analytics  2/2       2        running  2m
+ID        PID    NAME       PROJECT    SERVICES  CLIENTS  STATE    UPTIME
+7fa21c8d  18400  shop-dev   Shop       4/4       2        running  18m
+91bc430a  18022  billing    Billing    3/3       0        running  6m
+3de94a71  19001  analytics  Analytics  2/2       1        running  2m
 
 $ kranz clients
-RUNTIME    SURFACE     CLIENT            PID    CONNECTED
-shop-dev   background  Kranz background  18400  18m
-shop-dev   tui         Kranz dashboard   18421  18m
-shop-dev   mcp         Kranz MCP         18472  4m
-billing    background  Kranz background  18022  6m
-analytics  background  Kranz background  19001  2m
-analytics  cli         Kranz CLI         19108  <1s
+RUNTIME    PID    CLIENT  CONNECTED
+shop-dev   18421  TUI     18m
+shop-dev   18472  MCP     4m
+analytics  19108  CLI     <1s
 ```
 
-The `shop-dev` clients share one runtime row. Every running runtime has a
-background owner connection; TUI, foreground log streaming, CLI, and MCP
-connections come and go without taking ownership. The short-lived command on
-`analytics` appears only while it is connected. `kranz clients` never counts
-itself.
+The `shop-dev` clients share one runtime row. TUI, foreground log streaming,
+CLI, and MCP connections come and go without taking ownership. The short-lived
+command on `analytics` appears only while it is connected. The runtime's
+background owner is infrastructure rather than a client, so `kranz clients`
+does not show it and never shows its own discovery connection. A runtime with
+no clients remains visible in `kranz ps` and the TUI Runtimes window, where its
+`CLIENTS` value is `-`.
 
-These are the built-in client labels. The TUI reports `Kranz dashboard` (or
-`Kranz attach` when opened with `kranz attach`), the runtime owner reports
-`Kranz background`, a foreground `kranz up` client reports `Kranz foreground`,
-MCP reports `Kranz MCP`, and ordinary commands report `Kranz CLI`. An MCP launcher can set
-`KRANZ_MCP_CLIENT=codex` to replace the default MCP label with `MCP: codex` when
-several agent clients need to be distinguished. The label changes only what
-`kranz clients` displays; it does not select or rename a runtime.
+Built-in clients are displayed compactly as `TUI`, `CLI`, and `MCP`.
+Meaningful variants retain their identity, such as `TUI: attach`,
+`CLI: foreground`, or `MCP: codex`. An MCP launcher can set
+`KRANZ_MCP_CLIENT=codex` to produce the latter when several agent clients need
+to be distinguished. The label changes only what `kranz clients` displays; it
+does not select or rename a runtime.
+
+Both runtime listings accept Docker-style Go templates. Without the `table`
+prefix, the template renders once per row with no header:
+
+```console
+$ kranz ps --format '{{.PID}}\t{{.Name}}\t{{.State}}'
+18400   shop-dev   running
+
+$ kranz clients --format 'table {{.PID}}\t{{.Runtime}}\t{{.Client}}'
+PID     RUNTIME    CLIENT
+18421   shop-dev   TUI
+18472   shop-dev   MCP: codex
+```
+
+`ps` exposes `.ID`, `.FullID`, `.PID`, `.Name`, `.Project`, `.Services`,
+`.Clients`, `.State`, `.Uptime`, `.Directory`, `.Mode`, `.Version`, and
+`.StartedAt`. `clients` exposes `.Runtime`, `.ID`, `.FullID`, `.Project`,
+`.PID`, `.Client`, `.Surface`, `.Label`, `.Version`, `.Connected`, and
+`.ConnectedAt`. The `json`, `lower`, `upper`, `split`, and `join` template
+functions are available. `--format` and `--output=json` cannot be combined.
 
 Every `ps` row is an independently owned lifecycle runtime. A TUI, foreground
 log stream, CLI command, and MCP server are clients of that session — they

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -97,6 +97,7 @@ prefix.
 kranz init                                   # wizard, or flags when there is no terminal
 kranz init --from Procfile                   # convert an existing source
 kranz init --from process-compose.yaml
+kranz init --name Shop --service api --command "npm run dev" --yes
 kranz init --service api --command "npm run dev" --yes
 kranz init -o kranz.local.yaml
 ```
@@ -106,6 +107,11 @@ convert it, reads `package.json` scripts and offers them as actions without
 running them, previews the file it is about to write, and refuses to replace an
 existing file without `--yes` or a confirmation. It reloads what it wrote before
 reporting success.
+
+`--name` sets the project written into the new file. Older scripts may keep
+using `-p/--project` with `init`, but new invocations should prefer `--name` so
+the value cannot be confused with the global runtime selector. Supplying both
+forms is an error.
 
 ### Inspecting a project
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -251,6 +251,22 @@ The same formatter is available for `status`, `ports`, `doctor`,
 command with `--format '{{json .}}'` to discover its stable fields and current
 values; `table ` may be prefixed once the desired columns are selected.
 
+The three live listings can filter exact, case-insensitive values and refresh
+until interrupted. Comma-separated values are alternatives for one key;
+different keys must all match. `--count` makes a watch bounded for automation,
+while `--interval` changes the one-second default:
+
+```bash
+kranz ps --filter state=running --filter client=mcp
+kranz clients --filter client=mcp,tui --watch --count 5
+kranz status --filter state=running,unhealthy --watch --interval 2s
+```
+
+`ps` filters `name`, `project`, `state`, or `client`; `clients` filters
+`runtime`, `project`, `client`, `surface`, or `label`; and `status` filters
+`name`, `state`, or `health` after resolving selectors. Watch mode accepts text
+or template output because concatenated JSON documents would not be valid.
+
 Every `ps` row is an independently owned lifecycle runtime. A TUI, foreground
 log stream, CLI command, and MCP server are clients of that session — they
 appear in `clients`, never as a second `ps` row. The same project can have

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -221,8 +221,8 @@ Meaningful variants retain their identity, such as `TUI: attach`,
 to be distinguished. The label changes only what `kranz clients` displays; it
 does not select or rename a runtime.
 
-Both runtime listings accept Docker-style Go templates. Without the `table`
-prefix, the template renders once per row with no header:
+Row-oriented inspection commands accept Docker-style Go templates. Without
+the `table` prefix, the template renders once per row with no header:
 
 ```console
 $ kranz ps --format '{{.PID}}\t{{.Name}}\t{{.State}}'
@@ -240,6 +240,10 @@ PID     RUNTIME    CLIENT
 `.PID`, `.Client`, `.Surface`, `.Label`, `.Version`, `.Connected`, and
 `.ConnectedAt`. The `json`, `lower`, `upper`, `split`, and `join` template
 functions are available. `--format` and `--output=json` cannot be combined.
+The same formatter is available for `status`, `ports`, `doctor`,
+`config explain`, `action list`, and `list services/actions/tags`. Run a
+command with `--format '{{json .}}'` to discover its stable fields and current
+values; `table ` may be prefixed once the desired columns are selected.
 
 Every `ps` row is an independently owned lifecycle runtime. A TUI, foreground
 log stream, CLI command, and MCP server are clients of that session — they

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -221,7 +221,10 @@ session, not the ordinary way to stop a project.
 
 Every runtime has an independent background supervisor. Leaving a TUI through
 its detach action does not stop it; confirming shutdown or running an external
-`down` stops the runtime and closes attached clients cleanly.
+`down` stops the runtime and closes attached clients cleanly. The quit
+confirmation's **Close & choose** action stops the current runtime and opens
+the live chooser so another runtime can be attached without restarting the
+TUI.
 
 `ps` lists runtimes; `clients` lists the CLI, TUI, and MCP connections working
 in them, including client identity, PID, and connection age. They are two

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -296,7 +296,8 @@ entry, supervises nothing, and picks the runtime per call: the tool's `runtime`
 argument, then the `-C`/`-p` pin, then the directory it was started in, then an
 error carrying the runtimes that would have worked. `-C`, `-f`, and `-p` pin the
 connection to one project and make every other address an error.
-`--attach-only` is accepted and ignored. See the [MCP reference](./mcp.md).
+`--attach-only` is deprecated and ignored. It emits a warning and will be
+removed in the next major release. See the [MCP reference](./mcp.md).
 
 ### Logs
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -269,10 +269,10 @@ Row-oriented inspection commands accept Docker-style Go templates. Without
 the `table` prefix, the template renders once per row with no header:
 
 ```console
-$ kranz ps --format '{{.PID}}\t{{.Name}}\t{{.State}}'
+$ kranz ps --format '&lbrace;&lbrace;.PID}}\t&lbrace;&lbrace;.Name}}\t&lbrace;&lbrace;.State}}'
 18400   shop-dev   running
 
-$ kranz clients --format 'table {{.PID}}\t{{.Runtime}}\t{{.Client}}'
+$ kranz clients --format 'table &lbrace;&lbrace;.PID}}\t&lbrace;&lbrace;.Runtime}}\t&lbrace;&lbrace;.Client}}'
 PID     RUNTIME    CLIENT
 18421   shop-dev   TUI
 18472   shop-dev   MCP: codex
@@ -286,7 +286,7 @@ PID     RUNTIME    CLIENT
 functions are available. `--format` and `--output=json` cannot be combined.
 The same formatter is available for `status`, `ports`, `doctor`,
 `config explain`, `services`, `actions`, and `tags`. Run a
-command with `--format '{{json .}}'` to discover its stable fields and current
+command with `--format '&lbrace;&lbrace;json .}}'` to discover its stable fields and current
 values; `table ` may be prefixed once the desired columns are selected.
 
 The three live listings can filter exact, case-insensitive values and refresh
@@ -371,7 +371,7 @@ kranz runs                                # bounded run catalog
 kranz runs api analytics/stats            # narrow catalog by target
 kranz runs --status failed --since 2h     # filter by status and start time
 kranz runs --limit 10                     # newest ten matching runs
-kranz runs --format 'table {{.Run}}\t{{.Status}}\t{{.Duration}}'
+kranz runs --format 'table &lbrace;&lbrace;.Run}}\t&lbrace;&lbrace;.Status}}\t&lbrace;&lbrace;.Duration}}'
 kranz runs retention                      # per-target retention limits
 kranz runs delete api#4 --confirm         # delete one completed run and retained output
 ```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -313,8 +313,12 @@ kranz logs analytics/stats --run -1       # the latest run
 kranz logs analytics/stats --run -2       # the run before it
 kranz logs analytics/stats --runs 3       # the last three runs
 kranz logs api --run -1                   # only the newest start of a service
-kranz runs                                # bounded catalog and retention limits
+kranz runs                                # bounded run catalog
 kranz runs api analytics/stats            # narrow catalog by target
+kranz runs --status failed --since 2h     # filter by status and start time
+kranz runs --limit 10                     # newest ten matching runs
+kranz runs --format 'table {{.Run}}\t{{.Status}}\t{{.Duration}}'
+kranz runs retention                      # per-target retention limits
 kranz runs delete api#4 --confirm         # delete one completed run and retained output
 ```
 

--- a/docs/reference/controls.md
+++ b/docs/reference/controls.md
@@ -107,9 +107,10 @@ accent-coloured shortcuts.
 
 The quit confirmation shows the complete shutdown plan. `Enter` or `y` stops
 the runtime and quits, `d` detaches the TUI while keeping the runtime running,
-and `Esc` or `n` stays in the TUI. Shutdown stops process-owned services and
-only detached services with `stop_on_exit: true`; other external resources are
-listed and remain active.
+and `c` stops the current runtime and opens the live runtime chooser without
+leaving the TUI. `Esc` or `n` stays on the current dashboard. Shutdown stops
+process-owned services and only detached services with `stop_on_exit: true`;
+other external resources are listed and remain active.
 
 ## Switching runtimes
 
@@ -172,6 +173,10 @@ the TUI. Instead it shows a recovery screen:
 | `r` or `Enter` | Restart the same project's runtime and reattach |
 | `c` | Choose a different, already-running runtime |
 | `q` or `Ctrl+C` | Close only the TUI |
+
+The same chooser opens immediately after **Close & choose**. If no runtime
+remains, the empty list is valid; press `q` to leave the TUI or `Esc` to return
+to the recovery actions.
 
 A restart reuses the project directory and configuration paths Kranz already
 had for that runtime; it does not repeat any command a user typed. If it

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -32,8 +32,7 @@ nothing. Which runtime answers is decided per call.
 
 `-C DIR`, `-f FILE`, and `-p NAME|ID` pin the server to one project for a
 client that should reach exactly one. A pinned server rejects any other address
-with `runtime_pinned`. `--attach-only` is a deprecated compatibility flag: it
-has no effect, emits a warning, and will be removed in the next major release.
+with `runtime_pinned`.
 
 The [MCP guide](../guide/mcp) has ready-to-copy configurations and a
 first-connection check.

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -32,8 +32,8 @@ nothing. Which runtime answers is decided per call.
 
 `-C DIR`, `-f FILE`, and `-p NAME|ID` pin the server to one project for a
 client that should reach exactly one. A pinned server rejects any other address
-with `runtime_pinned`. `--attach-only` is accepted and ignored: it disabled an
-owner fallback that no longer exists.
+with `runtime_pinned`. `--attach-only` is a deprecated compatibility flag: it
+has no effect, emits a warning, and will be removed in the next major release.
 
 The [MCP guide](../guide/mcp) has ready-to-copy configurations and a
 first-connection check.

--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -15,7 +15,7 @@ func TestCompletionOffersOnlyRunnableCommands(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", shell, err)
 		}
-		for _, name := range []string{"ps", "status", "up", "list", "plan", "doctor", "logs", "action", "init"} {
+		for _, name := range []string{"ps", "project", "status", "up", "services", "actions", "tags", "ports", "plan", "doctor", "logs", "init"} {
 			if !strings.Contains(script, name) {
 				t.Errorf("%s completion omits %q", shell, name)
 			}
@@ -72,7 +72,7 @@ func TestCompletionRejectsAnUnknownShell(t *testing.T) {
 	}
 }
 
-// Subcommands have to complete too, or `kranz action <tab>` offers nothing.
+// Subcommands have to complete too, or `kranz actions <tab>` offers nothing.
 func TestCompletionIncludesSubcommands(t *testing.T) {
 	for _, shell := range CompletionShells() {
 		script, err := Completion(DefaultTree(), shell)
@@ -81,6 +81,20 @@ func TestCompletionIncludesSubcommands(t *testing.T) {
 		}
 		if !strings.Contains(script, "run") || !strings.Contains(script, "check") {
 			t.Errorf("%s completion omits subcommands", shell)
+		}
+	}
+}
+
+func TestCompletionOmitsRemovedOptions(t *testing.T) {
+	for _, shell := range CompletionShells() {
+		script, err := Completion(DefaultTree(), shell)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, removed := range []string{"--no-start", "--attach-only"} {
+			if strings.Contains(script, removed) {
+				t.Errorf("%s completion still offers removed option %q", shell, removed)
+			}
 		}
 	}
 }

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -25,7 +25,7 @@ func Help(tree *Command, path []string) (string, error) {
 	var output strings.Builder
 	fmt.Fprintf(&output, "%s — %s.\n", name, command.Summary)
 	if command.IsPlanned() {
-		output.WriteString("\nThis command is planned for v0.8.0 and this build does not implement it yet.\n")
+		output.WriteString("\nThis command is planned for a future release and this build does not implement it yet.\n")
 	}
 	fmt.Fprintf(&output, "\nUsage:\n  %s\n", usage)
 
@@ -40,7 +40,7 @@ func Help(tree *Command, path []string) (string, error) {
 		available = append(available, child)
 	}
 	writeSection(&output, "Commands", available)
-	writeSection(&output, "Planned for v0.8.0 (not implemented yet)", planned)
+	writeSection(&output, "Planned for a future release (not implemented yet)", planned)
 	writeOptions(&output, "Options", command.Options)
 	writeOptions(&output, "Global options", GlobalFlags())
 	return output.String(), nil

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -112,7 +112,7 @@ func TestHelpDocumentsLifecycleOptionsThatChangeCommandMeaning(t *testing.T) {
 	}{
 		{[]string{"init"}, []string{"-y|--yes"}},
 		{[]string{"config", "explain"}, []string{"--all"}},
-		{[]string{"up"}, []string{"-d|--detach", "--no-start"}},
+		{[]string{"up"}, []string{"-d|--detach", "--start"}},
 		{[]string{"down"}, []string{"--force"}},
 	} {
 		output, err := Help(DefaultTree(), test.command)
@@ -122,6 +122,20 @@ func TestHelpDocumentsLifecycleOptionsThatChangeCommandMeaning(t *testing.T) {
 		for _, want := range test.want {
 			if !strings.Contains(output, want) {
 				t.Errorf("help %v omits %q:\n%s", test.command, want, output)
+			}
+		}
+	}
+}
+
+func TestHelpOmitsRemovedOptions(t *testing.T) {
+	for _, path := range [][]string{{"up"}, {"mcp"}} {
+		output, err := Help(DefaultTree(), path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, removed := range []string{"--no-start", "--attach-only"} {
+			if strings.Contains(output, removed) {
+				t.Errorf("help for %q still mentions removed option %q", path, removed)
 			}
 		}
 	}

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -105,6 +105,23 @@ func TestReleaseSurfaceHasNoPlannedCommands(t *testing.T) {
 	}
 }
 
+func TestRootHelpKeepsActionsBesideServices(t *testing.T) {
+	output, err := Help(DefaultTree(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	services := strings.Index(output, "\n  services ")
+	actions := strings.Index(output, "\n  actions  ")
+	tags := strings.Index(output, "\n  tags     ")
+	if services < 0 || actions < 0 || tags < 0 {
+		t.Fatalf("root help is missing services, actions, or tags:\n%s", output)
+	}
+	if services >= actions || actions >= tags {
+		t.Fatalf("root help order is services=%d actions=%d tags=%d; actions should sit beside services:\n%s",
+			services, actions, tags, output)
+	}
+}
+
 func TestHelpDocumentsLifecycleOptionsThatChangeCommandMeaning(t *testing.T) {
 	for _, test := range []struct {
 		command []string

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 )
 
-// plannedTree mirrors the shape the real tree had while v0.8 was being built:
-// some commands runnable, some grammar reserved ahead of its implementation.
+// plannedTree covers a possible future tree: some commands runnable, some
+// grammar reserved ahead of its implementation.
 // The mechanism is tested here rather than against DefaultTree so it keeps
 // working for the next release that reserves a command before writing it.
 func plannedTree() *Command {
@@ -33,7 +33,7 @@ func TestHelpSeparatesPlannedCommands(t *testing.T) {
 		t.Fatalf("Help returned an error: %v", err)
 	}
 
-	commands, planned, found := strings.Cut(output, "Planned for v0.8.0 (not implemented yet):")
+	commands, planned, found := strings.Cut(output, "Planned for a future release (not implemented yet):")
 	if !found {
 		t.Fatalf("help does not list planned commands separately:\n%s", output)
 	}
@@ -78,8 +78,8 @@ func TestHelpForPlannedCommandSaysSo(t *testing.T) {
 	}
 }
 
-// Every command v0.8.0 promises is now implemented. A planned command
-// reappearing here means a release is about to ship grammar it cannot run.
+// Every command in the release tree is implemented. A planned command
+// appearing here means a release is about to ship grammar it cannot run.
 func TestReleaseSurfaceHasNoPlannedCommands(t *testing.T) {
 	var planned []string
 	var walk func(command *Command, path []string)

--- a/internal/cli/parse.go
+++ b/internal/cli/parse.go
@@ -107,7 +107,7 @@ func Parse(tree *Command, args []string) (Invocation, error) {
 				continue
 			}
 			// The token is not a subcommand. A group with a default takes it as
-			// that subcommand's argument, so `kranz port 8080` works; the
+			// that subcommand's argument, so `kranz ports api` works; the
 			// default then reports what is wrong with the token if anything is.
 			fallback := current.Child(current.Default)
 			if fallback == nil {

--- a/internal/cli/parse_test.go
+++ b/internal/cli/parse_test.go
@@ -121,9 +121,10 @@ func TestParseRejectsMissingSubcommandAndInvalidOutput(t *testing.T) {
 func TestGroupsRunTheirDefaultSubcommand(t *testing.T) {
 	clearKranzCoordinateEnvironment(t)
 	for group, want := range map[string]string{
-		"config": "config show",
-		"action": "action list",
-		"port":   "port inspect",
+		"config":   "config show",
+		"actions":  "actions list",
+		"services": "services list",
+		"ports":    "ports list",
 	} {
 		invocation, err := Parse(DefaultTree(), []string{group})
 		if err != nil {
@@ -145,12 +146,12 @@ func TestGroupsRunTheirDefaultSubcommand(t *testing.T) {
 	}
 
 	// Arguments reach the default subcommand.
-	invocation, err = Parse(DefaultTree(), []string{"port", "8080"})
+	invocation, err = Parse(DefaultTree(), []string{"ports", "api"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if invocation.Command() != "port inspect" || len(invocation.Args) != 1 || invocation.Args[0] != "8080" {
-		t.Errorf("port 8080 resolved to %q with args %v", invocation.Command(), invocation.Args)
+	if invocation.Command() != "ports list" || len(invocation.Args) != 1 || invocation.Args[0] != "api" {
+		t.Errorf("ports api resolved to %q with args %v", invocation.Command(), invocation.Args)
 	}
 }
 
@@ -159,6 +160,24 @@ func TestUnknownOptionIsNotReportedAsACommand(t *testing.T) {
 	_, err := Parse(DefaultTree(), []string{"--wat"})
 	if commandError := AsError(err); commandError.Code != "unknown_option" {
 		t.Fatalf("error = %#v", commandError)
+	}
+}
+
+func TestRemovedGrammarHasStableUsageErrors(t *testing.T) {
+	clearKranzCoordinateEnvironment(t)
+	for _, test := range []struct {
+		args []string
+		code string
+	}{
+		{[]string{"list"}, "unknown_command"},
+		{[]string{"action", "list"}, "unknown_command"},
+		{[]string{"info", "api"}, "unknown_command"},
+		{[]string{"port", "inspect", "8080"}, "unknown_command"},
+	} {
+		_, err := Parse(DefaultTree(), test.args)
+		if commandErr := AsError(err); commandErr.Code != test.code {
+			t.Errorf("Parse(%q) error = %#v, want code %q", test.args, commandErr, test.code)
+		}
 	}
 }
 

--- a/internal/cli/tree.go
+++ b/internal/cli/tree.go
@@ -118,8 +118,12 @@ func DefaultTree() *Command {
 			}},
 		}},
 		{Name: "doctor", Summary: "run project preflight checks"},
-		{Name: "ps", Summary: "list active project runtimes"},
-		{Name: "clients", Summary: "list clients attached to project runtimes"},
+		{Name: "ps", Summary: "list active project runtimes", Usage: "kranz ps [--format TEMPLATE]", Options: []Option{
+			{Flags: "--format TEMPLATE", Summary: "render each runtime with a Go template; prefix with 'table ' for headers"},
+		}},
+		{Name: "clients", Summary: "list clients attached to project runtimes", Usage: "kranz clients [--format TEMPLATE]", Options: []Option{
+			{Flags: "--format TEMPLATE", Summary: "render each client with a Go template; prefix with 'table ' for headers"},
+		}},
 		{Name: "list", Summary: "list services, actions, or tags", Usage: "kranz list [services|actions|tags]"},
 		{Name: "info", Summary: "show project or service details", Usage: "kranz info [SERVICE]"},
 		{Name: "status", Summary: "show runtime status", Usage: "kranz status [SELECTOR ...]"},

--- a/internal/cli/tree.go
+++ b/internal/cli/tree.go
@@ -100,9 +100,9 @@ type Command struct {
 // change, which is what moves the command into the working help section.
 func DefaultTree() *Command {
 	return &Command{Name: "kranz", Summary: "a local service orchestrator", Children: []*Command{
-		{Name: "init", Summary: "create a Kranz configuration", Usage: "kranz init [--from PATH] [--project NAME] [--service NAME] [--command COMMAND] [-o PATH] [-y|--yes]", Options: []Option{
+		{Name: "init", Summary: "create a Kranz configuration", Usage: "kranz init [--from PATH] [--name NAME] [--service NAME] [--command COMMAND] [-o PATH] [-y|--yes]", Options: []Option{
 			{Flags: "--from PATH", Summary: "convert an existing Procfile or compose file"},
-			{Flags: "--project NAME", Summary: "project name to write"},
+			{Flags: "--name NAME", Summary: "project name to write; -p/--project remains a compatibility alias"},
 			{Flags: "--service NAME", Summary: "name of the first service"},
 			{Flags: "--command COMMAND", Summary: "command that first service runs"},
 			{Flags: "-o, --output-file PATH", Summary: "file to write; defaults to kranz.yaml"},

--- a/internal/cli/tree.go
+++ b/internal/cli/tree.go
@@ -87,17 +87,15 @@ type Command struct {
 	Default string
 
 	// Planned marks a command whose grammar is reserved but whose execution a
-	// later feature stream still has to attach. Help lists planned commands
+	// future change still has to attach. Help lists planned commands
 	// apart from working ones and the dispatcher refuses them, so the tree
 	// stays the single place that decides which surface actually exists.
 	Planned bool
 }
 
-// DefaultTree returns the complete v0.8 command vocabulary. Feature streams
-// attach execution to these nodes incrementally; reserving the grammar here
-// keeps unknown-command handling, help, and future completions deterministic.
-// A stream that implements a command clears its Planned flag in the same
-// change, which is what moves the command into the working help section.
+// DefaultTree returns the command vocabulary implemented by this build.
+// Reserving future grammar here is optional; a command marked Planned stays
+// out of completions and is clearly separated in help until implemented.
 func DefaultTree() *Command {
 	return &Command{Name: "kranz", Summary: "a local service orchestrator", Children: []*Command{
 		{Name: "init", Summary: "create a Kranz configuration", Usage: "kranz init [--from PATH] [--name NAME] [--service NAME] [--command COMMAND] [-o PATH] [-y|--yes]", Options: []Option{
@@ -185,7 +183,7 @@ func DefaultTree() *Command {
 		}},
 		{Name: "attach", Summary: "open the TUI for an active runtime"},
 		{Name: "mcp", Summary: "serve project runtimes over MCP stdio; global -C/-p pin it to one", Usage: "kranz mcp", Options: []Option{
-			{Flags: "--attach-only", Summary: "accepted and ignored; MCP no longer creates a runtime on connect"},
+			{Flags: "--attach-only", Summary: "deprecated compatibility flag; ignored and removed in the next major release"},
 		}},
 		{Name: "logs", Summary: "show and clear logs", Default: "show", Children: []*Command{
 			{Name: "show", Summary: "show service and action logs", Usage: "kranz logs [SELECTOR ...] [--tail N | --all] [--since D]\n  [--run N | --runs N] [--source S] [--with-actions]\n  [--plain | --no-timestamps | --no-labels] [--follow]", Options: []Option{

--- a/internal/cli/tree.go
+++ b/internal/cli/tree.go
@@ -100,7 +100,7 @@ func DefaultTree() *Command {
 	return &Command{Name: "kranz", Summary: "a local service orchestrator", Children: []*Command{
 		{Name: "init", Summary: "author a Kranz configuration", Usage: "kranz init [DIRECTORY] [--from PATH] [--name NAME] [--service NAME] [--command COMMAND] [-o PATH] [-y|--yes] [--force]", Options: []Option{
 			{Flags: "--from PATH", Summary: "explicitly convert an existing Procfile or compose file"},
-			{Flags: "--name NAME", Summary: "project name to write; -p/--project remains a compatibility alias"},
+			{Flags: "--name NAME", Summary: "project name to write"},
 			{Flags: "--service NAME", Summary: "name of the first service"},
 			{Flags: "--command COMMAND", Summary: "command that first service runs"},
 			{Flags: "-o, --output-file PATH", Summary: "file to write; defaults to kranz.yaml"},
@@ -134,10 +134,16 @@ func DefaultTree() *Command {
 			{Flags: "--count N", Summary: "stop watch after N snapshots"},
 			{Flags: "--format TEMPLATE", Summary: "render each client with a Go template; prefix with 'table ' for headers"},
 		}},
-		{Name: "list", Summary: "list services, actions, or tags", Usage: "kranz list [services|actions|tags] [--format TEMPLATE]", Options: []Option{
-			{Flags: "--format TEMPLATE", Summary: "render each item with a Go template; prefix with 'table ' for headers"},
+		{Name: "services", Summary: "inspect configured services", Default: "list", Children: []*Command{
+			{Name: "list", Summary: "list configured services", Usage: "kranz services [--format TEMPLATE]", Options: []Option{
+				{Flags: "--format TEMPLATE", Summary: "render each service with a Go template; prefix with 'table ' for headers"},
+			}},
+			{Name: "info", Summary: "show service details", Usage: "kranz services info SERVICE"},
 		}},
-		{Name: "info", Summary: "show project or service details", Usage: "kranz info [SERVICE]"},
+		{Name: "tags", Summary: "list configured service tags", Usage: "kranz tags [--format TEMPLATE]", Options: []Option{
+			{Flags: "--format TEMPLATE", Summary: "render each tag with a Go template; prefix with 'table ' for headers"},
+		}},
+		{Name: "project", Summary: "show project details", Usage: "kranz project"},
 		{Name: "status", Summary: "show runtime status", Usage: "kranz status [SELECTOR ...] [--filter KEY=VALUE] [--watch] [--interval D] [--count N] [--format TEMPLATE]", Options: []Option{
 			{Flags: "--filter KEY=VALUE", Summary: "filter selected services by name, state, or health; repeatable"},
 			{Flags: "--watch", Summary: "refresh until interrupted"},
@@ -165,15 +171,15 @@ func DefaultTree() *Command {
 		{Name: "graph", Summary: "print the dependency graph", Usage: "kranz graph [--format text|json|dot]", Options: []Option{
 			{Flags: "--format FORMAT", Summary: "text, json, or dot; defaults to text", Values: []string{"text", "json", "dot"}},
 		}},
-		{Name: "ports", Summary: "list configured and detected ports", Usage: "kranz ports [SELECTOR ...] [--format TEMPLATE]", Options: []Option{
-			{Flags: "--format TEMPLATE", Summary: "render each port with a Go template; prefix with 'table ' for headers"},
+		{Name: "ports", Summary: "inspect ports", Default: "list", Children: []*Command{
+			{Name: "list", Summary: "list configured and detected ports", Usage: "kranz ports [SELECTOR ...] [--format TEMPLATE]", Options: []Option{
+				{Flags: "--format TEMPLATE", Summary: "render each port with a Go template; prefix with 'table ' for headers"},
+			}},
+			{Name: "inspect", Summary: "identify a local port listener", Usage: "kranz ports inspect PORT"},
 		}},
-		{Name: "port", Summary: "inspect a local port", Default: "inspect", Children: []*Command{
-			{Name: "inspect", Summary: "identify a port listener", Usage: "kranz port inspect PORT"},
-		}},
-		{Name: "up", Summary: "create a project runtime", Usage: "kranz up [SELECTOR ...] [-d|--detach]\n  kranz up --no-start [-d|--detach]", Options: []Option{
+		{Name: "up", Summary: "create a project runtime", Usage: "kranz up [SELECTOR ...] [-d|--detach]\n  kranz up --start [-d|--detach]", Options: []Option{
 			{Flags: "-d, --detach", Summary: "return after starting the independent runtime"},
-			{Flags: "--no-start", Summary: "create the runtime without starting any service"},
+			{Flags: "--start", Summary: "start every enabled service"},
 		}},
 		{Name: "start", Summary: "start services", Usage: "kranz start SELECTOR ..."},
 		{Name: "stop", Summary: "stop services", Usage: "kranz stop SELECTOR ..."},
@@ -183,9 +189,7 @@ func DefaultTree() *Command {
 			{Flags: "--force", Summary: "discard a runtime that no longer answers its socket"},
 		}},
 		{Name: "attach", Summary: "open the TUI for an active runtime"},
-		{Name: "mcp", Summary: "serve project runtimes over MCP stdio; global -C/-p pin it to one", Usage: "kranz mcp", Options: []Option{
-			{Flags: "--attach-only", Summary: "deprecated compatibility flag; ignored and removed in the next major release"},
-		}},
+		{Name: "mcp", Summary: "serve project runtimes over MCP stdio; global -C/-p pin it to one", Usage: "kranz mcp"},
 		{Name: "logs", Summary: "show and clear logs", Default: "show", Children: []*Command{
 			{Name: "show", Summary: "show service and action logs", Usage: "kranz logs [SELECTOR ...] [--tail N | --all] [--since D]\n  [--run N | --runs N] [--source S] [--with-actions]\n  [--plain | --no-timestamps | --no-labels] [--follow]", Options: []Option{
 				{Flags: "--tail N", Summary: "show the last N lines; a service defaults to 50"},
@@ -205,12 +209,12 @@ func DefaultTree() *Command {
 				{Flags: "--force", Summary: "required to clear every buffer at once"},
 			}},
 		}},
-		{Name: "action", Summary: "inspect and run actions", Default: "list", Children: []*Command{
-			{Name: "list", Summary: "list actions", Usage: "kranz action list [OWNER] [--format TEMPLATE]", Options: []Option{
+		{Name: "actions", Summary: "inspect and run actions", Default: "list", Children: []*Command{
+			{Name: "list", Summary: "list actions", Usage: "kranz actions [OWNER] [--format TEMPLATE]", Options: []Option{
 				{Flags: "--format TEMPLATE", Summary: "render each action with a Go template; prefix with 'table ' for headers"},
 			}},
-			{Name: "info", Summary: "show action details", Usage: "kranz action info OWNER/ACTION"},
-			{Name: "run", Summary: "run an action", Usage: "kranz action run OWNER/ACTION"},
+			{Name: "info", Summary: "show action details", Usage: "kranz actions info OWNER/ACTION"},
+			{Name: "run", Summary: "run an action", Usage: "kranz actions run OWNER/ACTION"},
 		}},
 		{Name: "completion", Summary: "generate shell completion", Usage: "kranz completion bash|zsh|fish"},
 		{Name: "help", Summary: "show command help", Usage: "kranz help [COMMAND]"},

--- a/internal/cli/tree.go
+++ b/internal/cli/tree.go
@@ -98,13 +98,14 @@ type Command struct {
 // out of completions and is clearly separated in help until implemented.
 func DefaultTree() *Command {
 	return &Command{Name: "kranz", Summary: "a local service orchestrator", Children: []*Command{
-		{Name: "init", Summary: "create a Kranz configuration", Usage: "kranz init [--from PATH] [--name NAME] [--service NAME] [--command COMMAND] [-o PATH] [-y|--yes]", Options: []Option{
-			{Flags: "--from PATH", Summary: "convert an existing Procfile or compose file"},
+		{Name: "init", Summary: "author a Kranz configuration", Usage: "kranz init [DIRECTORY] [--from PATH] [--name NAME] [--service NAME] [--command COMMAND] [-o PATH] [-y|--yes] [--force]", Options: []Option{
+			{Flags: "--from PATH", Summary: "explicitly convert an existing Procfile or compose file"},
 			{Flags: "--name NAME", Summary: "project name to write; -p/--project remains a compatibility alias"},
 			{Flags: "--service NAME", Summary: "name of the first service"},
 			{Flags: "--command COMMAND", Summary: "command that first service runs"},
 			{Flags: "-o, --output-file PATH", Summary: "file to write; defaults to kranz.yaml"},
-			{Flags: "-y, --yes", Summary: "answer every prompt yes, overwriting any file"},
+			{Flags: "-y, --yes", Summary: "write a fully specified non-interactive configuration"},
+			{Flags: "--force", Summary: "replace an existing file in non-interactive mode"},
 		}},
 		{Name: "config", Summary: "inspect effective configuration", Default: "show", Children: []*Command{
 			{Name: "check", Summary: "load and validate configuration"},

--- a/internal/cli/tree.go
+++ b/internal/cli/tree.go
@@ -113,20 +113,27 @@ func DefaultTree() *Command {
 			{Name: "show", Summary: "print redacted effective configuration", Usage: "kranz config show [--provenance]", Options: []Option{
 				{Flags: "--provenance", Summary: "annotate each field with the layer it came from"},
 			}},
-			{Name: "explain", Summary: "show field provenance", Usage: "kranz config explain [SERVICE] [--all]", Options: []Option{
+			{Name: "explain", Summary: "show field provenance", Usage: "kranz config explain [SERVICE] [--all] [--format TEMPLATE]", Options: []Option{
 				{Flags: "--all", Summary: "explain every service instead of one"},
+				{Flags: "--format TEMPLATE", Summary: "render each field with a Go template; prefix with 'table ' for headers"},
 			}},
 		}},
-		{Name: "doctor", Summary: "run project preflight checks"},
+		{Name: "doctor", Summary: "run project preflight checks", Usage: "kranz doctor [--format TEMPLATE]", Options: []Option{
+			{Flags: "--format TEMPLATE", Summary: "render each finding with a Go template; prefix with 'table ' for headers"},
+		}},
 		{Name: "ps", Summary: "list active project runtimes", Usage: "kranz ps [--format TEMPLATE]", Options: []Option{
 			{Flags: "--format TEMPLATE", Summary: "render each runtime with a Go template; prefix with 'table ' for headers"},
 		}},
 		{Name: "clients", Summary: "list clients attached to project runtimes", Usage: "kranz clients [--format TEMPLATE]", Options: []Option{
 			{Flags: "--format TEMPLATE", Summary: "render each client with a Go template; prefix with 'table ' for headers"},
 		}},
-		{Name: "list", Summary: "list services, actions, or tags", Usage: "kranz list [services|actions|tags]"},
+		{Name: "list", Summary: "list services, actions, or tags", Usage: "kranz list [services|actions|tags] [--format TEMPLATE]", Options: []Option{
+			{Flags: "--format TEMPLATE", Summary: "render each item with a Go template; prefix with 'table ' for headers"},
+		}},
 		{Name: "info", Summary: "show project or service details", Usage: "kranz info [SERVICE]"},
-		{Name: "status", Summary: "show runtime status", Usage: "kranz status [SELECTOR ...]"},
+		{Name: "status", Summary: "show runtime status", Usage: "kranz status [SELECTOR ...] [--format TEMPLATE]", Options: []Option{
+			{Flags: "--format TEMPLATE", Summary: "render each service with a Go template; prefix with 'table ' for headers"},
+		}},
 		{Name: "runs", Summary: "inspect and delete retained runs", Default: "list", Children: []*Command{
 			{Name: "list", Summary: "list retained service and action runs", Usage: "kranz runs [TARGET ...]"},
 			{Name: "delete", Summary: "delete one completed run", Usage: "kranz runs delete TARGET#N --confirm", Options: []Option{
@@ -137,7 +144,9 @@ func DefaultTree() *Command {
 		{Name: "graph", Summary: "print the dependency graph", Usage: "kranz graph [--format text|json|dot]", Options: []Option{
 			{Flags: "--format FORMAT", Summary: "text, json, or dot; defaults to text", Values: []string{"text", "json", "dot"}},
 		}},
-		{Name: "ports", Summary: "list configured and detected ports", Usage: "kranz ports [SELECTOR ...]"},
+		{Name: "ports", Summary: "list configured and detected ports", Usage: "kranz ports [SELECTOR ...] [--format TEMPLATE]", Options: []Option{
+			{Flags: "--format TEMPLATE", Summary: "render each port with a Go template; prefix with 'table ' for headers"},
+		}},
 		{Name: "port", Summary: "inspect a local port", Default: "inspect", Children: []*Command{
 			{Name: "inspect", Summary: "identify a port listener", Usage: "kranz port inspect PORT"},
 		}},
@@ -176,7 +185,9 @@ func DefaultTree() *Command {
 			}},
 		}},
 		{Name: "action", Summary: "inspect and run actions", Default: "list", Children: []*Command{
-			{Name: "list", Summary: "list actions", Usage: "kranz action list [OWNER]"},
+			{Name: "list", Summary: "list actions", Usage: "kranz action list [OWNER] [--format TEMPLATE]", Options: []Option{
+				{Flags: "--format TEMPLATE", Summary: "render each action with a Go template; prefix with 'table ' for headers"},
+			}},
 			{Name: "info", Summary: "show action details", Usage: "kranz action info OWNER/ACTION"},
 			{Name: "run", Summary: "run an action", Usage: "kranz action run OWNER/ACTION"},
 		}},

--- a/internal/cli/tree.go
+++ b/internal/cli/tree.go
@@ -140,7 +140,9 @@ func DefaultTree() *Command {
 				{Flags: "--confirm", Summary: "confirm permanent removal of the run and its retained output"},
 			}},
 		}},
-		{Name: "plan", Summary: "show the resolved start plan", Usage: "kranz plan [SELECTOR ...]"},
+		{Name: "plan", Summary: "show a resolved lifecycle plan", Usage: "kranz plan [SELECTOR ...] [--operation start|stop|restart]", Options: []Option{
+			{Flags: "--operation OPERATION", Summary: "operation to preview; defaults to start", Values: []string{"start", "stop", "restart"}},
+		}},
 		{Name: "graph", Summary: "print the dependency graph", Usage: "kranz graph [--format text|json|dot]", Options: []Option{
 			{Flags: "--format FORMAT", Summary: "text, json, or dot; defaults to text", Values: []string{"text", "json", "dot"}},
 		}},

--- a/internal/cli/tree.go
+++ b/internal/cli/tree.go
@@ -135,7 +135,15 @@ func DefaultTree() *Command {
 			{Flags: "--format TEMPLATE", Summary: "render each service with a Go template; prefix with 'table ' for headers"},
 		}},
 		{Name: "runs", Summary: "inspect and delete retained runs", Default: "list", Children: []*Command{
-			{Name: "list", Summary: "list retained service and action runs", Usage: "kranz runs [TARGET ...]"},
+			{Name: "list", Summary: "list retained service and action runs", Usage: "kranz runs [TARGET ...] [--limit N] [--since D] [--status STATUS] [--format TEMPLATE]", Options: []Option{
+				{Flags: "--limit N", Summary: "keep only the newest N matching runs"},
+				{Flags: "--since D", Summary: "keep runs started within a duration such as 30m or 2h"},
+				{Flags: "--status STATUS", Summary: "keep comma-separated statuses; repeatable"},
+				{Flags: "--format TEMPLATE", Summary: "render each run with a Go template; prefix with 'table ' for headers"},
+			}},
+			{Name: "retention", Summary: "show per-target run retention", Usage: "kranz runs retention [TARGET ...] [--format TEMPLATE]", Options: []Option{
+				{Flags: "--format TEMPLATE", Summary: "render each retention boundary with a Go template; prefix with 'table ' for headers"},
+			}},
 			{Name: "delete", Summary: "delete one completed run", Usage: "kranz runs delete TARGET#N --confirm", Options: []Option{
 				{Flags: "--confirm", Summary: "confirm permanent removal of the run and its retained output"},
 			}},

--- a/internal/cli/tree.go
+++ b/internal/cli/tree.go
@@ -121,17 +121,29 @@ func DefaultTree() *Command {
 		{Name: "doctor", Summary: "run project preflight checks", Usage: "kranz doctor [--format TEMPLATE]", Options: []Option{
 			{Flags: "--format TEMPLATE", Summary: "render each finding with a Go template; prefix with 'table ' for headers"},
 		}},
-		{Name: "ps", Summary: "list active project runtimes", Usage: "kranz ps [--format TEMPLATE]", Options: []Option{
+		{Name: "ps", Summary: "list active project runtimes", Usage: "kranz ps [--filter KEY=VALUE] [--watch] [--interval D] [--count N] [--format TEMPLATE]", Options: []Option{
+			{Flags: "--filter KEY=VALUE", Summary: "filter by name, project, state, or client; repeatable"},
+			{Flags: "--watch", Summary: "refresh until interrupted"},
+			{Flags: "--interval D", Summary: "watch refresh interval; defaults to 1s"},
+			{Flags: "--count N", Summary: "stop watch after N snapshots"},
 			{Flags: "--format TEMPLATE", Summary: "render each runtime with a Go template; prefix with 'table ' for headers"},
 		}},
-		{Name: "clients", Summary: "list clients attached to project runtimes", Usage: "kranz clients [--format TEMPLATE]", Options: []Option{
+		{Name: "clients", Summary: "list clients attached to project runtimes", Usage: "kranz clients [--filter KEY=VALUE] [--watch] [--interval D] [--count N] [--format TEMPLATE]", Options: []Option{
+			{Flags: "--filter KEY=VALUE", Summary: "filter by runtime, project, client, surface, or label; repeatable"},
+			{Flags: "--watch", Summary: "refresh until interrupted"},
+			{Flags: "--interval D", Summary: "watch refresh interval; defaults to 1s"},
+			{Flags: "--count N", Summary: "stop watch after N snapshots"},
 			{Flags: "--format TEMPLATE", Summary: "render each client with a Go template; prefix with 'table ' for headers"},
 		}},
 		{Name: "list", Summary: "list services, actions, or tags", Usage: "kranz list [services|actions|tags] [--format TEMPLATE]", Options: []Option{
 			{Flags: "--format TEMPLATE", Summary: "render each item with a Go template; prefix with 'table ' for headers"},
 		}},
 		{Name: "info", Summary: "show project or service details", Usage: "kranz info [SERVICE]"},
-		{Name: "status", Summary: "show runtime status", Usage: "kranz status [SELECTOR ...] [--format TEMPLATE]", Options: []Option{
+		{Name: "status", Summary: "show runtime status", Usage: "kranz status [SELECTOR ...] [--filter KEY=VALUE] [--watch] [--interval D] [--count N] [--format TEMPLATE]", Options: []Option{
+			{Flags: "--filter KEY=VALUE", Summary: "filter selected services by name, state, or health; repeatable"},
+			{Flags: "--watch", Summary: "refresh until interrupted"},
+			{Flags: "--interval D", Summary: "watch refresh interval; defaults to 1s"},
+			{Flags: "--count N", Summary: "stop watch after N snapshots"},
 			{Flags: "--format TEMPLATE", Summary: "render each service with a Go template; prefix with 'table ' for headers"},
 		}},
 		{Name: "runs", Summary: "inspect and delete retained runs", Default: "list", Children: []*Command{

--- a/internal/cli/tree.go
+++ b/internal/cli/tree.go
@@ -140,6 +140,13 @@ func DefaultTree() *Command {
 			}},
 			{Name: "info", Summary: "show service details", Usage: "kranz services info SERVICE"},
 		}},
+		{Name: "actions", Summary: "inspect and run actions", Default: "list", Children: []*Command{
+			{Name: "list", Summary: "list actions", Usage: "kranz actions [OWNER] [--format TEMPLATE]", Options: []Option{
+				{Flags: "--format TEMPLATE", Summary: "render each action with a Go template; prefix with 'table ' for headers"},
+			}},
+			{Name: "info", Summary: "show action details", Usage: "kranz actions info OWNER/ACTION"},
+			{Name: "run", Summary: "run an action", Usage: "kranz actions run OWNER/ACTION"},
+		}},
 		{Name: "tags", Summary: "list configured service tags", Usage: "kranz tags [--format TEMPLATE]", Options: []Option{
 			{Flags: "--format TEMPLATE", Summary: "render each tag with a Go template; prefix with 'table ' for headers"},
 		}},
@@ -208,13 +215,6 @@ func DefaultTree() *Command {
 				{Flags: "--with-actions", Summary: "clear the actions an owner has run as well"},
 				{Flags: "--force", Summary: "required to clear every buffer at once"},
 			}},
-		}},
-		{Name: "actions", Summary: "inspect and run actions", Default: "list", Children: []*Command{
-			{Name: "list", Summary: "list actions", Usage: "kranz actions [OWNER] [--format TEMPLATE]", Options: []Option{
-				{Flags: "--format TEMPLATE", Summary: "render each action with a Go template; prefix with 'table ' for headers"},
-			}},
-			{Name: "info", Summary: "show action details", Usage: "kranz actions info OWNER/ACTION"},
-			{Name: "run", Summary: "run an action", Usage: "kranz actions run OWNER/ACTION"},
 		}},
 		{Name: "completion", Summary: "generate shell completion", Usage: "kranz completion bash|zsh|fish"},
 		{Name: "help", Summary: "show command help", Usage: "kranz help [COMMAND]"},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -186,17 +186,19 @@ func TestLoadAllCanonicalExamples(t *testing.T) {
 
 func TestValidateUIBackgroundSource(t *testing.T) {
 	base := &Config{Project: "Appearance", Services: map[string]Service{"app": {Command: "exit 0"}}}
-	for _, source := range []string{"", "terminal", "theme"} {
+	for _, source := range []string{"", "terminal", "theme", "#002B36", "#f5efe3"} {
 		cfg := *base
 		cfg.UI.Background = source
 		if err := Validate(&cfg); err != nil {
 			t.Errorf("background %q was rejected: %v", source, err)
 		}
 	}
-	invalid := *base
-	invalid.UI.Background = "automatic"
-	if err := Validate(&invalid); err == nil || !strings.Contains(err.Error(), "ui.background") {
-		t.Fatalf("invalid background source error = %v", err)
+	for _, source := range []string{"automatic", "#12345", "#12345G"} {
+		invalid := *base
+		invalid.UI.Background = source
+		if err := Validate(&invalid); err == nil || !strings.Contains(err.Error(), "ui.background") {
+			t.Errorf("invalid background %q error = %v", source, err)
+		}
 	}
 }
 

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 )
 
+var uiHexColorPattern = regexp.MustCompile(`^#[0-9A-Fa-f]{6}$`)
+
 // Validate checks project metadata, commands, actions, dependencies, ports, and probes.
 func Validate(cfg *Config) error {
 	if cfg.Project == "" {
@@ -20,7 +22,9 @@ func Validate(cfg *Config) error {
 	switch cfg.UI.Background {
 	case "", UIBackgroundTerminal, UIBackgroundTheme:
 	default:
-		return fmt.Errorf("ui.background must be terminal or theme, got %q", cfg.UI.Background)
+		if !uiHexColorPattern.MatchString(cfg.UI.Background) {
+			return fmt.Errorf("ui.background must be terminal, theme, or a #RRGGBB color, got %q", cfg.UI.Background)
+		}
 	}
 	switch cfg.UI.ColorMode {
 	case "", UIColorModeAuto, UIColorModeDark, UIColorModeLight:

--- a/internal/runtime/registry.go
+++ b/internal/runtime/registry.go
@@ -60,8 +60,8 @@ type SessionRecord struct {
 	// caller can tell "no services" from "state unknown".
 	Services *int `json:"services"`
 	Running  *int `json:"running"`
-	// Clients counts the connections the runtime is serving, nil when it could
-	// not be reached. The listing probe is itself one of them and is excluded.
+	// Clients counts user-facing connections, nil when the runtime could not be
+	// reached. The listing probe and background owner are excluded.
 	Clients *int `json:"clients"`
 	// ClientSurfaces lists the unique delivery-surface labels (for example
 	// "tui", "mcp") currently connected, excluding the listing probe itself

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -143,7 +143,10 @@ type actionResultMsg struct {
 	sessionGen uint64
 }
 
-type shutdownResultMsg struct{ err error }
+type shutdownResultMsg struct {
+	err              error
+	chooseAfterClose bool
+}
 type shellFinishedMsg struct{ err error }
 type runExportResultMsg struct {
 	path string
@@ -606,6 +609,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.mode = ModeNormal
 		return m.toggleSelectedServices()
 	case shutdownResultMsg:
+		if msg.chooseAfterClose {
+			return m.handleCloseAndChooseResult(msg.err)
+		}
 		if msg.err != nil {
 			m.addNotification("system", "Shutdown failed: "+msg.err.Error(), config.LogError)
 		}

--- a/internal/ui/model_keys.go
+++ b/internal/ui/model_keys.go
@@ -10,6 +10,9 @@ import (
 // dashboard the handlers are tried in order and the first to claim it wins.
 
 func (m *Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.exiting {
+		return m, nil
+	}
 	if msg.String() == "ctrl+c" {
 		if m.mode == ModeRuntimeLost {
 			m.recoverySeq++

--- a/internal/ui/model_lifecycle.go
+++ b/internal/ui/model_lifecycle.go
@@ -546,6 +546,28 @@ func (m *Model) beginDetach() (tea.Model, tea.Cmd) {
 	return m.beginExit("Detaching")
 }
 
+func (m *Model) beginCloseAndChoose() (tea.Model, tea.Cmd) {
+	if !m.switcherSupported() || m.exiting {
+		return m, nil
+	}
+	if m.operationCancel != nil {
+		m.operationCancel()
+		m.operationCancel = nil
+	}
+	m.operationID++
+	m.operationKind = ""
+	m.operation = "Closing runtime"
+	m.mode = ModeNormal
+	m.exiting = true
+	// Capture the departing application just as beginExit freezes m.app. The
+	// chooser may install another session only after this command answers, and
+	// that new session must never become the target of the close request.
+	currentApp := m.app
+	return m, func() tea.Msg {
+		return shutdownResultMsg{err: currentApp.Shutdown(), chooseAfterClose: true}
+	}
+}
+
 func (m *Model) beginExit(operation string) (tea.Model, tea.Cmd) {
 	if m.operationCancel != nil {
 		m.operationCancel()
@@ -571,6 +593,8 @@ func (m *Model) handleConfirmQuitKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.beginShutdown()
 	case "d", "D":
 		return m.beginDetach()
+	case "c", "C":
+		return m.beginCloseAndChoose()
 	case "n", "N", "esc":
 		m.mode = ModeNormal
 	}

--- a/internal/ui/model_lifecycle_test.go
+++ b/internal/ui/model_lifecycle_test.go
@@ -116,6 +116,19 @@ func TestQuitConfirmationMouseCanDetach(t *testing.T) {
 	}
 }
 
+func TestQuitConfirmationOffersClickableCloseAndChooseWhenSupported(t *testing.T) {
+	model := newTestModel()
+	defer model.Shutdown()
+	model.registry = testRegistry(t)
+	model.width, model.height, model.ready = 100, 40, true
+	model.mode = ModeConfirmQuit
+
+	command := clickRenderedText(t, model, "[c]       Close & choose another runtime")
+	if command == nil || !model.exiting || model.operation != "Closing runtime" {
+		t.Fatalf("close-and-choose click = command %v, exiting %v, operation %q", command, model.exiting, model.operation)
+	}
+}
+
 // Tests for service lifecycle actions driven from the dashboard.
 
 func TestEnterDoesNotControlServiceLifecycle(t *testing.T) {

--- a/internal/ui/mouse.go
+++ b/internal/ui/mouse.go
@@ -335,6 +335,9 @@ func (m *Model) handleOverlayMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		return m.handleRuntimeRowClick(rendered, msg, m.closeRuntimeSwitcher)
 	case ModeRuntimeLost:
 		if m.recoveryShowingList {
+			if renderedTextHit(rendered, msg.X, msg.Y, "[q] Quit TUI") {
+				return m.handleRuntimeLostKeys(keyMessage("q"))
+			}
 			return m.handleRuntimeRowClick(rendered, msg, func() {
 				m.cancelPendingRuntimeSwitch()
 				m.recoveryShowingList = false
@@ -379,6 +382,9 @@ func (m *Model) handleOverlayMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		}
 		if renderedTextHit(rendered, msg.X, msg.Y, "[d]       Detach and keep runtime running") {
 			return m.beginDetach()
+		}
+		if renderedTextHit(rendered, msg.X, msg.Y, "[c]       Close & choose another runtime") {
+			return m.beginCloseAndChoose()
 		}
 		if renderedTextHit(rendered, msg.X, msg.Y, "[Esc/n]   Stay here") {
 			m.mode = ModeNormal

--- a/internal/ui/runtime_integration_test.go
+++ b/internal/ui/runtime_integration_test.go
@@ -2,10 +2,12 @@ package ui
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/kranz-org/kranz/internal/app"
 	"github.com/kranz-org/kranz/internal/config"
@@ -246,6 +248,87 @@ func TestRuntimeSwitcherEndToEndSwitchesAndRestoresState(t *testing.T) {
 	switchTo(t, model, beta.record)
 	if model.panelFocus != panelLogs {
 		t.Fatalf("beta's second-visit state was not restored: panelFocus=%v", model.panelFocus)
+	}
+}
+
+func TestCloseAndChooseStopsCurrentRuntimeAndSwitchesWithoutLeavingTUI(t *testing.T) {
+	registry := testRegistry(t)
+	alpha := startTestRuntime(t, registry, "close-alpha", serviceProjectConfig("Alpha", "worker"), t.TempDir())
+	beta := startTestRuntime(t, registry, "close-beta", emptyProjectConfig("Beta"), t.TempDir())
+	model := newSwitchableTestModel(t, registry, alpha, ModelOptions{DetachOnExit: true})
+	if err := alpha.client.StartServicesContext(context.Background(), []string{"worker"}); err != nil {
+		t.Fatalf("start worker: %v", err)
+	}
+	model.width, model.height, model.ready = 100, 24, true
+	model.mode = ModeConfirmQuit
+
+	_, closeCmd := model.handleConfirmQuitKeys(keyMessage("c"))
+	if closeCmd == nil || !model.exiting || model.operation != "Closing runtime" {
+		t.Fatalf("close-and-choose did not begin: cmd=%v exiting=%v operation=%q", closeCmd, model.exiting, model.operation)
+	}
+	closeMsg, ok := closeCmd().(shutdownResultMsg)
+	if !ok || closeMsg.err != nil || !closeMsg.chooseAfterClose {
+		t.Fatalf("close-and-choose result = %#v", closeMsg)
+	}
+	if alpha.local.HasRunningServices() {
+		t.Fatal("close-and-choose left the current runtime service running")
+	}
+	// The production runtime owner removes its listener and registry record
+	// after the shutdown response. The test harness owns that process boundary.
+	alpha.stop()
+	_, discoverCmd := model.Update(closeMsg)
+	discovering := ansi.Strip(model.renderRuntimeLostView())
+	if !strings.Contains(discovering, "Discovering local runtimes…") || strings.Contains(discovering, "No other local runtimes are registered") {
+		t.Fatalf("chooser showed an empty result before discovery finished:\n%s", discovering)
+	}
+	fireOnce(model, discoverCmd)
+
+	if model.mode != ModeRuntimeLost || !model.recoveryShowingList || model.exiting {
+		t.Fatalf("after close: mode=%v showingList=%v exiting=%v", model.mode, model.recoveryShowingList, model.exiting)
+	}
+	betaIndex := -1
+	for index, row := range model.switcherRows {
+		if row.Record.ID == alpha.record.ID {
+			t.Fatal("closed runtime remained in the chooser")
+		}
+		if row.Record.ID == beta.record.ID {
+			betaIndex = index
+		}
+	}
+	if betaIndex < 0 {
+		t.Fatalf("remaining runtime was not offered: %#v", model.switcherRows)
+	}
+	model.switcherCursor = betaIndex
+	_, connectCmd := model.connectToSwitcherSelection()
+	fireOnce(model, connectCmd)
+	if model.mode != ModeNormal || model.cfg.Project != "Beta" {
+		t.Fatalf("switch after close ended at mode=%v project=%q", model.mode, model.cfg.Project)
+	}
+}
+
+func TestCloseAndChooseAllowsAnEmptyRuntimeList(t *testing.T) {
+	registry := testRegistry(t)
+	alpha := startTestRuntime(t, registry, "only-runtime", emptyProjectConfig("Only"), t.TempDir())
+	model := newSwitchableTestModel(t, registry, alpha, ModelOptions{DetachOnExit: true})
+	model.width, model.height, model.ready = 100, 24, true
+	model.mode = ModeConfirmQuit
+
+	_, closeCmd := model.handleConfirmQuitKeys(keyMessage("c"))
+	closeMsg := closeCmd().(shutdownResultMsg)
+	alpha.stop()
+	_, discoverCmd := model.Update(closeMsg)
+	fireOnce(model, discoverCmd)
+
+	if len(model.switcherRows) != 0 {
+		t.Fatalf("empty chooser contains rows: %#v", model.switcherRows)
+	}
+	plain := ansi.Strip(model.renderRuntimeLostView())
+	if !strings.Contains(plain, "Runtime closed") || !strings.Contains(plain, "No other local runtimes are registered") || !strings.Contains(plain, "[q] Quit TUI") {
+		t.Fatalf("empty close-and-choose view is incomplete:\n%s", plain)
+	}
+	_, quitCmd := model.handleRuntimeLostKeys(keyMessage("q"))
+	if quitCmd == nil {
+		t.Fatal("empty chooser recovery screen cannot quit")
 	}
 }
 

--- a/internal/ui/runtime_picker.go
+++ b/internal/ui/runtime_picker.go
@@ -183,7 +183,7 @@ func (p *RuntimePicker) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		p.lastClickID, p.lastClickAt = row.Record.ID, now
 		return p, nil
 	}
-	if renderedTextHit(rendered, msg.X, msg.Y, "[q] Quit") {
+	if renderedTextHit(rendered, msg.X, msg.Y, "[Esc/q] Quit") {
 		return p, tea.Quit
 	}
 	return p, nil
@@ -194,10 +194,10 @@ func (p *RuntimePicker) View() string {
 		return ""
 	}
 	contentWidth := flushModalContentWidth(p.width, 110)
-	shortcutRows := renderModalShortcutRows([]string{"[↑/↓ · j/k] Select", "[Enter] Connect", "[q] Quit"}, contentWidth, lipgloss.NewStyle().Foreground(ColorDim))
+	shortcutRows := renderModalShortcutRows([]string{"[↑/↓ · j/k] Select", "[Enter] Connect", "[Esc/q] Quit"}, contentWidth, lipgloss.NewStyle().Foreground(ColorDim))
 	lines := []string{ModalTitleStyle.Render(" Kranz "), ""}
 	lines = append(lines, modalTextRows("No Kranz configuration was found in this directory.", contentWidth)...)
-	lines = append(lines, modalTextRows("Choose a local runtime to attach to, or press q to quit.", contentWidth)...)
+	lines = append(lines, modalTextRows("Choose a local runtime to attach to, or press Esc or q to quit.", contentWidth)...)
 	lines = append(lines, "")
 	if p.errText != "" {
 		for _, line := range modalTextRows(p.errText, contentWidth) {
@@ -223,5 +223,8 @@ func (p *RuntimePicker) View() string {
 	// switcher uses, so the two screens are recognisably the same modal.
 	modal := renderFlushModal(strings.Join(lines, "\n"))
 	centred := lipgloss.Place(p.width, p.height, lipgloss.Center, lipgloss.Center, modal)
+	if !TerminalCanvas {
+		centred = preserveCanvasBackground(centred, ColorBackground)
+	}
 	return frameToTerminal(centred, p.width, p.height)
 }

--- a/internal/ui/runtime_picker_test.go
+++ b/internal/ui/runtime_picker_test.go
@@ -1,0 +1,65 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/muesli/termenv"
+)
+
+func TestRuntimePickerEscapeQuitsAndIsAdvertised(t *testing.T) {
+	picker := &RuntimePicker{width: 120, height: 24, ready: true}
+
+	_, cmd := picker.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	if cmd == nil {
+		t.Fatal("Escape did not return a quit command")
+	}
+	msg := cmd()
+	if _, ok := msg.(tea.QuitMsg); !ok {
+		t.Fatalf("Escape command returned %T, want tea.QuitMsg", msg)
+	}
+
+	plain := ansi.Strip(picker.View())
+	if !strings.Contains(plain, "press Esc or q to quit") || !strings.Contains(plain, "[Esc/q] Quit") {
+		t.Fatalf("runtime picker does not advertise Escape: %q", plain)
+	}
+}
+
+func TestRuntimePickerRestoresCanvasBackgroundAfterModalReset(t *testing.T) {
+	previousProfile := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	defer lipgloss.SetColorProfile(previousProfile)
+	restoreDefaultTheme(t)
+
+	for _, themeName := range []string{"nord", "github-light"} {
+		t.Run(themeName, func(t *testing.T) {
+			if _, err := ApplyTheme(themeName, ""); err != nil {
+				t.Fatal(err)
+			}
+
+			picker := &RuntimePicker{width: 140, height: 24, ready: true}
+			rendered := picker.View()
+			canvasPrefix := terminalStylePrefix(lipgloss.NewStyle().Background(ColorBackground))
+			if canvasPrefix == "" {
+				t.Fatal("painted theme has no canvas background prefix")
+			}
+
+			var instructionLine string
+			for _, line := range strings.Split(rendered, "\n") {
+				if strings.Contains(line, "No Kranz configuration") {
+					instructionLine = line
+					break
+				}
+			}
+			if instructionLine == "" {
+				t.Fatal("runtime picker instruction line was not rendered")
+			}
+			if !strings.Contains(instructionLine, "\x1b[0m"+canvasPrefix) {
+				t.Fatalf("canvas background is not restored after the modal reset: %q", instructionLine)
+			}
+		})
+	}
+}

--- a/internal/ui/runtime_recovery.go
+++ b/internal/ui/runtime_recovery.go
@@ -82,6 +82,10 @@ func (m *Model) handleRuntimeLostKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case msg.String() == "esc":
 			m.cancelPendingRuntimeSwitch()
 			m.recoveryShowingList = false
+		case msg.String() == "q", msg.String() == "Q":
+			m.recoverySeq++
+			m.cancelPendingRuntimeSwitch()
+			return m.beginDetach()
 		}
 		return m, nil
 	}
@@ -98,6 +102,7 @@ func (m *Model) handleRuntimeLostKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.recoverySeq++
 		m.recoveryBusy = false
 		m.recoveryShowingList = true
+		m.switcherLoading = true
 		m.switcherGeneration++
 		return m, m.refreshRuntimeList()
 	case "q", "Q":

--- a/internal/ui/runtime_switcher.go
+++ b/internal/ui/runtime_switcher.go
@@ -110,6 +110,9 @@ func (m *Model) refreshRuntimeListIfVisible() tea.Cmd {
 func (m *Model) handleRuntimeListMsg(msg runtimeListMsg) (tea.Model, tea.Cmd) {
 	m.switcherRefreshBusy = false
 	if msg.generation != m.switcherGeneration {
+		if m.mode == ModeRuntimeSwitcher || (m.mode == ModeRuntimeLost && m.recoveryShowingList) {
+			return m, m.refreshRuntimeList()
+		}
 		return m, nil
 	}
 	m.switcherLoading = false
@@ -137,6 +140,27 @@ func (m *Model) handleRuntimeListMsg(msg runtimeListMsg) (tea.Model, tea.Cmd) {
 	}
 	m.switcherCursor = newIndex
 	return m, nil
+}
+
+func (m *Model) handleCloseAndChooseResult(closeErr error) (tea.Model, tea.Cmd) {
+	m.exiting = false
+	m.detachOnExit = true
+	m.operation = ""
+	m.sessionGeneration++
+	m.mode = ModeRuntimeLost
+	m.recoveryReason = "Runtime closed"
+	m.recoveryBusy = false
+	m.recoveryShowingList = true
+	m.recoveryErr = ""
+	if closeErr != nil {
+		m.recoveryErr = "Could not close current runtime cleanly: " + closeErr.Error()
+	}
+	m.switcherRows = nil
+	m.switcherCursor = 0
+	m.switcherLoading = true
+	m.switcherErr = ""
+	m.switcherGeneration++
+	return m, m.refreshRuntimeList()
 }
 
 func (m *Model) handleRuntimeSwitcherKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {

--- a/internal/ui/view_modals.go
+++ b/internal/ui/view_modals.go
@@ -254,14 +254,15 @@ func (m *Model) renderConfirmQuitView() string {
 		body = append(body, "", "The current operation will be cancelled.")
 	}
 	body = append(body, "", HelpSectionStyle.Render("EXIT"))
-	content := renderConfirmationModal(
-		"Quit Kranz?",
-		body,
+	actions := []string{
 		"  [Enter/y] Stop runtime and quit",
 		"  [d]       Detach and keep runtime running",
-		"",
-		"  [Esc/n]   Stay here",
-	)
+	}
+	if m.switcherSupported() {
+		actions = append(actions, "  [c]       Close & choose another runtime")
+	}
+	actions = append(actions, "", "  [Esc/n]   Stay here")
+	content := renderConfirmationModal("Quit Kranz?", body, actions...)
 	return m.placeOverlay(content)
 }
 

--- a/internal/ui/view_runtime.go
+++ b/internal/ui/view_runtime.go
@@ -93,12 +93,20 @@ func (m *Model) renderRuntimeLostView() string {
 	}
 	lines := []string{ansi.Truncate(ModalTitleStyle.Render(" "+title+" "), contentWidth, "…"), ""}
 	if m.recoveryShowingList {
-		shortcutRows := renderModalShortcutRows([]string{"[↑/↓ · j/k] Select", "[Enter] Connect", "[Esc] Back"}, contentWidth, lipgloss.NewStyle().Foreground(ColorDim))
+		shortcutRows := renderModalShortcutRows([]string{"[↑/↓ · j/k] Select", "[Enter] Connect", "[Esc] Back", "[q] Quit TUI"}, contentWidth, lipgloss.NewStyle().Foreground(ColorDim))
 		lines = append(lines, modalTextRows("Choose a running runtime:", contentWidth)...)
 		lines = append(lines, "")
+		if m.recoveryErr != "" {
+			for _, line := range modalTextRows(m.recoveryErr, contentWidth) {
+				lines = append(lines, ContextBarStyle.Render(line))
+			}
+			lines = append(lines, "")
+		}
 		rowLines := renderRuntimeRowLines(m.switcherRows, m.switcherCursor,
 			m.runListCapacity(len(lines)+max(0, len(shortcutRows)-1)), contentWidth)
-		if len(rowLines) == 0 {
+		if len(rowLines) == 0 && m.switcherLoading {
+			lines = append(lines, modalTextRows("Discovering local runtimes…", contentWidth)...)
+		} else if len(rowLines) == 0 {
 			lines = append(lines, modalTextRows("No other local runtimes are registered", contentWidth)...)
 		} else {
 			lines = append(lines, rowLines...)

--- a/skills/kranz-services/SKILL.md
+++ b/skills/kranz-services/SKILL.md
@@ -64,9 +64,9 @@ Use CLI only as a fallback or for a surface MCP does not expose:
 KRANZ_PROJECT=NAME kranz status --output json
 KRANZ_PROJECT=NAME kranz logs SERVICE --tail 200
 KRANZ_PROJECT=NAME kranz ports --output json
-KRANZ_PROJECT=NAME kranz info SERVICE
-KRANZ_PROJECT=NAME kranz action list --output json
-kranz port inspect 3303 --output json
+KRANZ_PROJECT=NAME kranz services info SERVICE
+KRANZ_PROJECT=NAME kranz actions --output json
+kranz ports inspect 3303 --output json
 KRANZ_PROJECT=NAME kranz clients --output json
 ```
 


### PR DESCRIPTION
## Summary

- add structured CLI inspection, filtering, watching, lifecycle plans, and run-history controls
- replace interactive init with a draft-based authoring wizard and clarify command grammar
- add Close & choose to the TUI and polish the standalone runtime picker
- update user documentation for the new behavior

## Verification

- `make verify`
- `make lint`
- `make release-check`
- `npm run docs:check-links`